### PR TITLE
feat: add breadcrumbs on product pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,11 @@
     "download": "Download",
     "home": "Home"
   },
+  "breadcrumbs": {
+    "categories": {
+      "analogue-mfc": "Analogue MFC"
+    }
+  },
   "product": {
     "specs": {
       "flowRange": "Flow range",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,8 +7,9 @@
     "home": "Home"
   },
   "breadcrumbs": {
+    "label": "Breadcrumb",
     "categories": {
-      "analogue-mfc": "Analogue MFC"
+      "analogueMfc": "Analogue MFC"
     }
   },
   "product": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -7,8 +7,9 @@
     "home": "홈"
   },
   "breadcrumbs": {
+    "label": "현재 위치",
     "categories": {
-      "analogue-mfc": "아날로그 MFC"
+      "analogueMfc": "아날로그 MFC"
     }
   },
   "product": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -6,6 +6,11 @@
     "download": "다운로드",
     "home": "홈"
   },
+  "breadcrumbs": {
+    "categories": {
+      "analogue-mfc": "아날로그 MFC"
+    }
+  },
   "product": {
     "specs": {
       "flowRange": "유량 범위",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -7,8 +7,9 @@
     "home": "首页"
   },
   "breadcrumbs": {
+    "label": "当前位置",
     "categories": {
-      "analogue-mfc": "模拟 MFC"
+      "analogueMfc": "模拟 MFC"
     }
   },
   "product": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -6,6 +6,11 @@
     "download": "下载",
     "home": "首页"
   },
+  "breadcrumbs": {
+    "categories": {
+      "analogue-mfc": "模拟 MFC"
+    }
+  },
   "product": {
     "specs": {
       "flowRange": "流量范围",

--- a/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
+++ b/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
@@ -25,7 +25,7 @@ export default async function ProductPage({ params }: Props) {
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },
     { label: tNav("products"), href: "/products" },
-    { label: tCategories("analogue-mfc"), href: "/products/analogue-mfc" },
+    { label: tCategories("analogueMfc"), href: "/products/analogue-mfc" },
     { label: product.model },
   ];
 

--- a/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
+++ b/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
@@ -1,4 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { M3030VA } from "@/lib/fixtures/products";
 import type { MassFlowSpecs } from "@/lib/types/product";
 
@@ -10,14 +11,25 @@ export default async function ProductPage({ params }: Props) {
 
   const t = await getTranslations("product.specs");
   const tDownloads = await getTranslations("product.downloads");
+  const tCommon = await getTranslations("common");
+  const tNav = await getTranslations("nav");
+  const tCategories = await getTranslations("breadcrumbs.categories");
 
   const product = M3030VA;
   const specEntries = Object.entries(product.massFlowSpecs) as Array<
     [keyof MassFlowSpecs, { display: string }]
   >;
 
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("products"), href: "/products" },
+    { label: tCategories("analogue-mfc"), href: "/products/analogue-mfc" },
+    { label: product.model },
+  ];
+
   return (
     <main>
+      <Breadcrumbs items={breadcrumbs} />
       <h1>{product.model}</h1>
       <p>
         Series: {product.series} · Function: {product.function} · Form factor:{" "}

--- a/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
+++ b/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
@@ -9,11 +9,13 @@ export default async function ProductPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const t = await getTranslations("product.specs");
-  const tDownloads = await getTranslations("product.downloads");
-  const tCommon = await getTranslations("common");
-  const tNav = await getTranslations("nav");
-  const tCategories = await getTranslations("breadcrumbs.categories");
+  const [t, tDownloads, tCommon, tNav, tCategories] = await Promise.all([
+    getTranslations("product.specs"),
+    getTranslations("product.downloads"),
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("breadcrumbs.categories"),
+  ]);
 
   const product = M3030VA;
   const specEntries = Object.entries(product.massFlowSpecs) as Array<

--- a/src/components/layout/Breadcrumbs.css
+++ b/src/components/layout/Breadcrumbs.css
@@ -9,7 +9,6 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0;
   margin: 0;
   padding: 0;
   list-style: none;

--- a/src/components/layout/Breadcrumbs.css
+++ b/src/components/layout/Breadcrumbs.css
@@ -1,0 +1,52 @@
+/* Line Tech — breadcrumb trail. Renders on product/category pages. */
+
+.lt-breadcrumbs {
+  font: 400 15px/1.4 var(--lt-sans);
+  color: var(--pd-muted);
+}
+
+.lt-breadcrumbs__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lt-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  color: var(--pd-muted);
+}
+
+.lt-breadcrumbs__item:not(:first-child)::before {
+  content: "›";
+  margin: 0 0.5rem;
+  color: var(--pd-muted);
+  user-select: none;
+}
+
+.lt-breadcrumbs__link {
+  color: var(--pd-muted);
+  text-decoration: none;
+  border-radius: var(--pd-r-sm);
+  transition: color 120ms ease;
+}
+
+.lt-breadcrumbs__link:hover {
+  color: var(--pd-fg-strong);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.lt-breadcrumbs__link:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.lt-breadcrumbs__item--current {
+  color: var(--pd-primary);
+  font-weight: 500;
+}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,69 @@
+import { getLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import "./Breadcrumbs.css";
+
+export type BreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+type Props = {
+  items: BreadcrumbItem[];
+};
+
+export async function Breadcrumbs({ items }: Props) {
+  const locale = await getLocale();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.label,
+      ...(item.href !== undefined && {
+        item: `${siteUrl}/${locale}${item.href === "/" ? "" : item.href}`,
+      }),
+    })),
+  };
+
+  return (
+    <>
+      <nav className="lt-breadcrumbs" aria-label="Breadcrumb">
+        <ol className="lt-breadcrumbs__list">
+          {items.map((item, index) => {
+            const isLast = index === items.length - 1;
+            const className = `lt-breadcrumbs__item${
+              isLast ? " lt-breadcrumbs__item--current" : ""
+            }`;
+
+            if (isLast || !item.href) {
+              return (
+                <li
+                  key={index}
+                  className={className}
+                  aria-current={isLast ? "page" : undefined}
+                >
+                  {item.label}
+                </li>
+              );
+            }
+
+            return (
+              <li key={index} className={className}>
+                <Link className="lt-breadcrumbs__link" href={item.href}>
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -37,24 +37,22 @@ export async function Breadcrumbs({ items }: Props) {
             const className = `lt-breadcrumbs__item${
               isLast ? " lt-breadcrumbs__item--current" : ""
             }`;
-
-            if (isLast || !item.href) {
-              return (
-                <li
-                  key={index}
-                  className={className}
-                  aria-current={isLast ? "page" : undefined}
-                >
-                  {item.label}
-                </li>
-              );
-            }
-
-            return (
-              <li key={index} className={className}>
+            const content =
+              item.href && !isLast ? (
                 <Link className="lt-breadcrumbs__link" href={item.href}>
                   {item.label}
                 </Link>
+              ) : (
+                item.label
+              );
+
+            return (
+              <li
+                key={index}
+                className={className}
+                aria-current={isLast ? "page" : undefined}
+              >
+                {content}
               </li>
             );
           })}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
-import { getLocale } from "next-intl/server";
-import { Link } from "@/i18n/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+import { Link, getPathname } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
 import "./Breadcrumbs.css";
 
 export type BreadcrumbItem = {
@@ -11,9 +12,25 @@ type Props = {
   items: BreadcrumbItem[];
 };
 
+function resolveSiteUrl(): string {
+  const fromEnv = process.env.SITE_URL;
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  if (process.env.VERCEL_ENV === "production") {
+    throw new Error(
+      "SITE_URL is required on Vercel production deploys for breadcrumb JSON-LD absolute URLs.",
+    );
+  }
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "http://localhost:3000";
+}
+
 export async function Breadcrumbs({ items }: Props) {
-  const locale = await getLocale();
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+  const [locale, t] = await Promise.all([
+    getLocale(),
+    getTranslations("breadcrumbs"),
+  ]);
+  const siteUrl = resolveSiteUrl();
+  const typedLocale = locale as (typeof routing.locales)[number];
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -23,14 +40,14 @@ export async function Breadcrumbs({ items }: Props) {
       position: index + 1,
       name: item.label,
       ...(item.href !== undefined && {
-        item: `${siteUrl}/${locale}${item.href === "/" ? "" : item.href}`,
+        item: `${siteUrl}${getPathname({ locale: typedLocale, href: item.href })}`,
       }),
     })),
   };
 
   return (
     <>
-      <nav className="lt-breadcrumbs" aria-label="Breadcrumb">
+      <nav className="lt-breadcrumbs" aria-label={t("label")}>
         <ol className="lt-breadcrumbs__list">
           {items.map((item, index) => {
             const isLast = index === items.length - 1;

--- a/src/components/layout/LocaleSwitcher.css
+++ b/src/components/layout/LocaleSwitcher.css
@@ -23,7 +23,9 @@
   padding: 8px 14px;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .lt-locale__seg:hover {

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -116,9 +116,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           heading: "회사 안내",
           links: [
             { href: "/company", label: "인사말", desc: "CEO 메시지" },
-            { href: "/company/history", label: "연혁", desc: "1997년부터 현재까지" },
-            { href: "/company/certifications", label: "인증", desc: "ISO · CE · INNOBIZ 외" },
-            { href: "/company/location", label: "오시는 길", desc: "대전 본사 위치" },
+            {
+              href: "/company/history",
+              label: "연혁",
+              desc: "1997년부터 현재까지",
+            },
+            {
+              href: "/company/certifications",
+              label: "인증",
+              desc: "ISO · CE · INNOBIZ 외",
+            },
+            {
+              href: "/company/location",
+              label: "오시는 길",
+              desc: "대전 본사 위치",
+            },
           ],
         },
       },
@@ -148,10 +160,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "자료실",
           links: [
-            { href: "/resources/catalogues", label: "카탈로그", desc: "제품군 별 PDF 카탈로그" },
-            { href: "/resources/drawings", label: "도면", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "매뉴얼", desc: "모델별 사용 설명서" },
-            { href: "/resources/certifications", label: "인증서", desc: "13종 인증 문서" },
+            {
+              href: "/resources/catalogues",
+              label: "카탈로그",
+              desc: "제품군 별 PDF 카탈로그",
+            },
+            {
+              href: "/resources/drawings",
+              label: "도면",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "매뉴얼",
+              desc: "모델별 사용 설명서",
+            },
+            {
+              href: "/resources/certifications",
+              label: "인증서",
+              desc: "13종 인증 문서",
+            },
           ],
           featured: {
             eyebrow: "주목할 자료",
@@ -170,9 +198,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "문의 방법",
           links: [
-            { href: "/contact", label: "견적 요청", desc: "공정 조건을 알려주세요" },
-            { href: "/contact#support", label: "기술 문의", desc: "적합 모델 추천" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "이메일", desc: "linetech@line-tech.co.kr" },
+            {
+              href: "/contact",
+              label: "견적 요청",
+              desc: "공정 조건을 알려주세요",
+            },
+            {
+              href: "/contact#support",
+              label: "기술 문의",
+              desc: "적합 모델 추천",
+            },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "이메일",
+              desc: "linetech@line-tech.co.kr",
+            },
             { href: "tel:+82426240700", label: "전화", desc: "042-624-0700" },
           ],
         },
@@ -196,10 +236,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "About Line Tech",
           links: [
-            { href: "/company", label: "Greeting", desc: "Message from the CEO" },
-            { href: "/company/history", label: "History", desc: "From 1997 to today" },
-            { href: "/company/certifications", label: "Certifications", desc: "ISO · CE · INNOBIZ and more" },
-            { href: "/company/location", label: "Location", desc: "Daejeon headquarters" },
+            {
+              href: "/company",
+              label: "Greeting",
+              desc: "Message from the CEO",
+            },
+            {
+              href: "/company/history",
+              label: "History",
+              desc: "From 1997 to today",
+            },
+            {
+              href: "/company/certifications",
+              label: "Certifications",
+              desc: "ISO · CE · INNOBIZ and more",
+            },
+            {
+              href: "/company/location",
+              label: "Location",
+              desc: "Daejeon headquarters",
+            },
           ],
         },
       },
@@ -215,7 +271,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           featured: {
             eyebrow: "Featured model",
             title: "M3030VA",
-            blurb: "Digital piezo-actuated MFC for semiconductor and display process lines.",
+            blurb:
+              "Digital piezo-actuated MFC for semiconductor and display process lines.",
             href: "/products/m3030va",
             cta: "View product",
           },
@@ -229,15 +286,32 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "Resources",
           links: [
-            { href: "/resources/catalogues", label: "Catalogues", desc: "Series-level PDF catalogues" },
-            { href: "/resources/drawings", label: "CAD drawings", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "Manuals", desc: "Per-model user guides" },
-            { href: "/resources/certifications", label: "Certifications", desc: "13 certification documents" },
+            {
+              href: "/resources/catalogues",
+              label: "Catalogues",
+              desc: "Series-level PDF catalogues",
+            },
+            {
+              href: "/resources/drawings",
+              label: "CAD drawings",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "Manuals",
+              desc: "Per-model user guides",
+            },
+            {
+              href: "/resources/certifications",
+              label: "Certifications",
+              desc: "13 certification documents",
+            },
           ],
           featured: {
             eyebrow: "Spotlight",
             title: "M3030VA manual + catalogue",
-            blurb: "Full specs and Modbus protocol for our flagship digital MFC.",
+            blurb:
+              "Full specs and Modbus protocol for our flagship digital MFC.",
             href: "/products/m3030va",
             cta: "Open M3030VA",
           },
@@ -251,17 +325,34 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "Get in touch",
           links: [
-            { href: "/contact", label: "Request quote", desc: "Share your process conditions" },
-            { href: "/contact#support", label: "Technical inquiry", desc: "Model recommendations" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "Email", desc: "linetech@line-tech.co.kr" },
-            { href: "tel:+82426240700", label: "Phone", desc: "+82 42-624-0700" },
+            {
+              href: "/contact",
+              label: "Request quote",
+              desc: "Share your process conditions",
+            },
+            {
+              href: "/contact#support",
+              label: "Technical inquiry",
+              desc: "Model recommendations",
+            },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "Email",
+              desc: "linetech@line-tech.co.kr",
+            },
+            {
+              href: "tel:+82426240700",
+              label: "Phone",
+              desc: "+82 42-624-0700",
+            },
           ],
         },
       },
     ],
     footer: {
       signoff: "Building precision mass-flow control since 1997.",
-      address: "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea · TEL +82 42-624-0700",
+      address:
+        "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea · TEL +82 42-624-0700",
       rights: "© 2026 Line Tech Inc. All rights reserved.",
       version: SHELL_VERSION,
     },
@@ -278,9 +369,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           heading: "关于莱因",
           links: [
             { href: "/company", label: "问候语", desc: "CEO 致辞" },
-            { href: "/company/history", label: "发展历程", desc: "自 1997 年至今" },
-            { href: "/company/certifications", label: "资质认证", desc: "ISO · CE · INNOBIZ 等" },
-            { href: "/company/location", label: "联系地址", desc: "大田总部位置" },
+            {
+              href: "/company/history",
+              label: "发展历程",
+              desc: "自 1997 年至今",
+            },
+            {
+              href: "/company/certifications",
+              label: "资质认证",
+              desc: "ISO · CE · INNOBIZ 等",
+            },
+            {
+              href: "/company/location",
+              label: "联系地址",
+              desc: "大田总部位置",
+            },
           ],
         },
       },
@@ -310,10 +413,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "技术资料",
           links: [
-            { href: "/resources/catalogues", label: "产品样册", desc: "系列 PDF 样册" },
-            { href: "/resources/drawings", label: "CAD 图纸", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "使用手册", desc: "按型号分类的说明书" },
-            { href: "/resources/certifications", label: "认证文件", desc: "13 份认证文件" },
+            {
+              href: "/resources/catalogues",
+              label: "产品样册",
+              desc: "系列 PDF 样册",
+            },
+            {
+              href: "/resources/drawings",
+              label: "CAD 图纸",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "使用手册",
+              desc: "按型号分类的说明书",
+            },
+            {
+              href: "/resources/certifications",
+              label: "认证文件",
+              desc: "13 份认证文件",
+            },
           ],
           featured: {
             eyebrow: "推荐资料",
@@ -334,15 +453,24 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           links: [
             { href: "/contact", label: "申请报价", desc: "告知您的工艺条件" },
             { href: "/contact#support", label: "技术咨询", desc: "型号推荐" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "邮箱", desc: "linetech@line-tech.co.kr" },
-            { href: "tel:+82426240700", label: "电话", desc: "+82 42-624-0700" },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "邮箱",
+              desc: "linetech@line-tech.co.kr",
+            },
+            {
+              href: "tel:+82426240700",
+              label: "电话",
+              desc: "+82 42-624-0700",
+            },
           ],
         },
       },
     ],
     footer: {
       signoff: "自 1997 年起专注于精密质量流量控制。",
-      address: "韩国大田广域市儒城区大德大路 806 号 (34055) · TEL +82 42-624-0700",
+      address:
+        "韩国大田广域市儒城区大德大路 806 号 (34055) · TEL +82 42-624-0700",
       rights: "© 2026 株式会社莱因。保留所有权利。",
       version: SHELL_VERSION,
     },


### PR DESCRIPTION
## Summary
- Localized breadcrumb trail (`Home › Products › Analogue MFC › M3030VA`) on the M3030VA page in KO/EN/ZH
- New `Breadcrumbs` server component with locale-aware links via `@/i18n/navigation`
- Emits a JSON-LD `BreadcrumbList` for search-engine breadcrumb rendering
- Adds `breadcrumbs.categories.analogue-mfc` to all three message files

Closes #5.

## Test plan
- Visit `/{ko,en,zh}/products/analogue-mfc/m3030va` — trail renders with localized labels
- Click "Products" / "Analogue MFC" — locale-prefixed routes (will 404 today; #9 builds those pages)
- Inspect DOM: leaf has `aria-current="page"`, nav has `aria-label="Breadcrumb"`
- View source: `<script type="application/ld+json">` with absolute URLs, leaf entry omits `item`
- `pnpm build` — all 9 SSG routes still generate

🤖 Generated with [Claude Code](https://claude.com/claude-code)