### PR TITLE
feat: header shell + PageShell wiring + sticky compression (#6)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,8 @@ import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
-import { LocaleSwitcher } from "@/components/layout/LocaleSwitcher";
+import { PageShell } from "@/components/layout/PageShell";
+import type { Locale } from "@/lib/content/home";
 import "../globals.css";
 
 const fontSans = Inter({
@@ -50,8 +51,7 @@ export default async function LocaleLayout({ children, params }: Props) {
     <html lang={locale} className={`${fontSans.variable} ${fontMono.variable}`}>
       <body>
         <NextIntlClientProvider>
-          <LocaleSwitcher />
-          {children}
+          <PageShell locale={locale as Locale}>{children}</PageShell>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -76,7 +76,9 @@
   color: var(--pd-fg);
   border-radius: var(--pd-r-md);
   cursor: pointer;
-  transition: border-color 0.15s ease, color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 .pd-top__iconbtn:hover {
   border-color: var(--pd-primary);

--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -1,0 +1,102 @@
+/* Line Tech — top bar shell.
+ * Ported from docs/handoff/styles.css `.pd-top` rules. */
+
+.pd-top {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: var(--pd-bg);
+  border-bottom: 1px solid var(--pd-border);
+}
+.pd-top.is-menuopen {
+  z-index: 60;
+}
+
+.pd-top__inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 32px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  transition: height 0.2s ease;
+}
+.pd-top.is-scrolled .pd-top__inner {
+  height: 60px;
+}
+
+.pd-top__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--pd-primary);
+  text-decoration: none;
+  flex: 0 0 auto;
+}
+.pd-top__brand:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.pd-top__logomark {
+  display: inline-flex;
+}
+.pd-top__logomark svg {
+  display: block;
+}
+
+.pd-top__wordmark {
+  font: 700 16px/1 var(--lt-sans);
+  letter-spacing: 0.01em;
+  color: var(--pd-fg-strong);
+}
+.pd-top__wordmark-dot {
+  color: var(--pd-primary);
+  padding: 0 2px;
+}
+
+.pd-top__right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.pd-top__iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--pd-border);
+  background: var(--pd-surface);
+  color: var(--pd-fg);
+  border-radius: var(--pd-r-md);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.pd-top__iconbtn:hover {
+  border-color: var(--pd-primary);
+  color: var(--pd-primary);
+}
+.pd-top__iconbtn:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.pd-top__divider {
+  width: 1px;
+  height: 20px;
+  background: var(--pd-border);
+  display: inline-block;
+}
+
+@media (max-width: 1000px) {
+  .pd-top__inner {
+    padding: 0 16px;
+    gap: 12px;
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -33,11 +33,7 @@ export function Header({ locale }: Props) {
 
         <div className="pd-top__right">
           {/* TODO(#8): wire to SearchPanel via HeaderNavContext */}
-          <button
-            type="button"
-            className="pd-top__iconbtn"
-            aria-label="Search"
-          >
+          <button type="button" className="pd-top__iconbtn" aria-label="Search">
             <svg
               width="16"
               height="16"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,77 @@
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/components/ui/Button";
+import { LT_SHELL } from "@/lib/content/shell";
+import type { Locale } from "@/lib/content/home";
+import { HeaderShell } from "./HeaderShell";
+import { HeaderNav } from "./HeaderNav";
+import { LocaleSwitcher } from "./LocaleSwitcher";
+import { Logomark } from "./Logomark";
+import "./Header.css";
+
+type Props = { locale: Locale };
+
+export function Header({ locale }: Props) {
+  const shell = LT_SHELL[locale];
+
+  return (
+    <HeaderShell>
+      <div className="pd-top__inner">
+        <Link href="/" className="pd-top__brand" aria-label="Line Tech">
+          <span className="pd-top__logomark">
+            <Logomark />
+          </span>
+          <span className="pd-top__wordmark">
+            LINE
+            <span className="pd-top__wordmark-dot" aria-hidden="true">
+              ·
+            </span>
+            TECH
+          </span>
+        </Link>
+
+        <HeaderNav items={shell.nav} />
+
+        <div className="pd-top__right">
+          {/* TODO(#8): wire to SearchPanel via HeaderNavContext */}
+          <button
+            type="button"
+            className="pd-top__iconbtn"
+            aria-label="Search"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle
+                cx="7"
+                cy="7"
+                r="4.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+              <path
+                d="M11 11l3 3"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+          <span className="pd-top__divider" aria-hidden="true" />
+          <LocaleSwitcher />
+          <Button
+            variant="primary"
+            size="md"
+            href="mailto:linetech@line-tech.co.kr"
+            plain
+          >
+            {shell.quoteLabel}
+          </Button>
+        </div>
+      </div>
+    </HeaderShell>
+  );
+}

--- a/src/components/layout/HeaderNav.css
+++ b/src/components/layout/HeaderNav.css
@@ -57,7 +57,9 @@
 
 .pd-top__navitem svg {
   opacity: 0.55;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
 }
 .pd-top__navitem.is-open svg {
   transform: rotate(180deg);

--- a/src/components/layout/HeaderNav.css
+++ b/src/components/layout/HeaderNav.css
@@ -1,0 +1,71 @@
+/* Line Tech — header nav row + items.
+ * Ported from docs/handoff/styles.css `.pd-top__nav` / `.pd-top__navitem` rules. */
+
+.pd-top__nav {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  margin-left: 16px;
+  height: 100%;
+}
+
+.pd-top__navitem {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: 500 14px var(--lt-sans);
+  color: var(--pd-fg);
+  padding: 0 14px;
+  height: 100%;
+  position: relative;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.pd-top__navitem::after {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--pd-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.pd-top__navitem:hover {
+  color: var(--pd-primary);
+}
+
+.pd-top__navitem:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: -4px;
+  border-radius: 2px;
+}
+
+.pd-top__navitem.is-open {
+  color: var(--pd-primary);
+}
+.pd-top__navitem.is-open::after {
+  transform: scaleX(1);
+}
+
+.pd-top__navitem svg {
+  opacity: 0.55;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+.pd-top__navitem.is-open svg {
+  transform: rotate(180deg);
+  opacity: 1;
+}
+
+@media (max-width: 1000px) {
+  .pd-top__nav {
+    display: none;
+  }
+}

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Link } from "@/i18n/navigation";
+import type { ShellNavItem } from "@/lib/content/shell";
+import { useHeaderNav } from "./HeaderNavContext";
+import "./HeaderNav.css";
+
+type Props = { items: ShellNavItem[] };
+
+export function HeaderNav({ items }: Props) {
+  const { openId, onItemEnter, onItemLeave, setOpenId } = useHeaderNav();
+
+  return (
+    <nav
+      className="pd-top__nav"
+      aria-label="Primary"
+      onMouseLeave={onItemLeave}
+    >
+      {items.map((item) => {
+        const isOpen = openId === item.id;
+        const hasMenu = !!item.menu;
+        const cls = `pd-top__navitem${isOpen ? " is-open" : ""}`;
+        const handleEnter = () => {
+          if (hasMenu) onItemEnter(item.id);
+        };
+        const handleFocus = () => {
+          if (hasMenu) setOpenId(item.id);
+        };
+        return (
+          <Link
+            key={item.id}
+            href={item.href}
+            className={cls}
+            aria-haspopup={hasMenu ? "true" : undefined}
+            aria-expanded={hasMenu ? isOpen : undefined}
+            onMouseEnter={handleEnter}
+            onFocus={handleFocus}
+          >
+            {item.label}
+            {hasMenu && (
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M2 4l3 3 3-3"
+                  stroke="currentColor"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                />
+              </svg>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/layout/HeaderNavContext.tsx
+++ b/src/components/layout/HeaderNavContext.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export type HeaderNavCtx = {
+  openId: string | null;
+  setOpenId: (id: string | null) => void;
+  onItemEnter: (id: string) => void;
+  onItemLeave: () => void;
+};
+
+const Ctx = createContext<HeaderNavCtx | null>(null);
+
+export const HeaderNavProvider = Ctx.Provider;
+
+export function useHeaderNav(): HeaderNavCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useHeaderNav must be used inside <HeaderShell>");
+  }
+  return ctx;
+}

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  HeaderNavProvider,
-  type HeaderNavCtx,
-} from "./HeaderNavContext";
+import { HeaderNavProvider, type HeaderNavCtx } from "./HeaderNavContext";
 
 const OPEN_DELAY = 120;
 const CLOSE_DELAY = 120;
@@ -88,11 +85,7 @@ export function HeaderShell({ children }: Props) {
     };
   }, [openId]);
 
-  const cls = [
-    "pd-top",
-    scrolled && "is-scrolled",
-    openId && "is-menuopen",
-  ]
+  const cls = ["pd-top", scrolled && "is-scrolled", openId && "is-menuopen"]
     .filter(Boolean)
     .join(" ");
 

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  HeaderNavProvider,
+  type HeaderNavCtx,
+} from "./HeaderNavContext";
+
+const OPEN_DELAY = 120;
+const CLOSE_DELAY = 120;
+const SCROLL_ON = 40;
+const SCROLL_OFF = 30;
+
+type Props = { children: React.ReactNode };
+
+export function HeaderShell({ children }: Props) {
+  const [scrolled, setScrolled] = useState(false);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    let raf = 0;
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        const y = window.scrollY;
+        setScrolled((prev) => (prev ? y > SCROLL_OFF : y > SCROLL_ON));
+        raf = 0;
+      });
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpenId(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const ctx = useMemo<HeaderNavCtx>(() => {
+    const clearTimers = () => {
+      if (openTimer.current) {
+        window.clearTimeout(openTimer.current);
+        openTimer.current = null;
+      }
+      if (closeTimer.current) {
+        window.clearTimeout(closeTimer.current);
+        closeTimer.current = null;
+      }
+    };
+    return {
+      openId,
+      setOpenId: (id) => {
+        clearTimers();
+        setOpenId(id);
+      },
+      onItemEnter: (id) => {
+        if (closeTimer.current) {
+          window.clearTimeout(closeTimer.current);
+          closeTimer.current = null;
+        }
+        if (openId === id) return;
+        if (openTimer.current) window.clearTimeout(openTimer.current);
+        openTimer.current = window.setTimeout(() => {
+          setOpenId(id);
+          openTimer.current = null;
+        }, OPEN_DELAY);
+      },
+      onItemLeave: () => {
+        if (openTimer.current) {
+          window.clearTimeout(openTimer.current);
+          openTimer.current = null;
+        }
+        if (closeTimer.current) window.clearTimeout(closeTimer.current);
+        closeTimer.current = window.setTimeout(() => {
+          setOpenId(null);
+          closeTimer.current = null;
+        }, CLOSE_DELAY);
+      },
+    };
+  }, [openId]);
+
+  const cls = [
+    "pd-top",
+    scrolled && "is-scrolled",
+    openId && "is-menuopen",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <HeaderNavProvider value={ctx}>
+      <header className={cls}>{children}</header>
+    </HeaderNavProvider>
+  );
+}

--- a/src/components/layout/LocaleSwitcher.css
+++ b/src/components/layout/LocaleSwitcher.css
@@ -23,7 +23,9 @@
   padding: 8px 14px;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .lt-locale__seg:hover {

--- a/src/components/layout/Logomark.tsx
+++ b/src/components/layout/Logomark.tsx
@@ -1,0 +1,34 @@
+// TODO(slice-2, #2): swap placeholder geometry for traced real logo from
+// docs/brand-reference/logo-crop.png. Keep currentColor + viewBox so the
+// header brand color flows through.
+
+type Props = { size?: number };
+
+export function Logomark({ size = 22 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 22 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <rect
+        x="1.5"
+        y="1.5"
+        width="19"
+        height="19"
+        rx="3"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M11 5.5v11M5.5 11h11"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -1,0 +1,14 @@
+import type { Locale } from "@/lib/content/home";
+import { Header } from "./Header";
+
+type Props = { locale: Locale; children: React.ReactNode };
+
+// Footer slot is intentionally empty — issue #4 wires <Footer> here.
+export function PageShell({ locale, children }: Props) {
+  return (
+    <>
+      <Header locale={locale} />
+      {children}
+    </>
+  );
+}

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -75,6 +75,8 @@ export type ShellFooter = {
 
 export type ShellContent = {
   nav: ShellNavItem[];
+  /** Top-right "Quote" button label in the header. Mailto target is shared. */
+  quoteLabel: string;
   footer: ShellFooter;
 };
 
@@ -178,6 +180,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         },
       },
     ],
+    quoteLabel: "견적 요청",
     footer: {
       signoff: "1997년부터 정밀 질량유량 제어를 만들어 온 라인텍입니다.",
       address: "(34055) 대전광역시 유성구 대덕대로 806 · TEL 042-624-0700",
@@ -259,6 +262,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         },
       },
     ],
+    quoteLabel: "Quote",
     footer: {
       signoff: "Building precision mass-flow control since 1997.",
       address: "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea · TEL +82 42-624-0700",
@@ -340,6 +344,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         },
       },
     ],
+    quoteLabel: "申请报价",
     footer: {
       signoff: "自 1997 年起专注于精密质量流量控制。",
       address: "韩国大田广域市儒城区大德大路 806 号 (34055) · TEL +82 42-624-0700",

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -118,9 +118,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           heading: "회사 안내",
           links: [
             { href: "/company", label: "인사말", desc: "CEO 메시지" },
-            { href: "/company/history", label: "연혁", desc: "1997년부터 현재까지" },
-            { href: "/company/certifications", label: "인증", desc: "ISO · CE · INNOBIZ 외" },
-            { href: "/company/location", label: "오시는 길", desc: "대전 본사 위치" },
+            {
+              href: "/company/history",
+              label: "연혁",
+              desc: "1997년부터 현재까지",
+            },
+            {
+              href: "/company/certifications",
+              label: "인증",
+              desc: "ISO · CE · INNOBIZ 외",
+            },
+            {
+              href: "/company/location",
+              label: "오시는 길",
+              desc: "대전 본사 위치",
+            },
           ],
         },
       },
@@ -150,10 +162,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "자료실",
           links: [
-            { href: "/resources/catalogues", label: "카탈로그", desc: "제품군 별 PDF 카탈로그" },
-            { href: "/resources/drawings", label: "도면", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "매뉴얼", desc: "모델별 사용 설명서" },
-            { href: "/resources/certifications", label: "인증서", desc: "13종 인증 문서" },
+            {
+              href: "/resources/catalogues",
+              label: "카탈로그",
+              desc: "제품군 별 PDF 카탈로그",
+            },
+            {
+              href: "/resources/drawings",
+              label: "도면",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "매뉴얼",
+              desc: "모델별 사용 설명서",
+            },
+            {
+              href: "/resources/certifications",
+              label: "인증서",
+              desc: "13종 인증 문서",
+            },
           ],
           featured: {
             eyebrow: "주목할 자료",
@@ -172,9 +200,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "문의 방법",
           links: [
-            { href: "/contact", label: "견적 요청", desc: "공정 조건을 알려주세요" },
-            { href: "/contact#support", label: "기술 문의", desc: "적합 모델 추천" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "이메일", desc: "linetech@line-tech.co.kr" },
+            {
+              href: "/contact",
+              label: "견적 요청",
+              desc: "공정 조건을 알려주세요",
+            },
+            {
+              href: "/contact#support",
+              label: "기술 문의",
+              desc: "적합 모델 추천",
+            },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "이메일",
+              desc: "linetech@line-tech.co.kr",
+            },
             { href: "tel:+82426240700", label: "전화", desc: "042-624-0700" },
           ],
         },
@@ -199,10 +239,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "About Line Tech",
           links: [
-            { href: "/company", label: "Greeting", desc: "Message from the CEO" },
-            { href: "/company/history", label: "History", desc: "From 1997 to today" },
-            { href: "/company/certifications", label: "Certifications", desc: "ISO · CE · INNOBIZ and more" },
-            { href: "/company/location", label: "Location", desc: "Daejeon headquarters" },
+            {
+              href: "/company",
+              label: "Greeting",
+              desc: "Message from the CEO",
+            },
+            {
+              href: "/company/history",
+              label: "History",
+              desc: "From 1997 to today",
+            },
+            {
+              href: "/company/certifications",
+              label: "Certifications",
+              desc: "ISO · CE · INNOBIZ and more",
+            },
+            {
+              href: "/company/location",
+              label: "Location",
+              desc: "Daejeon headquarters",
+            },
           ],
         },
       },
@@ -218,7 +274,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           featured: {
             eyebrow: "Featured model",
             title: "M3030VA",
-            blurb: "Digital piezo-actuated MFC for semiconductor and display process lines.",
+            blurb:
+              "Digital piezo-actuated MFC for semiconductor and display process lines.",
             href: "/products/m3030va",
             cta: "View product",
           },
@@ -232,15 +289,32 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "Resources",
           links: [
-            { href: "/resources/catalogues", label: "Catalogues", desc: "Series-level PDF catalogues" },
-            { href: "/resources/drawings", label: "CAD drawings", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "Manuals", desc: "Per-model user guides" },
-            { href: "/resources/certifications", label: "Certifications", desc: "13 certification documents" },
+            {
+              href: "/resources/catalogues",
+              label: "Catalogues",
+              desc: "Series-level PDF catalogues",
+            },
+            {
+              href: "/resources/drawings",
+              label: "CAD drawings",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "Manuals",
+              desc: "Per-model user guides",
+            },
+            {
+              href: "/resources/certifications",
+              label: "Certifications",
+              desc: "13 certification documents",
+            },
           ],
           featured: {
             eyebrow: "Spotlight",
             title: "M3030VA manual + catalogue",
-            blurb: "Full specs and Modbus protocol for our flagship digital MFC.",
+            blurb:
+              "Full specs and Modbus protocol for our flagship digital MFC.",
             href: "/products/m3030va",
             cta: "Open M3030VA",
           },
@@ -254,10 +328,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "simple",
           heading: "Get in touch",
           links: [
-            { href: "/contact", label: "Request quote", desc: "Share your process conditions" },
-            { href: "/contact#support", label: "Technical inquiry", desc: "Model recommendations" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "Email", desc: "linetech@line-tech.co.kr" },
-            { href: "tel:+82426240700", label: "Phone", desc: "+82 42-624-0700" },
+            {
+              href: "/contact",
+              label: "Request quote",
+              desc: "Share your process conditions",
+            },
+            {
+              href: "/contact#support",
+              label: "Technical inquiry",
+              desc: "Model recommendations",
+            },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "Email",
+              desc: "linetech@line-tech.co.kr",
+            },
+            {
+              href: "tel:+82426240700",
+              label: "Phone",
+              desc: "+82 42-624-0700",
+            },
           ],
         },
       },
@@ -265,7 +355,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
     quoteLabel: "Quote",
     footer: {
       signoff: "Building precision mass-flow control since 1997.",
-      address: "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea · TEL +82 42-624-0700",
+      address:
+        "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea · TEL +82 42-624-0700",
       rights: "© 2026 Line Tech Inc. All rights reserved.",
       version: SHELL_VERSION,
     },
@@ -282,9 +373,21 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           heading: "关于莱因",
           links: [
             { href: "/company", label: "问候语", desc: "CEO 致辞" },
-            { href: "/company/history", label: "发展历程", desc: "自 1997 年至今" },
-            { href: "/company/certifications", label: "资质认证", desc: "ISO · CE · INNOBIZ 等" },
-            { href: "/company/location", label: "联系地址", desc: "大田总部位置" },
+            {
+              href: "/company/history",
+              label: "发展历程",
+              desc: "自 1997 年至今",
+            },
+            {
+              href: "/company/certifications",
+              label: "资质认证",
+              desc: "ISO · CE · INNOBIZ 等",
+            },
+            {
+              href: "/company/location",
+              label: "联系地址",
+              desc: "大田总部位置",
+            },
           ],
         },
       },
@@ -314,10 +417,26 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "技术资料",
           links: [
-            { href: "/resources/catalogues", label: "产品样册", desc: "系列 PDF 样册" },
-            { href: "/resources/drawings", label: "CAD 图纸", desc: "AutoCAD (.dwg · .stp)" },
-            { href: "/resources/manuals", label: "使用手册", desc: "按型号分类的说明书" },
-            { href: "/resources/certifications", label: "认证文件", desc: "13 份认证文件" },
+            {
+              href: "/resources/catalogues",
+              label: "产品样册",
+              desc: "系列 PDF 样册",
+            },
+            {
+              href: "/resources/drawings",
+              label: "CAD 图纸",
+              desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/manuals",
+              label: "使用手册",
+              desc: "按型号分类的说明书",
+            },
+            {
+              href: "/resources/certifications",
+              label: "认证文件",
+              desc: "13 份认证文件",
+            },
           ],
           featured: {
             eyebrow: "推荐资料",
@@ -338,8 +457,16 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           links: [
             { href: "/contact", label: "申请报价", desc: "告知您的工艺条件" },
             { href: "/contact#support", label: "技术咨询", desc: "型号推荐" },
-            { href: "mailto:linetech@line-tech.co.kr", label: "邮箱", desc: "linetech@line-tech.co.kr" },
-            { href: "tel:+82426240700", label: "电话", desc: "+82 42-624-0700" },
+            {
+              href: "mailto:linetech@line-tech.co.kr",
+              label: "邮箱",
+              desc: "linetech@line-tech.co.kr",
+            },
+            {
+              href: "tel:+82426240700",
+              label: "电话",
+              desc: "+82 42-624-0700",
+            },
           ],
         },
       },
@@ -347,7 +474,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
     quoteLabel: "申请报价",
     footer: {
       signoff: "自 1997 年起专注于精密质量流量控制。",
-      address: "韩国大田广域市儒城区大德大路 806 号 (34055) · TEL +82 42-624-0700",
+      address:
+        "韩国大田广域市儒城区大德大路 806 号 (34055) · TEL +82 42-624-0700",
       rights: "© 2026 株式会社莱因。保留所有权利。",
       version: SHELL_VERSION,
     },


### PR DESCRIPTION
## Summary

Top-bar shell for slice 2 — unblocks #7 (mega-menu) and #8 (search panel).

- `PageShell` wraps `<Header>` + children (Footer slot empty until #4 lands)
- `Header` renders `.pd-top` from `LT_SHELL[locale]`: logomark placeholder + 4-item nav + search-icon stub + locale pill + Quote button
- `HeaderShell` (client) owns the `<header>` element, runs the sticky scroll effect (72→60px past 40px, 10px hysteresis), and provides `HeaderNavContext` for `#7` to consume
- `HeaderNav` wires hover/focus open-state with 120ms open + 120ms close grace; Esc closes
- `LT_SHELL` gains a per-locale `quoteLabel` (KO 견적 요청 / EN Quote / ZH 申请报价)
- `Logomark` ships an inline SVG placeholder; `TODO(#2)` logged to swap for the traced real logo

CSS is colocated (`Header.css`, `HeaderNav.css`) and ports the prescribed `.pd-top` rules from `docs/handoff/styles.css` verbatim, with tokens swapped to `--pd-*` / `--lt-*`.

## What this PR does NOT do

- Render any mega-menu panel → #7
- Render the search panel → #8
- Render the footer → #4
- Render breadcrumbs → #5 (already in #21)
- Trace the real logo → soft #2

Closes #6.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean for new files
- [x] `pnpm build` static-gens `/`, `/ko`, `/en`, `/zh` (+ product pages)
- [x] All three locales render correct nav labels + Quote button (verified via `curl` HTML inspection)
- [ ] Browser spot-check: scroll past 40px → height animates 72→60; scroll back → animates back
- [ ] Tab order: logomark → nav items → search → locale → Quote
- [ ] Hover a nav item → underline appears + chevron rotates (no panel renders yet, expected)
- [ ] Resize <1000px → nav hides; logo + locale + Quote remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)