### PR TITLE
test(shell): pin locked taxonomy + cross-locale invariants

### DIFF
--- a/src/lib/content/shell.test.ts
+++ b/src/lib/content/shell.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { LT_SHELL, seriesHref } from "./shell";
+import { LT_HOME, type Locale } from "./home";
+import { routing } from "@/i18n/routing";
+
+const LOCALES = routing.locales as readonly Locale[];
+
+const LOCKED_CATEGORY_CODES = [
+  "analogue-mfc",
+  "digital-mfc",
+  "mfm",
+  "specialized",
+] as const;
+
+describe("LT_SHELL invariants", () => {
+  it("uses the same nav ids in the same order across locales", () => {
+    const reference = LT_SHELL.ko.nav.map((item) => item.id);
+    for (const locale of LOCALES) {
+      expect(LT_SHELL[locale].nav.map((item) => item.id)).toEqual(reference);
+    }
+  });
+
+  it("locks the 4-category products taxonomy across locales", () => {
+    for (const locale of LOCALES) {
+      const codes = LT_SHELL[locale].productsCategories.map((c) => c.code);
+      expect(codes).toEqual([...LOCKED_CATEGORY_CODES]);
+    }
+  });
+
+  it("aligns each productsCategory href with its slug", () => {
+    for (const locale of LOCALES) {
+      for (const cat of LT_SHELL[locale].productsCategories) {
+        expect(cat.href).toBe(`/products/${cat.code}`);
+      }
+    }
+  });
+
+  it("attaches regulatory blocks only to the locales that need them", () => {
+    expect(LT_SHELL.ko.footer.legal).toBeDefined();
+    expect(LT_SHELL.en.footer.legal).toBeUndefined();
+    expect(LT_SHELL.zh.footer.legal).toBeUndefined();
+
+    expect(LT_SHELL.zh.footer.subsidiary).toBeDefined();
+    expect(LT_SHELL.ko.footer.subsidiary).toBeUndefined();
+    expect(LT_SHELL.en.footer.subsidiary).toBeUndefined();
+  });
+});
+
+describe("seriesHref", () => {
+  it("resolves every series code defined on LT_HOME to a real category route", () => {
+    // Catches the silent-fallback bug: adding a series in LT_HOME without
+    // wiring its href in shell.ts would route the homepage card to /products.
+    for (const item of LT_HOME.ko.series.items) {
+      expect(seriesHref(item.code)).not.toBe("/products");
+      expect(seriesHref(item.code).startsWith("/products/")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 5 vitest tests in `src/lib/content/shell.test.ts` covering the silent-drift cases that TypeScript can't catch and that aren't obvious in review.
- Pins the locked 4-category products taxonomy (#19) across all three locales — adding/removing/reordering a category in one locale now fails CI.
- Pins the `LT_HOME.series.items` ↔ `seriesHref()` coupling — adding a new series code without wiring its href would silently route the homepage card to `/products`; this test catches it.
- Also asserts: nav id parity across locales, slug↔href alignment in `productsCategories`, and locale-conditional footer blocks (KO `legal`, ZH `subsidiary`).

## What's intentionally NOT here
Trimmed initial round of ~35 low-value tests (Glyph, Chip, default-prop assertions). Those were testing what TypeScript already enforces or what's visually obvious from the JSX.

## Test plan
- [x] `pnpm test:run` — 5/5 pass
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)