### PR TITLE
fix(header): tighten search panel layout

### DIFF
--- a/src/components/layout/SearchPanel.css
+++ b/src/components/layout/SearchPanel.css
@@ -45,51 +45,10 @@
 .pd-search__inner {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 22px 32px 26px;
+  padding: 16px 32px 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.pd-search__row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.pd-search__heading {
-  margin: 0;
-  font: 600 11px/1 var(--lt-sans);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--pd-muted);
-}
-
-.pd-search__close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border: 1px solid var(--pd-border);
-  background: var(--pd-surface);
-  color: var(--pd-fg);
-  border-radius: var(--pd-r-md);
-  cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    color 0.15s ease;
-}
-
-.pd-search__close:hover {
-  border-color: var(--pd-primary);
-  color: var(--pd-primary);
-}
-
-.pd-search__close:focus-visible {
-  outline: 2px solid var(--pd-primary);
-  outline-offset: 2px;
+  gap: 12px;
 }
 
 .pd-search__form {
@@ -100,7 +59,7 @@
 
 .pd-search__icon {
   position: absolute;
-  left: 14px;
+  left: 12px;
   display: inline-flex;
   align-items: center;
   color: var(--pd-muted);
@@ -109,13 +68,13 @@
 
 .pd-search__input {
   width: 100%;
-  height: 52px;
-  padding: 0 16px 0 42px;
+  height: 42px;
+  padding: 0 14px 0 38px;
   border: 1px solid var(--pd-border);
   border-radius: var(--pd-r-lg);
-  background: var(--pd-surface-2);
+  background: transparent;
   color: var(--pd-fg-strong);
-  font: 500 16px/1.4 var(--lt-sans);
+  font: 500 14px/1.4 var(--lt-sans);
   outline: 0;
   transition:
     border-color 0.15s ease,
@@ -129,22 +88,7 @@
 
 .pd-search__input:focus-visible {
   border-color: var(--pd-primary);
-  background: var(--pd-surface);
   box-shadow: 0 0 0 3px var(--lt-primary-100);
-}
-
-.pd-search__chips {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.pd-search__chips-heading {
-  margin: 0;
-  font: 600 11px/1 var(--lt-sans);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--pd-muted);
 }
 
 .pd-search__chip-list {
@@ -159,13 +103,13 @@
 .pd-search__chip {
   display: inline-flex;
   align-items: center;
-  height: 30px;
-  padding: 0 12px;
+  height: 26px;
+  padding: 0 10px;
   border: 1px solid var(--pd-border);
   border-radius: 999px;
   background: var(--pd-surface);
   color: var(--pd-fg);
-  font: 500 13px/1 var(--lt-sans);
+  font: 500 12px/1 var(--lt-sans);
   cursor: pointer;
   transition:
     border-color 0.15s ease,
@@ -198,12 +142,12 @@
 
 @media (max-width: 640px) {
   .pd-search__inner {
-    padding: 18px 16px 22px;
+    padding: 14px 16px 18px;
   }
 
   .pd-search__input {
-    height: 48px;
-    font-size: 15px;
+    height: 40px;
+    font-size: 14px;
   }
 }
 

--- a/src/components/layout/SearchPanel.tsx
+++ b/src/components/layout/SearchPanel.tsx
@@ -119,32 +119,23 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
         onKeyDown={handleKeyDown}
       >
         <div className="pd-search__inner">
-          <div className="pd-search__row">
-            <h2 id={headingId} className="pd-search__heading">
-              {content.heading}
-            </h2>
-            <button
-              type="button"
-              className="pd-search__close"
-              aria-label={content.closeLabel}
-              onClick={onClose}
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                aria-hidden="true"
-              >
-                <path
-                  d="M4 4l8 8M12 4l-8 8"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                />
-              </svg>
-            </button>
-          </div>
+          <h2 id={headingId} className="pd-search__sr">
+            {content.heading}
+          </h2>
+
+          <ul className="pd-search__chip-list">
+            {content.quickChips.map((chip) => (
+              <li key={chip.id}>
+                <button
+                  type="button"
+                  className="pd-search__chip"
+                  data-chip-id={chip.id}
+                >
+                  {chip.label}
+                </button>
+              </li>
+            ))}
+          </ul>
 
           <form
             className="pd-search__form"
@@ -155,7 +146,7 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
               {content.inputLabel}
             </label>
             <span className="pd-search__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <svg width="16" height="16" viewBox="0 0 18 18" fill="none">
                 <circle
                   cx="8"
                   cy="8"
@@ -182,25 +173,6 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
               onChange={(e) => setValue(e.target.value)}
             />
           </form>
-
-          <div className="pd-search__chips">
-            <p className="pd-search__chips-heading">
-              {content.quickChipsHeading}
-            </p>
-            <ul className="pd-search__chip-list">
-              {content.quickChips.map((chip) => (
-                <li key={chip.id}>
-                  <button
-                    type="button"
-                    className="pd-search__chip"
-                    data-chip-id={chip.id}
-                  >
-                    {chip.label}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
         </div>
       </div>
     </div>

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -114,16 +114,12 @@ export type ProductsCategory = {
 export type ShellSearch = {
   /** aria-label for the header search trigger icon button. */
   openLabel: string;
-  /** Visible heading rendered at the top of the panel. */
+  /** Dialog accessible name (visually-hidden, exposed via aria-labelledby). */
   heading: string;
   /** aria-label for the search input (visually-hidden label). */
   inputLabel: string;
   /** Placeholder text shown inside the empty input. */
   inputPlaceholder: string;
-  /** aria-label for the panel's close button. */
-  closeLabel: string;
-  /** Small label rendered above the quick-chip row, e.g. "Popular". */
-  quickChipsHeading: string;
   /** 4–6 inert chips. `id` is locale-independent for tracking later. */
   quickChips: { id: string; label: string }[];
 };
@@ -311,8 +307,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "사이트 검색",
       inputLabel: "제품, 자료, 모델명을 검색",
       inputPlaceholder: "예: M3030VA, 카탈로그, 디지털 MFC",
-      closeLabel: "검색 닫기",
-      quickChipsHeading: "자주 찾는 항목",
       quickChips: [
         { id: "m3030va", label: "M3030VA" },
         { id: "digital-mfc", label: "디지털 MFC" },
@@ -495,8 +489,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "Search the site",
       inputLabel: "Search products, resources, models",
       inputPlaceholder: "Try M3030VA, catalogue, digital MFC",
-      closeLabel: "Close search",
-      quickChipsHeading: "Popular",
       quickChips: [
         { id: "m3030va", label: "M3030VA" },
         { id: "digital-mfc", label: "Digital MFC" },
@@ -660,8 +652,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "站内搜索",
       inputLabel: "搜索产品、资料、型号",
       inputPlaceholder: "如：M3030VA、产品样册、数字 MFC",
-      closeLabel: "关闭搜索",
-      quickChipsHeading: "热门搜索",
       quickChips: [
         { id: "m3030va", label: "M3030VA" },
         { id: "digital-mfc", label: "数字 MFC" },


### PR DESCRIPTION
## Summary
Follow-up to #27 — the merged version felt modal-sized; this is a design pass to make the search panel read like a header continuation instead.

- Drop the heading row + X close button. Esc and scrim already cover every dismiss path; the row was the source of the top-heavy margins. Heading text is now visually-hidden but still the `aria-labelledby` target for the dialog.
- Drop the "Popular" label above the chips — chips read as suggestions on their own.
- Move chips above the input. Autofocus still drops the cursor into the input on open; tab order is chips → input → wrap.
- Lighten the input: transparent background instead of filled, so it recedes visually.
- Tighten sizing to header scale: input 52→42px, font 16→14px (matches nav), chips 30→26px, padding 22→16px top / 26→20px bottom.
- Drop `closeLabel` and `quickChipsHeading` from `ShellSearch` since neither is rendered.

## Test plan
- [ ] `/ko`, `/en`, `/zh` — open search → chips render above input, input is focused
- [ ] Esc / scrim click both dismiss
- [ ] Tab from input wraps to first chip
- [ ] `pnpm build` static-gens all three locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)