### PR TITLE
feat(nav): click toggles mega menu, restyle as contained dropdown card

### DIFF
--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -16,14 +16,14 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: 0 32px;
-  height: 72px;
+  height: 56px;
   display: flex;
   align-items: center;
   gap: 28px;
   transition: height 0.2s ease;
 }
 .pd-top.is-scrolled .pd-top__inner {
-  height: 60px;
+  height: 48px;
 }
 
 .pd-top__brand {
@@ -50,10 +50,10 @@
 .pd-top__wordmark {
   font: 700 16px/1 var(--lt-sans);
   letter-spacing: 0.01em;
-  color: var(--pd-fg-strong);
+  color: var(--pd-primary);
 }
 .pd-top__wordmark-dot {
-  color: var(--pd-primary);
+  color: var(--pd-accent);
   padding: 0 2px;
 }
 

--- a/src/components/layout/HeaderNav.test.tsx
+++ b/src/components/layout/HeaderNav.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { HeaderNav } from "./HeaderNav";
+import { HeaderNavProvider, type HeaderNavCtx } from "./HeaderNavContext";
+import { LT_SHELL } from "@/lib/content/shell";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: { href: unknown; children: React.ReactNode } & Record<
+    string,
+    unknown
+  >) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function stubCtx(overrides: Partial<HeaderNavCtx> = {}): HeaderNavCtx {
+  return {
+    openId: null,
+    setOpenId: vi.fn(),
+    onItemEnter: vi.fn(),
+    onItemLeave: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderNav(ctx: HeaderNavCtx) {
+  return render(
+    <HeaderNavProvider value={ctx}>
+      <HeaderNav items={LT_SHELL.en.nav} />
+    </HeaderNavProvider>,
+  );
+}
+
+describe("HeaderNav", () => {
+  it("renders menu items as buttons and non-menu items as links", () => {
+    const { container } = renderNav(stubCtx());
+    const products = container.querySelector('[aria-controls="pd-mega-products"]');
+    expect(products?.tagName).toBe("BUTTON");
+    expect(products).toHaveAttribute("aria-haspopup", "true");
+    expect(products).toHaveAttribute("aria-expanded", "false");
+
+    const contact = LT_SHELL.en.nav.find((i) => !i.menu);
+    if (!contact) throw new Error("expected a non-menu nav item in fixture");
+    const link = container.querySelector(`a[href="${contact.href}"]`);
+    expect(link?.tagName).toBe("A");
+    expect(link).not.toHaveAttribute("aria-haspopup");
+  });
+
+  it("clicking a closed menu button opens its panel", () => {
+    const setOpenId = vi.fn();
+    const { container } = renderNav(stubCtx({ openId: null, setOpenId }));
+    const btn = container.querySelector(
+      '[aria-controls="pd-mega-products"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+    expect(setOpenId).toHaveBeenCalledWith("products");
+  });
+
+  it("clicking an open menu button closes it", () => {
+    const setOpenId = vi.fn();
+    const { container } = renderNav(
+      stubCtx({ openId: "products", setOpenId }),
+    );
+    const btn = container.querySelector(
+      '[aria-controls="pd-mega-products"]',
+    ) as HTMLButtonElement;
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(btn);
+    expect(setOpenId).toHaveBeenCalledWith(null);
+  });
+
+  it("hovering a non-menu item triggers close-grace", () => {
+    const onItemLeave = vi.fn();
+    const contact = LT_SHELL.en.nav.find((i) => !i.menu);
+    if (!contact) throw new Error("expected a non-menu nav item in fixture");
+    const { container } = renderNav(
+      stubCtx({ openId: "products", onItemLeave }),
+    );
+    const link = container.querySelector(
+      `a[href="${contact.href}"]`,
+    ) as HTMLAnchorElement;
+    fireEvent.mouseEnter(link);
+    expect(onItemLeave).toHaveBeenCalled();
+  });
+
+  it("hovering a menu item schedules the open via onItemEnter", () => {
+    const onItemEnter = vi.fn();
+    const { container } = renderNav(stubCtx({ onItemEnter }));
+    const btn = container.querySelector(
+      '[aria-controls="pd-mega-products"]',
+    ) as HTMLButtonElement;
+    fireEvent.mouseEnter(btn);
+    expect(onItemEnter).toHaveBeenCalledWith("products");
+  });
+});

--- a/src/components/layout/HeaderNav.test.tsx
+++ b/src/components/layout/HeaderNav.test.tsx
@@ -40,7 +40,9 @@ function renderNav(ctx: HeaderNavCtx) {
 describe("HeaderNav", () => {
   it("renders menu items as buttons and non-menu items as links", () => {
     const { container } = renderNav(stubCtx());
-    const products = container.querySelector('[aria-controls="pd-mega-products"]');
+    const products = container.querySelector(
+      '[aria-controls="pd-mega-products"]',
+    );
     expect(products?.tagName).toBe("BUTTON");
     expect(products).toHaveAttribute("aria-haspopup", "true");
     expect(products).toHaveAttribute("aria-expanded", "false");
@@ -64,9 +66,7 @@ describe("HeaderNav", () => {
 
   it("clicking an open menu button closes it", () => {
     const setOpenId = vi.fn();
-    const { container } = renderNav(
-      stubCtx({ openId: "products", setOpenId }),
-    );
+    const { container } = renderNav(stubCtx({ openId: "products", setOpenId }));
     const btn = container.querySelector(
       '[aria-controls="pd-mega-products"]',
     ) as HTMLButtonElement;

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -29,6 +29,7 @@ export function HeaderNav({ items }: Props) {
               className={cls}
               aria-haspopup="true"
               aria-expanded={isOpen}
+              aria-controls={`pd-mega-${item.id}`}
               onMouseEnter={() => onItemEnter(item.id)}
               onFocus={() => setOpenId(item.id)}
               onClick={() => setOpenId(isOpen ? null : item.id)}
@@ -52,6 +53,9 @@ export function HeaderNav({ items }: Props) {
           );
         }
 
+        // Cursor moving from a menu trigger to a no-menu sibling never fires
+        // the nav's onMouseLeave; trigger close-grace here so the open panel
+        // doesn't linger.
         return (
           <Link
             key={item.id}

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -20,24 +20,20 @@ export function HeaderNav({ items }: Props) {
         const isOpen = openId === item.id;
         const hasMenu = !!item.menu;
         const cls = `pd-top__navitem${isOpen ? " is-open" : ""}`;
-        const handleEnter = () => {
-          if (hasMenu) onItemEnter(item.id);
-        };
-        const handleFocus = () => {
-          if (hasMenu) setOpenId(item.id);
-        };
-        return (
-          <Link
-            key={item.id}
-            href={item.href}
-            className={cls}
-            aria-haspopup={hasMenu ? "true" : undefined}
-            aria-expanded={hasMenu ? isOpen : undefined}
-            onMouseEnter={handleEnter}
-            onFocus={handleFocus}
-          >
-            {item.label}
-            {hasMenu && (
+
+        if (hasMenu) {
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={cls}
+              aria-haspopup="true"
+              aria-expanded={isOpen}
+              onMouseEnter={() => onItemEnter(item.id)}
+              onFocus={() => setOpenId(item.id)}
+              onClick={() => setOpenId(isOpen ? null : item.id)}
+            >
+              {item.label}
               <svg
                 width="10"
                 height="10"
@@ -52,7 +48,18 @@ export function HeaderNav({ items }: Props) {
                   strokeLinecap="round"
                 />
               </svg>
-            )}
+            </button>
+          );
+        }
+
+        return (
+          <Link
+            key={item.id}
+            href={item.href}
+            className={cls}
+            onMouseEnter={onItemLeave}
+          >
+            {item.label}
           </Link>
         );
       })}

--- a/src/components/layout/MegaMenu.css
+++ b/src/components/layout/MegaMenu.css
@@ -14,14 +14,15 @@
 .pd-mega__panel {
   position: absolute;
   top: 8px;
-  left: 50%;
+  inset-inline: 0;
+  margin-inline: auto;
   width: min(880px, calc(100% - 32px));
   background: var(--pd-surface);
   border: 1px solid var(--pd-border);
   border-radius: 12px;
   box-shadow: 0 16px 40px rgba(12, 14, 20, 0.12);
   opacity: 0;
-  transform: translate(-50%, -4px);
+  transform: translateY(-4px);
   transition:
     opacity 160ms ease-out,
     transform 160ms ease-out;
@@ -29,12 +30,12 @@
 }
 .pd-mega__panel.is-open {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: translateY(0);
   pointer-events: auto;
 }
 
 .pd-mega__inner {
-  padding: 14px 20px 18px;
+  padding: 14px 20px;
 }
 
 .pd-mega__heading {

--- a/src/components/layout/MegaMenu.css
+++ b/src/components/layout/MegaMenu.css
@@ -160,7 +160,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  top: 72px;
+  top: 56px;
   z-index: 45;
   background: rgba(12, 14, 20, 0.18);
   opacity: 0;
@@ -173,7 +173,7 @@
 }
 .pd-top.is-scrolled ~ * .pd-mega-scrim,
 .pd-top.is-scrolled .pd-mega-scrim {
-  top: 60px;
+  top: 48px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/layout/MegaMenu.css
+++ b/src/components/layout/MegaMenu.css
@@ -13,12 +13,15 @@
 
 .pd-mega__panel {
   position: absolute;
-  inset: 0 0 auto 0;
+  top: 8px;
+  left: 50%;
+  width: min(880px, calc(100% - 32px));
   background: var(--pd-surface);
-  border-bottom: 1px solid var(--pd-border);
-  box-shadow: 0 12px 32px rgba(12, 14, 20, 0.08);
+  border: 1px solid var(--pd-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(12, 14, 20, 0.12);
   opacity: 0;
-  transform: translateY(-4px);
+  transform: translate(-50%, -4px);
   transition:
     opacity 160ms ease-out,
     transform 160ms ease-out;
@@ -26,14 +29,12 @@
 }
 .pd-mega__panel.is-open {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(-50%, 0);
   pointer-events: auto;
 }
 
 .pd-mega__inner {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 28px 32px 32px;
+  padding: 14px 20px 18px;
 }
 
 .pd-mega__heading {
@@ -41,13 +42,13 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--pd-muted);
-  margin: 0 0 18px;
+  margin: 0 0 8px;
 }
 
 .pd-mega__cols {
   display: grid;
-  grid-template-columns: 1fr minmax(280px, 360px);
-  gap: 40px;
+  grid-template-columns: 1fr minmax(200px, 260px);
+  gap: 24px;
   align-items: start;
 }
 
@@ -57,14 +58,14 @@
   padding: 0;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 4px 24px;
+  gap: 2px 18px;
 }
 
 .pd-mega__link {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 10px 12px;
+  gap: 1px;
+  padding: 6px 10px;
   border-radius: var(--pd-r-md, 8px);
   text-decoration: none;
   color: var(--pd-fg);
@@ -84,18 +85,18 @@
 }
 
 .pd-mega__link-label {
-  font: 600 14px/1.3 var(--lt-sans);
+  font: 600 14px/1.2 var(--lt-sans);
 }
 .pd-mega__link-desc {
-  font: 400 12px/1.4 var(--lt-sans);
+  font: 400 12px/1.3 var(--lt-sans);
   color: var(--pd-muted);
 }
 
 .pd-mega__featured {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 20px;
+  gap: 2px;
+  padding: 12px 16px;
   border-radius: var(--pd-r-md, 8px);
   background: var(--pd-bg);
   border: 1px solid var(--pd-border);
@@ -122,24 +123,24 @@
   color: var(--pd-primary);
 }
 .pd-mega__featured-title {
-  font: 700 18px/1.2 var(--lt-sans);
+  font: 700 15px/1.2 var(--lt-sans);
   color: var(--pd-fg-strong);
-  margin-top: 4px;
+  margin-top: 3px;
 }
 .pd-mega__featured-blurb {
-  font: 400 13px/1.5 var(--lt-sans);
+  font: 400 12px/1.4 var(--lt-sans);
   color: var(--pd-muted);
-  margin-top: 4px;
+  margin-top: 2px;
 }
 .pd-mega__featured-cta {
-  font: 600 13px/1 var(--lt-sans);
+  font: 600 12px/1 var(--lt-sans);
   color: var(--pd-primary);
-  margin-top: 10px;
+  margin-top: 6px;
 }
 
 .pd-mega__all {
   display: inline-block;
-  margin-top: 18px;
+  margin-top: 8px;
   font: 600 13px/1 var(--lt-sans);
   color: var(--pd-primary);
   text-decoration: none;

--- a/src/components/layout/MegaMenu.tsx
+++ b/src/components/layout/MegaMenu.tsx
@@ -37,6 +37,7 @@ export function MegaMenu({ items, locale }: Props) {
         return (
           <section
             key={item.id}
+            id={`pd-mega-${item.id}`}
             className={cls}
             aria-hidden={!isOpen}
             inert={!isOpen}


### PR DESCRIPTION
## Summary
- Nav items with a mega-menu now render as `<button>` and toggle on click instead of navigating, so touch users can open the panel
- Items without a menu (e.g. Contact) trigger the close-grace timer on hover so the panel doesn't linger when moving the cursor between siblings
- Mega-menu surface restyled from a full-bleed strip to a centered ~880px card with rounded corners, shadow, and tightened internal spacing
- a11y: `aria-controls` on each menu button mapped to the panel section's `id`
- Reduced-motion safe: panel centers via `inset-inline` + `margin-inline:auto` instead of `translateX(-50%)`, so the existing `transform: none` rule under `prefers-reduced-motion` doesn't break centering

## Design note
Top-level parents (Products, Resources, Company) are now buttons that **only toggle the panel** — they no longer navigate. This is intentional. Each panel exposes a "See all products"-style link as the way through to the landing page. This was chosen over the hover-opens / click-navigates pattern because (a) touch devices have no hover, and (b) the panel itself is the curated entry point we want users to see.

## Test plan
- Hover any nav item with a menu (Products, Resources, Company) — panel still opens after the hover delay
- Click an open mega-menu item — panel closes; click a closed one — panel opens
- Hover Resources, then move cursor to Contact — Resources panel closes (no longer lingers)
- Click outside the panel / press Escape — closes
- `prefers-reduced-motion: reduce` enabled — panel still centers correctly (no horizontal jump)
- Resize from desktop down to 1000px — nav still hides correctly under the breakpoint
- `pnpm test:run` — 17 tests pass (5 new in HeaderNav.test.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)