### PR TITLE
feat(contact): add /contact page with form, distributors, map

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import type { ContactFormCopy } from "@/lib/content/contact";
+
+type Props = { form: ContactFormCopy; privacyNotice: string };
+
+export function ContactForm({ form, privacyNotice }: Props) {
+  const [type, setType] = useState<string>("");
+  const selected = form.inquiryTypeOptions.find((o) => o.id === type);
+  const extra = selected?.extraField;
+
+  return (
+    <form noValidate>
+      <div className="ct-form__grid">
+        <div className="ct-form__row ct-form__row--full">
+          <label htmlFor="ct-inquiry-type" className="ct-form__label">
+            {form.fields.inquiryType}
+            <span className="ct-form__required" aria-hidden>
+              {form.required}
+            </span>
+          </label>
+          <select
+            id="ct-inquiry-type"
+            name="inquiryType"
+            required
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="ct-form__select"
+          >
+            <option value="" disabled>
+              {form.placeholders.inquiryType}
+            </option>
+            {form.inquiryTypeOptions.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {extra && (
+          <div className="ct-form__row ct-form__row--full">
+            <label htmlFor="ct-type-detail" className="ct-form__label">
+              {extra.label}
+              {extra.required && (
+                <span className="ct-form__required" aria-hidden>
+                  {form.required}
+                </span>
+              )}
+            </label>
+            <input
+              // Keying on `type` resets the value when the visitor switches
+              // buckets — a serial number left over from "support" makes no
+              // sense if they pivot to "partnership".
+              key={type}
+              id="ct-type-detail"
+              name="typeDetail"
+              type="text"
+              required={extra.required}
+              placeholder={extra.placeholder}
+              className="ct-form__input"
+            />
+          </div>
+        )}
+
+        <div className="ct-form__row">
+          <label htmlFor="ct-name" className="ct-form__label">
+            {form.fields.name}
+            <span className="ct-form__required" aria-hidden>
+              {form.required}
+            </span>
+          </label>
+          <input
+            id="ct-name"
+            name="name"
+            type="text"
+            autoComplete="name"
+            required
+            placeholder={form.placeholders.name}
+            className="ct-form__input"
+          />
+        </div>
+
+        <div className="ct-form__row">
+          <label htmlFor="ct-email" className="ct-form__label">
+            {form.fields.email}
+            <span className="ct-form__required" aria-hidden>
+              {form.required}
+            </span>
+          </label>
+          <input
+            id="ct-email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            placeholder={form.placeholders.email}
+            className="ct-form__input"
+          />
+        </div>
+
+        <div className="ct-form__row">
+          <label htmlFor="ct-company" className="ct-form__label">
+            {form.fields.company}
+          </label>
+          <input
+            id="ct-company"
+            name="company"
+            type="text"
+            autoComplete="organization"
+            placeholder={form.placeholders.company}
+            className="ct-form__input"
+          />
+        </div>
+
+        <div className="ct-form__row">
+          <label htmlFor="ct-phone" className="ct-form__label">
+            {form.fields.phone}
+          </label>
+          <input
+            id="ct-phone"
+            name="phone"
+            type="tel"
+            autoComplete="tel"
+            placeholder={form.placeholders.phone}
+            className="ct-form__input"
+          />
+        </div>
+
+        <div className="ct-form__row ct-form__row--full">
+          <label htmlFor="ct-subject" className="ct-form__label">
+            {form.fields.subject}
+          </label>
+          <input
+            id="ct-subject"
+            name="subject"
+            type="text"
+            placeholder={form.placeholders.subject}
+            className="ct-form__input"
+          />
+        </div>
+
+        <div className="ct-form__row ct-form__row--full">
+          <label htmlFor="ct-message" className="ct-form__label">
+            {form.fields.message}
+            <span className="ct-form__required" aria-hidden>
+              {form.required}
+            </span>
+          </label>
+          <textarea
+            id="ct-message"
+            name="message"
+            required
+            rows={6}
+            placeholder={form.placeholders.message}
+            className="ct-form__textarea"
+          />
+        </div>
+      </div>
+
+      {/* TODO: wire submit to backend (Resend / route handler). For now the
+          button is non-functional; visitors are routed to direct email via
+          the notice + sidebar CTA. */}
+      <div className="ct-form__actions">
+        <Button variant="primary" size="lg">
+          {form.submit}
+        </Button>
+        <p className="ct-form__help">{form.submitDisabledHelp}</p>
+      </div>
+      <p className="ct-form__privacy">{privacyNotice}</p>
+    </form>
+  );
+}

--- a/src/app/[locale]/contact/contact-page.css
+++ b/src/app/[locale]/contact/contact-page.css
@@ -1,0 +1,320 @@
+/* Line Tech — /contact page */
+.ct {
+  display: grid;
+  gap: 48px;
+  padding-top: 16px;
+}
+.ct__header {
+  max-width: 720px;
+}
+.ct__title {
+  margin: 8px 0 12px;
+  font: 500 44px/1.1 var(--lt-sans);
+  letter-spacing: -0.02em;
+  color: var(--pd-fg-strong);
+}
+.ct__lede {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--pd-muted);
+}
+.ct__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: 40px;
+  align-items: start;
+}
+@media (max-width: 880px) {
+  .ct__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── Info card ─────────────────────────────────────────────────────── */
+.ct-info {
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
+  border-radius: var(--pd-r-lg);
+  padding: 28px;
+  position: sticky;
+  top: 24px;
+}
+.ct-info__heading {
+  margin: 0 0 20px;
+  font: 500 18px/1.2 var(--lt-sans);
+  letter-spacing: -0.01em;
+  color: var(--pd-fg-strong);
+}
+.ct-info__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 16px;
+}
+.ct-info__row {
+  display: grid;
+  gap: 4px;
+}
+.ct-info__label {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pd-muted);
+}
+.ct-info__value {
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--pd-fg-strong);
+}
+.ct-info__value a {
+  color: var(--pd-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgba(24, 86, 134, 0.35);
+}
+.ct-info__value a:hover {
+  text-decoration-color: var(--pd-primary);
+}
+.ct-info__cta {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--pd-rule);
+}
+
+/* ─── Form ─────────────────────────────────────────────────────────── */
+.ct-form {
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
+  border-radius: var(--pd-r-lg);
+  padding: 32px;
+}
+.ct-form__heading {
+  margin: 0 0 8px;
+  font: 500 22px/1.2 var(--lt-sans);
+  letter-spacing: -0.01em;
+  color: var(--pd-fg-strong);
+}
+.ct-form__notice {
+  margin: 0 0 24px;
+  padding: 12px 14px;
+  background: var(--lt-accent-50);
+  border: 1px solid var(--lt-accent-200);
+  border-radius: var(--pd-r-md);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--lt-accent-900);
+}
+.ct-form__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.ct-form__row {
+  display: grid;
+  gap: 6px;
+}
+.ct-form__row--full {
+  grid-column: 1 / -1;
+}
+@media (max-width: 600px) {
+  .ct-form__grid {
+    grid-template-columns: 1fr;
+  }
+  .ct-form__row--full {
+    grid-column: auto;
+  }
+}
+.ct-form__label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--pd-fg-strong);
+}
+.ct-form__required {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--lt-danger);
+}
+.ct-form__input,
+.ct-form__textarea,
+.ct-form__select {
+  font: inherit;
+  font-size: 15px;
+  color: var(--pd-fg-strong);
+  background: var(--pd-surface-2);
+  border: 1px solid var(--pd-border-strong);
+  border-radius: var(--pd-r-md);
+  padding: 10px 12px;
+  width: 100%;
+  box-sizing: border-box;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.ct-form__input:focus,
+.ct-form__textarea:focus,
+.ct-form__select:focus {
+  outline: none;
+  border-color: var(--pd-primary);
+  box-shadow: 0 0 0 3px rgba(24, 86, 134, 0.15);
+}
+.ct-form__select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 36px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10' fill='none'><path d='M2 4l3 3 3-3' stroke='%236b7485' stroke-width='1.4' stroke-linecap='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  cursor: pointer;
+}
+.ct-form__select:invalid {
+  color: var(--pd-muted);
+}
+.ct-form__textarea {
+  resize: vertical;
+  min-height: 140px;
+  line-height: 1.5;
+}
+.ct-form__actions {
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.ct-form__help {
+  font-size: 13px;
+  color: var(--pd-muted);
+  line-height: 1.45;
+  flex: 1 1 240px;
+}
+.ct-form__privacy {
+  margin: 14px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--pd-rule);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--pd-muted);
+}
+
+/* ─── Distributors block ──────────────────────────────────────────── */
+.ct-dist {
+  display: grid;
+  gap: 24px;
+}
+.ct-dist__header {
+  max-width: 720px;
+}
+.ct-dist__heading {
+  margin: 0 0 8px;
+  font: 500 28px/1.2 var(--lt-sans);
+  letter-spacing: -0.01em;
+  color: var(--pd-fg-strong);
+}
+.ct-dist__lede {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--pd-muted);
+}
+.ct-dist__grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+@media (max-width: 1000px) {
+  .ct-dist__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 560px) {
+  .ct-dist__grid {
+    grid-template-columns: 1fr;
+  }
+}
+.ct-dist__card {
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
+  border-radius: var(--pd-r-lg);
+  padding: 20px;
+  display: grid;
+  gap: 6px;
+}
+.ct-dist__region {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pd-primary);
+}
+.ct-dist__status {
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--pd-fg-strong);
+}
+
+/* ─── Map block ───────────────────────────────────────────────────── */
+.ct-map {
+  display: grid;
+  gap: 16px;
+}
+.ct-map__header {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.ct-map__heading {
+  margin: 0;
+  font: 500 28px/1.2 var(--lt-sans);
+  letter-spacing: -0.01em;
+  color: var(--pd-fg-strong);
+}
+.ct-map__caption {
+  margin: 0;
+  font-size: 14px;
+  color: var(--pd-muted);
+}
+.ct-map__frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 7;
+  background: var(--pd-surface-2);
+  border: 1px solid var(--pd-border);
+  border-radius: var(--pd-r-lg);
+  overflow: hidden;
+}
+.ct-map__frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+@media (max-width: 720px) {
+  .ct-map__frame {
+    aspect-ratio: 4 / 3;
+  }
+}
+.ct-map__open {
+  justify-self: start;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--pd-primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: rgba(24, 86, 134, 0.35);
+}
+.ct-map__open:hover {
+  text-decoration-color: var(--pd-primary);
+}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,0 +1,160 @@
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
+import { Button } from "@/components/ui/Button";
+import { LT_CONTACT } from "@/lib/content/contact";
+import { LT_SHELL } from "@/lib/content/shell";
+import type { Locale } from "@/lib/content/home";
+import { ContactForm } from "./ContactForm";
+import "./contact-page.css";
+
+type Props = { params: Promise<{ locale: Locale }> };
+
+export default async function ContactPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const tCommon = await getTranslations("common");
+  const c = LT_CONTACT[locale];
+  const info = LT_SHELL[locale].footer.contact;
+  const { form } = c;
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: c.breadcrumbLabel },
+  ];
+
+  // Iframe stays Google (Naver doesn't allow keyless embeds). The deep link,
+  // however, follows the visitor's natural map preference — Naver for KR,
+  // Google for EN/ZH.
+  const mapEmbedAddress = "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea";
+  const mapEmbedUrl = `https://maps.google.com/maps?q=${encodeURIComponent(
+    mapEmbedAddress,
+  )}&t=&z=15&ie=UTF8&iwloc=&output=embed`;
+  const mapOpenUrl =
+    locale === "ko"
+      ? `https://map.naver.com/p/search/${encodeURIComponent(
+          "대전광역시 유성구 대덕대로 806",
+        )}`
+      : `https://maps.google.com/maps?q=${encodeURIComponent(mapEmbedAddress)}`;
+
+  return (
+    <main className="lt-wrap">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <div className="ct">
+        <header className="ct__header">
+          <h1 className="ct__title">{c.title}</h1>
+          <p className="ct__lede">{c.lede}</p>
+        </header>
+
+        <div className="ct__layout">
+          <section className="ct-form" aria-labelledby="ct-form-heading">
+            <h2 id="ct-form-heading" className="ct-form__heading">
+              {form.heading}
+            </h2>
+            <p className="ct-form__notice" role="status">
+              {form.notice}
+            </p>
+
+            <ContactForm form={form} privacyNotice={c.privacyNotice} />
+          </section>
+
+          <aside
+            className="ct-info"
+            aria-labelledby="ct-info-heading"
+          >
+            <h2 id="ct-info-heading" className="ct-info__heading">
+              {c.infoHeading}
+            </h2>
+            <ul className="ct-info__list">
+              <li className="ct-info__row">
+                <span className="ct-info__label">{c.addressLabel}</span>
+                <span className="ct-info__value">{info.address}</span>
+              </li>
+              <li className="ct-info__row">
+                <span className="ct-info__label">{c.phoneLabel}</span>
+                <span className="ct-info__value">
+                  <a href={`tel:${info.phone.replace(/\s+/g, "")}`}>
+                    {info.phone}
+                  </a>
+                </span>
+              </li>
+              {info.fax && (
+                <li className="ct-info__row">
+                  <span className="ct-info__label">{c.faxLabel}</span>
+                  <span className="ct-info__value">{info.fax}</span>
+                </li>
+              )}
+              <li className="ct-info__row">
+                <span className="ct-info__label">{c.emailLabel}</span>
+                <span className="ct-info__value">
+                  <a href={`mailto:${info.email}`}>{info.email}</a>
+                </span>
+              </li>
+              <li className="ct-info__row">
+                <span className="ct-info__label">{c.hoursLabel}</span>
+                <span className="ct-info__value">{c.hoursValue}</span>
+              </li>
+            </ul>
+            <div className="ct-info__cta">
+              <Button
+                variant="ghost"
+                size="md"
+                href={`mailto:${info.email}`}
+                plain
+                fullWidth
+              >
+                {c.emailDirectCta}
+              </Button>
+            </div>
+          </aside>
+        </div>
+
+        <section
+          className="ct-dist"
+          aria-labelledby="ct-dist-heading"
+        >
+          <header className="ct-dist__header">
+            <h2 id="ct-dist-heading" className="ct-dist__heading">
+              {c.distributors.heading}
+            </h2>
+            <p className="ct-dist__lede">{c.distributors.lede}</p>
+          </header>
+          <ul className="ct-dist__grid">
+            {c.distributors.regions.map((region) => (
+              <li key={region.id} className="ct-dist__card">
+                <span className="ct-dist__region">{region.name}</span>
+                <span className="ct-dist__status">{region.status}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="ct-map" aria-labelledby="ct-map-heading">
+          <header className="ct-map__header">
+            <h2 id="ct-map-heading" className="ct-map__heading">
+              {c.map.heading}
+            </h2>
+            <p className="ct-map__caption">{c.map.caption}</p>
+          </header>
+          <div className="ct-map__frame">
+            <iframe
+              title={c.map.caption}
+              src={mapEmbedUrl}
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+            />
+          </div>
+          <a
+            className="ct-map__open"
+            href={mapOpenUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {c.map.openLabel} →
+          </a>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -7,6 +7,16 @@ import type { Locale } from "@/lib/content/home";
 import { ContactForm } from "./ContactForm";
 import "./contact-page.css";
 
+// Per-locale Google Maps Embed URLs (`pb=…`) generated from
+// "Share → Embed map" in each language's session. The labels on the map
+// (street names, place name) render in the locale's language. Same place
+// ID across all three (0x35654a04e7c961ab:0xe91272f47a8f5e5).
+const MAP_EMBED_URLS: Record<Locale, string> = {
+  en: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d24056.780848582704!2d127.36912219355615!3d36.38991365710943!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2sLine%20Tech!5e0!3m2!1sen!2sus!4v1777338643281!5m2!1sen!2sus",
+  ko: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3211.3139884913467!2d127.37273477657999!3d36.4015978723635!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2zKOyjvCnrnbzsnbjthY0!5e0!3m2!1sko!2sus!4v1777338879348!5m2!1sko!2sus",
+  zh: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3211.3139873492805!2d127.3753097!3d36.4015979!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2sLine%20Tech!5e0!3m2!1szh-CN!2sus!4v1777338907476!5m2!1szh-CN!2sus",
+};
+
 type Props = { params: Promise<{ locale: Locale }> };
 
 export default async function ContactPage({ params }: Props) {
@@ -23,20 +33,18 @@ export default async function ContactPage({ params }: Props) {
     { label: c.breadcrumbLabel },
   ];
 
-  // Iframe stays Google (Naver doesn't allow keyless embeds). Using the
-  // official Google Maps Embed URL (`pb=…`) generated via "Share → Embed
-  // map" — stable across Google's UI changes, unlike the older `output=embed`
-  // pattern. The deep link follows the visitor's natural map preference:
-  // Naver for KR, Google for EN/ZH.
-  const mapEmbedAddress = "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea";
-  const mapEmbedUrl =
-    "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d24056.780848582704!2d127.36912219355615!3d36.38991365710943!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2sLine%20Tech!5e0!3m2!1sen!2sus!4v1777338643281!5m2!1sen!2sus";
+  // Iframe stays Google (Naver doesn't allow keyless embeds). Embed URL is
+  // localized so the map's labels match the locale. Deep link follows the
+  // visitor's natural map preference: Naver for KR, Google for EN/ZH.
+  const mapEmbedUrl = MAP_EMBED_URLS[locale];
   const mapOpenUrl =
     locale === "ko"
       ? `https://map.naver.com/p/search/${encodeURIComponent(
           "대전광역시 유성구 대덕대로 806",
         )}`
-      : `https://maps.google.com/maps?q=${encodeURIComponent(mapEmbedAddress)}`;
+      : `https://maps.google.com/maps?q=${encodeURIComponent(
+          "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea",
+        )}`;
 
   return (
     <main className="lt-wrap">

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { Button } from "@/components/ui/Button";
@@ -19,6 +20,15 @@ const MAP_EMBED_URLS: Record<Locale, string> = {
 
 type Props = { params: Promise<{ locale: Locale }> };
 
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const c = LT_CONTACT[locale];
+  return {
+    title: `${c.title} — Line Tech`,
+    description: c.lede,
+  };
+}
+
 export default async function ContactPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
@@ -37,13 +47,17 @@ export default async function ContactPage({ params }: Props) {
   // localized so the map's labels match the locale. Deep link follows the
   // visitor's natural map preference: Naver for KR, Google for EN/ZH.
   const mapEmbedUrl = MAP_EMBED_URLS[locale];
+  // Naver search rejects the parenthetical postal-code suffix LT_SHELL keeps
+  // on the KO address ("… 806 (34055)") — strip it before encoding.
+  const naverQuery = LT_SHELL.ko.footer.contact.address.replace(
+    /\s*\(\d+\)\s*$/,
+    "",
+  );
   const mapOpenUrl =
     locale === "ko"
-      ? `https://map.naver.com/p/search/${encodeURIComponent(
-          "대전광역시 유성구 대덕대로 806",
-        )}`
+      ? `https://map.naver.com/p/search/${encodeURIComponent(naverQuery)}`
       : `https://maps.google.com/maps?q=${encodeURIComponent(
-          "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea",
+          LT_SHELL.en.footer.contact.address,
         )}`;
 
   return (
@@ -61,9 +75,7 @@ export default async function ContactPage({ params }: Props) {
             <h2 id="ct-form-heading" className="ct-form__heading">
               {form.heading}
             </h2>
-            <p className="ct-form__notice" role="status">
-              {form.notice}
-            </p>
+            <p className="ct-form__notice">{form.notice}</p>
 
             <ContactForm form={form} privacyNotice={c.privacyNotice} />
           </section>
@@ -83,7 +95,7 @@ export default async function ContactPage({ params }: Props) {
               <li className="ct-info__row">
                 <span className="ct-info__label">{c.phoneLabel}</span>
                 <span className="ct-info__value">
-                  <a href={`tel:${info.phone.replace(/\s+/g, "")}`}>
+                  <a href={`tel:${info.phone.replace(/[^\d+]/g, "")}`}>
                     {info.phone}
                   </a>
                 </span>
@@ -152,6 +164,7 @@ export default async function ContactPage({ params }: Props) {
               src={mapEmbedUrl}
               loading="lazy"
               referrerPolicy="no-referrer-when-downgrade"
+              allowFullScreen
             />
           </div>
           <a

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -80,10 +80,7 @@ export default async function ContactPage({ params }: Props) {
             <ContactForm form={form} privacyNotice={c.privacyNotice} />
           </section>
 
-          <aside
-            className="ct-info"
-            aria-labelledby="ct-info-heading"
-          >
+          <aside className="ct-info" aria-labelledby="ct-info-heading">
             <h2 id="ct-info-heading" className="ct-info__heading">
               {c.infoHeading}
             </h2>
@@ -131,10 +128,7 @@ export default async function ContactPage({ params }: Props) {
           </aside>
         </div>
 
-        <section
-          className="ct-dist"
-          aria-labelledby="ct-dist-heading"
-        >
+        <section className="ct-dist" aria-labelledby="ct-dist-heading">
           <header className="ct-dist__header">
             <h2 id="ct-dist-heading" className="ct-dist__heading">
               {c.distributors.heading}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -23,13 +23,14 @@ export default async function ContactPage({ params }: Props) {
     { label: c.breadcrumbLabel },
   ];
 
-  // Iframe stays Google (Naver doesn't allow keyless embeds). The deep link,
-  // however, follows the visitor's natural map preference — Naver for KR,
-  // Google for EN/ZH.
+  // Iframe stays Google (Naver doesn't allow keyless embeds). Using the
+  // official Google Maps Embed URL (`pb=…`) generated via "Share → Embed
+  // map" — stable across Google's UI changes, unlike the older `output=embed`
+  // pattern. The deep link follows the visitor's natural map preference:
+  // Naver for KR, Google for EN/ZH.
   const mapEmbedAddress = "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea";
-  const mapEmbedUrl = `https://maps.google.com/maps?q=${encodeURIComponent(
-    mapEmbedAddress,
-  )}&t=&z=15&ie=UTF8&iwloc=&output=embed`;
+  const mapEmbedUrl =
+    "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d24056.780848582704!2d127.36912219355615!3d36.38991365710943!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2sLine%20Tech!5e0!3m2!1sen!2sus!4v1777338643281!5m2!1sen!2sus";
   const mapOpenUrl =
     locale === "ko"
       ? `https://map.naver.com/p/search/${encodeURIComponent(

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -121,7 +121,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
         name: "홍길동",
         email: "name@company.com",
         company: "(주)회사명",
-        phone: "010-0000-0000",
+        phone: "+82 10-0000-0000",
         subject: "예: 견적 요청, 기술 문의, 협력 제안",
         message:
           "어떤 도움이 필요하신지 자세히 적어주세요. 제품 문의라면 가스 종류·유량 범위 등 공정 조건을 함께 알려주시면 더 빠르게 안내드릴 수 있습니다.",

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -1,0 +1,395 @@
+/**
+ * Line Tech — /contact page content.
+ *
+ * Static info (address / phone / fax / email) is sourced from `LT_SHELL.footer.contact`
+ * to stay DRY with the footer. This file only carries page-specific copy
+ * (heading, intro, hours, form labels, submission-notice).
+ */
+import type { Locale } from "./home";
+
+export type InquiryTypeId =
+  | "sales"
+  | "support"
+  | "partnership"
+  | "general";
+
+export type ContactFormCopy = {
+  heading: string;
+  notice: string;
+  fields: {
+    inquiryType: string;
+    name: string;
+    email: string;
+    company: string;
+    phone: string;
+    subject: string;
+    message: string;
+  };
+  placeholders: {
+    inquiryType: string;
+    name: string;
+    email: string;
+    company: string;
+    phone: string;
+    subject: string;
+    message: string;
+  };
+  inquiryTypeOptions: {
+    id: InquiryTypeId;
+    label: string;
+    /**
+     * Optional follow-up field that appears below the select when this type
+     * is chosen. Captures the one piece of structured info that matters most
+     * for the bucket (model number for support, region for partnership, etc).
+     */
+    extraField?: {
+      label: string;
+      placeholder: string;
+      required: boolean;
+    };
+  }[];
+  required: string;
+  submit: string;
+  submitDisabledHelp: string;
+};
+
+export type DistributorRegion = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+export type ContactContent = {
+  breadcrumbLabel: string;
+  title: string;
+  lede: string;
+  infoHeading: string;
+  hoursLabel: string;
+  hoursValue: string;
+  addressLabel: string;
+  phoneLabel: string;
+  faxLabel: string;
+  emailLabel: string;
+  emailDirectCta: string;
+  form: ContactFormCopy;
+  /**
+   * Inline fine-print under the form's submit. References "privacy policy" in
+   * each locale's natural phrasing — wrap the relevant phrase in an <a> once
+   * the policy page lands.
+   */
+  privacyNotice: string;
+  distributors: {
+    heading: string;
+    lede: string;
+    regions: DistributorRegion[];
+  };
+  map: {
+    heading: string;
+    caption: string;
+    openLabel: string;
+  };
+};
+
+export const LT_CONTACT: Record<Locale, ContactContent> = {
+  ko: {
+    breadcrumbLabel: "문의",
+    title: "문의하기",
+    lede: "제품 문의부터 기술 지원, 협력 제안까지 — 영업일 기준 2일 이내에 회신드립니다.",
+    infoHeading: "연락처",
+    hoursLabel: "운영 시간",
+    hoursValue: "평일 09:00 – 18:00 (KST) · 점심 12:00 – 13:00",
+    addressLabel: "주소",
+    phoneLabel: "전화",
+    faxLabel: "팩스",
+    emailLabel: "이메일",
+    emailDirectCta: "이메일로 직접 문의",
+    form: {
+      heading: "온라인 문의",
+      notice:
+        "온라인 제출 시스템을 업그레이드 중입니다. 즉시 회신이 필요하시면 위 이메일로 직접 연락해 주세요.",
+      fields: {
+        inquiryType: "문의 유형",
+        name: "성함",
+        email: "이메일",
+        company: "회사명",
+        phone: "연락처",
+        subject: "제목",
+        message: "문의 내용",
+      },
+      placeholders: {
+        inquiryType: "문의 유형을 선택해 주세요",
+        name: "홍길동",
+        email: "name@company.com",
+        company: "(주)회사명",
+        phone: "010-0000-0000",
+        subject: "예: 견적 요청, 기술 문의, 협력 제안",
+        message:
+          "어떤 도움이 필요하신지 자세히 적어주세요. 제품 문의라면 가스 종류·유량 범위 등 공정 조건을 함께 알려주시면 더 빠르게 안내드릴 수 있습니다.",
+      },
+      inquiryTypeOptions: [
+        {
+          id: "sales",
+          label: "영업·견적",
+          extraField: {
+            label: "관심 제품·모델",
+            placeholder: "예: M3030VA, MD2030, 또는 카테고리",
+            required: false,
+          },
+        },
+        {
+          id: "support",
+          label: "기술 지원",
+          extraField: {
+            label: "모델·시리얼 번호",
+            placeholder: "예: M3030VA / SN-12345",
+            required: true,
+          },
+        },
+        {
+          id: "partnership",
+          label: "협력·파트너십",
+          extraField: {
+            label: "지역·시장",
+            placeholder: "예: 동남아시아, 일본, 유럽",
+            required: false,
+          },
+        },
+        { id: "general", label: "일반 문의" },
+      ],
+      required: "필수",
+      submit: "문의 보내기",
+      submitDisabledHelp:
+        "제출 백엔드는 현재 작업 중입니다. 위 이메일 주소로 보내주시면 즉시 회신드리겠습니다.",
+    },
+    privacyNotice:
+      "문의 내용은 개인정보처리방침에 따라 처리되며 제3자에 공유되지 않습니다.",
+    distributors: {
+      heading: "글로벌 네트워크",
+      lede: "한국 본사를 중심으로 주요 시장을 직간접적으로 지원하고 있습니다.",
+      regions: [
+        { id: "kr", name: "한국 (본사)", status: "대전 본사 직접 영업" },
+        {
+          id: "cn",
+          name: "중국",
+          status: "라인텍 정밀 기술(우시) 자회사",
+        },
+        {
+          id: "sea",
+          name: "동남아시아",
+          status: "파트너 네트워크 확장 중 — 본사 문의",
+        },
+        {
+          id: "other",
+          name: "기타 지역",
+          status: "유럽 · 북미 · 일본 — 본사 직접 문의",
+        },
+      ],
+    },
+    map: {
+      heading: "오시는 길",
+      caption: "라인텍 본사 · 대전광역시 유성구",
+      openLabel: "네이버 지도에서 열기",
+    },
+  },
+
+  en: {
+    breadcrumbLabel: "Contact",
+    title: "Get in touch",
+    lede: "Product questions, technical support, partnership ideas — whatever brings you here, we'll reply within two business days.",
+    infoHeading: "Contact details",
+    hoursLabel: "Hours",
+    hoursValue: "Mon – Fri, 09:00 – 18:00 KST · Lunch 12:00 – 13:00",
+    addressLabel: "Address",
+    phoneLabel: "Phone",
+    faxLabel: "Fax",
+    emailLabel: "Email",
+    emailDirectCta: "Email us directly",
+    form: {
+      heading: "Send an inquiry",
+      notice:
+        "Our online submission system is being upgraded. For an immediate response, please email us directly using the address above.",
+      fields: {
+        inquiryType: "What's this about?",
+        name: "Name",
+        email: "Email",
+        company: "Company",
+        phone: "Phone",
+        subject: "Subject",
+        message: "Message",
+      },
+      placeholders: {
+        inquiryType: "Choose one",
+        name: "Jane Doe",
+        email: "name@company.com",
+        company: "Company name",
+        phone: "+1 555 000 0000",
+        subject: "e.g. Quote request, technical question, distributor inquiry",
+        message:
+          "Tell us how we can help. If it's a product inquiry, gas type, flow range, and timeline help us route you faster.",
+      },
+      inquiryTypeOptions: [
+        {
+          id: "sales",
+          label: "Sales / quote",
+          extraField: {
+            label: "Product or model of interest",
+            placeholder: "e.g. M3030VA, MD2030, or a category",
+            required: false,
+          },
+        },
+        {
+          id: "support",
+          label: "Technical support",
+          extraField: {
+            label: "Model and serial number",
+            placeholder: "e.g. M3030VA / SN-12345",
+            required: true,
+          },
+        },
+        {
+          id: "partnership",
+          label: "Partnership / distributor",
+          extraField: {
+            label: "Region or market",
+            placeholder: "e.g. Southeast Asia, Japan, EU",
+            required: false,
+          },
+        },
+        { id: "general", label: "General inquiry" },
+      ],
+      required: "Required",
+      submit: "Send inquiry",
+      submitDisabledHelp:
+        "Submission backend is in progress. Please email the address above for an immediate reply.",
+    },
+    privacyNotice:
+      "We'll handle your message per our privacy policy and won't share your details with third parties.",
+    distributors: {
+      heading: "Global network",
+      lede: "Headquartered in Korea, supporting key markets directly or through our subsidiary and partners.",
+      regions: [
+        { id: "kr", name: "Korea (HQ)", status: "Direct sales from Daejeon HQ" },
+        {
+          id: "cn",
+          name: "China",
+          status: "Line Tech Precision (Wuxi) — subsidiary office",
+        },
+        {
+          id: "sea",
+          name: "Southeast Asia",
+          status: "Partner network expanding — contact HQ",
+        },
+        {
+          id: "other",
+          name: "Other regions",
+          status: "Europe · North America · Japan — contact HQ directly",
+        },
+      ],
+    },
+    map: {
+      heading: "Find us",
+      caption: "Line Tech HQ · Daejeon, Korea",
+      openLabel: "Open in Google Maps",
+    },
+  },
+
+  zh: {
+    breadcrumbLabel: "联系",
+    title: "联系我们",
+    lede: "无论是产品咨询、技术支持，还是合作洽谈 — 我们都会在两个工作日内回复您。",
+    infoHeading: "联系方式",
+    hoursLabel: "工作时间",
+    hoursValue: "周一至周五 09:00 – 18:00（韩国时间）· 午休 12:00 – 13:00",
+    addressLabel: "地址",
+    phoneLabel: "电话",
+    faxLabel: "传真",
+    emailLabel: "邮箱",
+    emailDirectCta: "直接发送邮件",
+    form: {
+      heading: "在线咨询",
+      notice: "在线提交系统正在升级。如需即时回复，请使用上方邮箱直接联系我们。",
+      fields: {
+        inquiryType: "咨询类型",
+        name: "姓名",
+        email: "邮箱",
+        company: "公司",
+        phone: "电话",
+        subject: "主题",
+        message: "咨询内容",
+      },
+      placeholders: {
+        inquiryType: "请选择咨询类型",
+        name: "张三",
+        email: "name@company.com",
+        company: "公司名称",
+        phone: "+86 138 0000 0000",
+        subject: "例如：报价咨询、技术支持、合作洽谈",
+        message:
+          "请说明您的需求。如为产品咨询，请一并提供气体种类与流量范围，我们将更快为您对接。",
+      },
+      inquiryTypeOptions: [
+        {
+          id: "sales",
+          label: "销售·报价",
+          extraField: {
+            label: "关注产品或型号",
+            placeholder: "例如：M3030VA、MD2030 或某一类别",
+            required: false,
+          },
+        },
+        {
+          id: "support",
+          label: "技术支持",
+          extraField: {
+            label: "型号与序列号",
+            placeholder: "例如：M3030VA / SN-12345",
+            required: true,
+          },
+        },
+        {
+          id: "partnership",
+          label: "合作·代理",
+          extraField: {
+            label: "地区或市场",
+            placeholder: "例如：东南亚、日本、欧洲",
+            required: false,
+          },
+        },
+        { id: "general", label: "一般咨询" },
+      ],
+      required: "必填",
+      submit: "发送咨询",
+      submitDisabledHelp:
+        "提交后端正在开发中。请使用上方邮箱直接联系我们以获得即时回复。",
+    },
+    privacyNotice:
+      "您的信息将依据我们的隐私政策处理，不会与第三方共享。",
+    distributors: {
+      heading: "全球网络",
+      lede: "以韩国总部为核心，直接或通过子公司与合作伙伴覆盖主要市场。",
+      regions: [
+        { id: "kr", name: "韩国（总部）", status: "大田总部直接销售" },
+        {
+          id: "cn",
+          name: "中国",
+          status: "莱因精密技术（无锡）子公司",
+        },
+        {
+          id: "sea",
+          name: "东南亚",
+          status: "合作网络扩展中 — 请联系总部",
+        },
+        {
+          id: "other",
+          name: "其他地区",
+          status: "欧洲 · 北美 · 日本 — 请联系总部",
+        },
+      ],
+    },
+    map: {
+      heading: "公司位置",
+      caption: "莱因总部 · 韩国大田广域市",
+      openLabel: "在 Google 地图中打开",
+    },
+  },
+};

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -7,11 +7,7 @@
  */
 import type { Locale } from "./home";
 
-export type InquiryTypeId =
-  | "sales"
-  | "support"
-  | "partnership"
-  | "general";
+export type InquiryTypeId = "sales" | "support" | "partnership" | "general";
 
 export type ContactFormCopy = {
   heading: string;
@@ -268,7 +264,11 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       heading: "Global network",
       lede: "Headquartered in Korea, supporting key markets directly or through our subsidiary and partners.",
       regions: [
-        { id: "kr", name: "Korea (HQ)", status: "Direct sales from Daejeon HQ" },
+        {
+          id: "kr",
+          name: "Korea (HQ)",
+          status: "Direct sales from Daejeon HQ",
+        },
         {
           id: "cn",
           name: "China",
@@ -307,7 +307,8 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
     emailDirectCta: "直接发送邮件",
     form: {
       heading: "在线咨询",
-      notice: "在线提交系统正在升级。如需即时回复，请使用上方邮箱直接联系我们。",
+      notice:
+        "在线提交系统正在升级。如需即时回复，请使用上方邮箱直接联系我们。",
       fields: {
         inquiryType: "咨询类型",
         name: "姓名",
@@ -362,8 +363,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       submitDisabledHelp:
         "提交后端正在开发中。请使用上方邮箱直接联系我们以获得即时回复。",
     },
-    privacyNotice:
-      "您的信息将依据我们的隐私政策处理，不会与第三方共享。",
+    privacyNotice: "您的信息将依据我们的隐私政策处理，不会与第三方共享。",
     distributors: {
       heading: "全球网络",
       lede: "以韩国总部为核心，直接或通过子公司与合作伙伴覆盖主要市场。",


### PR DESCRIPTION
## Summary
- Adds 3-locale (ko/en/zh) \`/contact\` route — already wired in the header nav
- Inquiry-type select (sales · support · partnership · general) with a conditional follow-up field per bucket; only support's serial-number field is required
- Sidebar info card pulls address/phone/fax/email from \`LT_SHELL\` to stay DRY with the footer
- Distributors block scaffolded with 4 placeholder regions — replace with real distributor data when available
- Google Maps iframe for visual; deep-link goes to Naver for KR locale, Google for EN/ZH
- Inline privacy notice below submit; wrap the policy phrase in an \`<a>\` once \`/privacy\` exists

## Known TODOs
- Form submit is intentionally non-functional — visitors are routed to direct email via the notice and sidebar CTA. Wire to a backend (Resend / route handler) when ready.
- Naver Maps iframe embed needs an API key + their JS SDK; punted until a key is registered.

## Test plan
- [ ] Visit \`/en/contact\`, \`/ko/contact\`, \`/zh/contact\` — page renders with localized copy
- [ ] Select each inquiry type — verify follow-up field appears with correct label/placeholder, and is required only for "Technical support"
- [ ] Switch between inquiry types — confirm follow-up field value resets
- [ ] Click "Open in Google Maps" on EN/ZH; click "네이버 지도에서 열기" on KO — confirms correct provider opens
- [ ] Mobile viewport — 2-col layout collapses, distributors grid wraps
- [ ] \`pnpm typecheck\` and \`pnpm lint\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)