### PR TITLE
feat(sanity): seed pipeline + 5 catalog products

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,7 @@ jobs:
         run: pnpm test:run
 
       - name: Build
+        env:
+          NEXT_PUBLIC_SANITY_PROJECT_ID: 9ped5k0o
+          NEXT_PUBLIC_SANITY_DATASET: production
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format:check": "prettier --check .",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "seed:products": "tsx scripts/seed-products.ts"
   },
   "dependencies": {
     "@sanity/client": "^7.22.0",

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,6 +2,7 @@
 
 import { defineConfig } from "sanity";
 import { structureTool } from "sanity/structure";
+import { internationalizedArray } from "sanity-plugin-internationalized-array";
 import { schemaTypes } from "./sanity/schemaTypes";
 import { dataset, projectId } from "./src/sanity/env";
 
@@ -11,6 +12,17 @@ export default defineConfig({
   projectId,
   dataset,
   basePath: "/studio",
-  plugins: [structureTool()],
+  plugins: [
+    structureTool(),
+    internationalizedArray({
+      languages: [
+        { id: "ko", title: "한국어" },
+        { id: "en", title: "English" },
+        { id: "zh", title: "中文" },
+      ],
+      defaultLanguages: ["ko", "en", "zh"],
+      fieldTypes: ["string"],
+    }),
+  ],
   schema: { types: schemaTypes },
 });

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -45,9 +45,36 @@ export const product = defineType({
       options: { list: ["MFC", "MFM"] },
     }),
     defineField({
-      name: "formFactor",
-      type: "string",
-      options: { list: ["M", "MS"] },
+      name: "productLabel",
+      title: "Product label",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      name: "features",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            defineField({
+              name: "ko",
+              type: "string",
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "en",
+              type: "string",
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "zh",
+              type: "string",
+              validation: (r) => r.required(),
+            }),
+          ],
+          preview: { select: { title: "en" } },
+        },
+      ],
     }),
     defineField({
       name: "connections",
@@ -153,6 +180,21 @@ export const product = defineType({
             numberField("max"),
             stringField("unit"),
           ],
+        }),
+      ],
+    }),
+    defineField({
+      name: "digitalCommunication",
+      type: "object",
+      fields: [
+        stringField("protocol"),
+        numberField("baudRate"),
+        numberField("dataBits"),
+        numberField("stopBits"),
+        defineField({
+          name: "parity",
+          type: "string",
+          options: { list: ["None", "Even", "Odd"] },
         }),
       ],
     }),

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -1,10 +1,7 @@
 import { readFileSync } from "node:fs";
 import { createClient } from "@sanity/client";
 import { ALL_PRODUCTS } from "../src/lib/fixtures/products";
-import type {
-  LocalizedString,
-  Product,
-} from "../src/lib/types/product";
+import type { LocalizedString, Product } from "../src/lib/types/product";
 
 function loadEnv(path: string) {
   for (const line of readFileSync(path, "utf-8").split("\n")) {

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -9,7 +9,7 @@ import type {
 function loadEnv(path: string) {
   for (const line of readFileSync(path, "utf-8").split("\n")) {
     const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-    if (m) process.env[m[1]] ??= m[2];
+    if (m) process.env[m[1]] ??= m[2].trimEnd();
   }
 }
 
@@ -44,10 +44,8 @@ function localizedToArray(loc: LocalizedString) {
   ];
 }
 
-function productToDoc(p: Product) {
-  const doc: Record<string, unknown> = {
-    _id: `product-${p.slug.current}`,
-    _type: "product",
+function productToSeedFields(p: Product) {
+  const fields: Record<string, unknown> = {
     model: p.model,
     slug: p.slug,
     series: p.series,
@@ -58,9 +56,9 @@ function productToDoc(p: Product) {
     massFlowSpecs: p.massFlowSpecs,
   };
   if (p.digitalCommunication) {
-    doc.digitalCommunication = p.digitalCommunication;
+    fields.digitalCommunication = p.digitalCommunication;
   }
-  return doc;
+  return fields;
 }
 
 async function main() {
@@ -69,13 +67,18 @@ async function main() {
   );
 
   for (const product of ALL_PRODUCTS) {
-    const doc = productToDoc(product);
+    const _id = `product-${product.slug.current}`;
+    const fields = productToSeedFields(product);
     try {
+      await client.createIfNotExists({
+        _id,
+        _type: "product",
+        ...fields,
+      } as Parameters<typeof client.createIfNotExists>[0]);
       if (force) {
-        await client.createOrReplace(doc as Parameters<typeof client.createOrReplace>[0]);
-        console.log(`  replaced ${product.model}`);
+        await client.patch(_id).set(fields).commit();
+        console.log(`  patched  ${product.model}`);
       } else {
-        await client.createIfNotExists(doc as Parameters<typeof client.createIfNotExists>[0]);
         console.log(`  ensured  ${product.model}`);
       }
     } catch (err) {

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+import { ALL_PRODUCTS } from "../src/lib/fixtures/products";
+import type {
+  LocalizedString,
+  Product,
+} from "../src/lib/types/product";
+
+function loadEnv(path: string) {
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) process.env[m[1]] ??= m[2];
+  }
+}
+
+loadEnv(".env.local");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error(
+    "Missing env vars. Need NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET, SANITY_WRITE_TOKEN in .env.local",
+  );
+  process.exit(1);
+}
+
+const force = process.argv.includes("--force");
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+function localizedToArray(loc: LocalizedString) {
+  return [
+    { _key: "ko", language: "ko", value: loc.ko },
+    { _key: "en", language: "en", value: loc.en },
+    { _key: "zh", language: "zh", value: loc.zh },
+  ];
+}
+
+function productToDoc(p: Product) {
+  const doc: Record<string, unknown> = {
+    _id: `product-${p.slug.current}`,
+    _type: "product",
+    model: p.model,
+    slug: p.slug,
+    series: p.series,
+    function: p.function,
+    productLabel: localizedToArray(p.productLabel),
+    features: p.features.map((f, i) => ({ _key: `feature-${i}`, ...f })),
+    connections: p.connections.map((c, i) => ({ _key: `conn-${i}`, ...c })),
+    massFlowSpecs: p.massFlowSpecs,
+  };
+  if (p.digitalCommunication) {
+    doc.digitalCommunication = p.digitalCommunication;
+  }
+  return doc;
+}
+
+async function main() {
+  console.log(
+    `Seeding ${ALL_PRODUCTS.length} products → ${projectId}/${dataset} (force=${force})`,
+  );
+
+  for (const product of ALL_PRODUCTS) {
+    const doc = productToDoc(product);
+    try {
+      if (force) {
+        await client.createOrReplace(doc as Parameters<typeof client.createOrReplace>[0]);
+        console.log(`  replaced ${product.model}`);
+      } else {
+        await client.createIfNotExists(doc as Parameters<typeof client.createIfNotExists>[0]);
+        console.log(`  ensured  ${product.model}`);
+      }
+    } catch (err) {
+      console.error(`  FAILED   ${product.model}:`, err);
+      process.exit(1);
+    }
+  }
+
+  console.log("Done.");
+}
+
+main();

--- a/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
+++ b/src/app/[locale]/products/analogue-mfc/m3030va/page.tsx
@@ -1,13 +1,21 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
-import { M3030VA } from "@/lib/fixtures/products";
-import type { MassFlowSpecs } from "@/lib/types/product";
+import { sanityClient } from "@/sanity/client";
+import { productBySlugQuery } from "@/sanity/queries";
+import type { MassFlowSpecs, Product } from "@/lib/types/product";
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function ProductPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
+
+  const product = (await sanityClient.fetch(productBySlugQuery, {
+    slug: "m3030va",
+  })) as Product | null;
+
+  if (!product) notFound();
 
   const [t, tDownloads, tCommon, tNav, tCategories] = await Promise.all([
     getTranslations("product.specs"),
@@ -17,7 +25,6 @@ export default async function ProductPage({ params }: Props) {
     getTranslations("breadcrumbs.categories"),
   ]);
 
-  const product = M3030VA;
   const specEntries = Object.entries(product.massFlowSpecs) as Array<
     [keyof MassFlowSpecs, { display: string }]
   >;
@@ -34,8 +41,8 @@ export default async function ProductPage({ params }: Props) {
       <Breadcrumbs items={breadcrumbs} />
       <h1>{product.model}</h1>
       <p>
-        Series: {product.series} · Function: {product.function} · Form factor:{" "}
-        {product.formFactor}
+        {product.productLabel[locale as "ko" | "en" | "zh"]} · {product.series}{" "}
+        · {product.function}
       </p>
 
       <h2>Specifications</h2>

--- a/src/lib/fixtures/products.ts
+++ b/src/lib/fixtures/products.ts
@@ -1,11 +1,32 @@
-import type { Product } from "@/lib/types/product";
+import type { Product } from "../types/product";
+
+const features = (...items: string[]) =>
+  items.map((en) => ({ ko: en, en, zh: en }));
+
+const label = (en: string) => ({ ko: en, en, zh: en });
 
 export const M3030VA: Product = {
   model: "M3030VA",
+  slug: { current: "m3030va" },
   series: "analogue",
   function: "MFC",
-  formFactor: "M",
-  connections: [{ type: '1/4" SW', length: "131.3 mm" }],
+  productLabel: label("Mass Flow Controller"),
+  features: features(
+    "Accurate at Low Flow",
+    "Fast Response",
+    "Wide Pressure Range Compatibility",
+    "Excellent Linearity",
+    "Long-Term Stability",
+    "High Corrosion Resistance",
+    "Highly Stable Removable Sensor",
+    "Compact Connection",
+  ),
+  connections: [
+    { type: '1/8" SW', length: "126.7 mm" },
+    { type: '1/4" SW', length: "128 mm" },
+    { type: '3/8" SW', length: "134.3 mm" },
+    { type: '1/4" VCR', length: "127.8 mm" },
+  ],
   massFlowSpecs: {
     flowRange: {
       display: "0.01–30 slpm",
@@ -21,7 +42,7 @@ export const M3030VA: Product = {
       comparator: "lt",
     },
     accuracy: { display: "±1% of FS", value: 1, unit: "%FS" },
-    repeatability: { display: "±0.2% of FS", value: 0.2, unit: "%FS" },
+    repeatability: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
     ioSignal: {
       display: "0–5 Vdc or 4–20 mA",
       outputs: ["0-5Vdc", "4-20mA"],
@@ -43,6 +64,277 @@ export const M3030VA: Product = {
       value: 1e-9,
       unit: "atm·cc/sec",
     },
-    controlRange: { display: "2–100%", min: 2, max: 100, unit: "%" },
+    controlRange: { display: "3–100%", min: 3, max: 100, unit: "%" },
   },
 };
+
+export const MD30C: Product = {
+  model: "MD30C",
+  slug: { current: "md30c" },
+  series: "digital",
+  function: "MFC",
+  productLabel: label("Digital Mass Flow Controller"),
+  features: features(
+    "Accurate at Low Flow",
+    "Fast Response",
+    "Wide Pressure Range Compatibility",
+    "Excellent Linearity",
+    "Long-Term Stability",
+    "High Corrosion Resistance",
+    "Highly Stable Removable Sensor",
+    "Compact Connection",
+  ),
+  connections: [
+    { type: '1/8" SW', length: "126.7 mm" },
+    { type: '1/4" SW', length: "128 mm" },
+    { type: '3/8" SW', length: "134.3 mm" },
+    { type: '1/4" VCR', length: "127.8 mm" },
+  ],
+  massFlowSpecs: {
+    flowRange: {
+      display: "0.01–30 slpm",
+      min: 0.01,
+      max: 30,
+      unit: "slpm",
+      referenceGas: "N2",
+    },
+    responseTime: {
+      display: "<1 second",
+      value: 1,
+      unit: "s",
+      comparator: "lt",
+    },
+    accuracy: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    repeatability: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    ioSignal: {
+      display: "0–5 Vdc or 4–20 mA",
+      outputs: ["0-5Vdc", "4-20mA"],
+    },
+    supplyPower: {
+      display: "+15 or +24 Vdc, 350 mA",
+      voltages: [15, 24],
+      currentMA: 350,
+    },
+    maxPressure: {
+      display: "<90 bar",
+      value: 90,
+      unit: "bar",
+      comparator: "lt",
+    },
+    tempRange: { display: "0–50 °C", min: 0, max: 50, unit: "°C" },
+    leakRate: {
+      display: "1×10⁻⁹ atm·cc/sec",
+      value: 1e-9,
+      unit: "atm·cc/sec",
+    },
+    controlRange: { display: "3–100%", min: 3, max: 100, unit: "%" },
+  },
+  digitalCommunication: {
+    protocol: "RS-485",
+    baudRate: 38400,
+    dataBits: 8,
+    stopBits: 1,
+    parity: "None",
+  },
+};
+
+export const MD30M: Product = {
+  model: "MD30M",
+  slug: { current: "md30m" },
+  series: "digital",
+  function: "MFM",
+  productLabel: label("Digital Mass Flow Meter"),
+  features: features(
+    "Accurate at Low Flow",
+    "Fast Response",
+    "Wide Pressure Range Compatibility",
+    "Excellent Linearity",
+    "Long-Term Stability",
+    "High Corrosion Resistance",
+    "Highly Stable Removable Sensor",
+    "Compact Connection",
+  ),
+  connections: [
+    { type: '1/8" SW', length: "104.5 mm" },
+    { type: '1/4" SW', length: "111.9 mm" },
+    { type: '3/8" SW', length: "115.3 mm" },
+    { type: '1/4" VCR', length: "107.5 mm" },
+  ],
+  massFlowSpecs: {
+    flowRange: {
+      display: "0.01–30 slpm",
+      min: 0.01,
+      max: 30,
+      unit: "slpm",
+      referenceGas: "N2",
+    },
+    accuracy: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    repeatability: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    ioSignal: {
+      display: "0–5 Vdc or 4–20 mA",
+      outputs: ["0-5Vdc", "4-20mA"],
+    },
+    supplyPower: {
+      display: "+15 or +24 Vdc, 350 mA",
+      voltages: [15, 24],
+      currentMA: 350,
+    },
+    maxPressure: {
+      display: "<90 bar",
+      value: 90,
+      unit: "bar",
+      comparator: "lt",
+    },
+    tempRange: { display: "0–50 °C", min: 0, max: 50, unit: "°C" },
+    leakRate: {
+      display: "1×10⁻⁹ atm·cc/sec",
+      value: 1e-9,
+      unit: "atm·cc/sec",
+    },
+    controlRange: { display: "3–100%", min: 3, max: 100, unit: "%" },
+  },
+  digitalCommunication: {
+    protocol: "RS-485",
+    baudRate: 38400,
+    dataBits: 8,
+    stopBits: 1,
+    parity: "None",
+  },
+};
+
+export const MD100C: Product = {
+  model: "MD100C",
+  slug: { current: "md100c" },
+  series: "digital",
+  function: "MFC",
+  productLabel: label("Digital Mass Flow Controller"),
+  features: features(
+    "Accurate at Low Flow",
+    "Fast Response",
+    "Wide Pressure Range Compatibility",
+    "Excellent Linearity",
+    "Long-Term Stability",
+    "High Corrosion Resistance",
+    "Highly Stable Removable Sensor",
+    "Compact Connection",
+  ),
+  connections: [
+    { type: '1/4" SW', length: "145.9 mm" },
+    { type: '3/8" SW', length: "149.3 mm" },
+    { type: '1/2" SW', length: "161.5 mm" },
+    { type: '1/4" VCR', length: "141.5 mm" },
+    { type: '1/2" VCR', length: "149 mm" },
+  ],
+  massFlowSpecs: {
+    flowRange: {
+      display: "30–100 slpm",
+      min: 30,
+      max: 100,
+      unit: "slpm",
+      referenceGas: "N2",
+    },
+    responseTime: {
+      display: "<1 second",
+      value: 1,
+      unit: "s",
+      comparator: "lt",
+    },
+    accuracy: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    repeatability: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    ioSignal: {
+      display: "0–5 Vdc or 4–20 mA",
+      outputs: ["0-5Vdc", "4-20mA"],
+    },
+    supplyPower: {
+      display: "+15 or +24 Vdc, 350 mA",
+      voltages: [15, 24],
+      currentMA: 350,
+    },
+    maxPressure: {
+      display: "<90 bar",
+      value: 90,
+      unit: "bar",
+      comparator: "lt",
+    },
+    tempRange: { display: "0–50 °C", min: 0, max: 50, unit: "°C" },
+    leakRate: {
+      display: "1×10⁻⁹ atm·cc/sec",
+      value: 1e-9,
+      unit: "atm·cc/sec",
+    },
+    controlRange: { display: "3–100%", min: 3, max: 100, unit: "%" },
+  },
+  digitalCommunication: {
+    protocol: "RS-485",
+    baudRate: 38400,
+    dataBits: 8,
+    stopBits: 1,
+    parity: "None",
+  },
+};
+
+export const LD030C: Product = {
+  model: "LD030C",
+  slug: { current: "ld030c" },
+  series: "specialized",
+  function: "MFC",
+  productLabel: label("Mass Flow Controller with Display"),
+  features: features(
+    "Accurate Real Time Flow Measurements",
+    "Real Time Setting Changes",
+    "Fast Response",
+    "Wide Pressure Range Compatibility",
+    "Excellent Linearity",
+    "Long-Term Stability",
+    "High Corrosion Resistance",
+    "Highly Stable Removable Sensor",
+    "Compact Connection",
+  ),
+  connections: [
+    { type: '1/8" SW', length: "140.2 mm" },
+    { type: '1/4" SW', length: "141.5 mm" },
+    { type: '3/8" SW', length: "147.8 mm" },
+    { type: '1/4" VCR', length: "141.3 mm" },
+  ],
+  massFlowSpecs: {
+    flowRange: {
+      display: "0.01–30 slpm",
+      min: 0.01,
+      max: 30,
+      unit: "slpm",
+      referenceGas: "N2",
+    },
+    responseTime: {
+      display: "<2 seconds",
+      value: 2,
+      unit: "s",
+      comparator: "lt",
+    },
+    accuracy: { display: "±1% of FS", value: 1, unit: "%FS" },
+    repeatability: { display: "±0.25% of FS", value: 0.25, unit: "%FS" },
+    ioSignal: {
+      display: "0–5 Vdc",
+      outputs: ["0-5Vdc"],
+    },
+    supplyPower: {
+      display: "+15 or +24 Vdc, 350 mA",
+      voltages: [15, 24],
+      currentMA: 350,
+    },
+    maxPressure: {
+      display: "<90 bar",
+      value: 90,
+      unit: "bar",
+      comparator: "lt",
+    },
+    tempRange: { display: "0–50 °C", min: 0, max: 50, unit: "°C" },
+    leakRate: {
+      display: "1×10⁻⁹ atm·cc/sec",
+      value: 1e-9,
+      unit: "atm·cc/sec",
+    },
+    controlRange: { display: "3–100%", min: 3, max: 100, unit: "%" },
+  },
+};
+
+export const ALL_PRODUCTS: Product[] = [M3030VA, MD30C, MD30M, MD100C, LD030C];

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -1,3 +1,5 @@
+export type LocalizedString = { ko: string; en: string; zh: string };
+
 export type Connection = { type: string; length: string };
 
 type DisplayOnly = { display: string };
@@ -47,7 +49,7 @@ export type ControlRange = DisplayOnly & {
 
 export type MassFlowSpecs = {
   flowRange: FlowRange;
-  responseTime: ResponseTime;
+  responseTime?: ResponseTime;
   accuracy: Accuracy;
   repeatability: Repeatability;
   ioSignal: IoSignal;
@@ -58,11 +60,31 @@ export type MassFlowSpecs = {
   controlRange: ControlRange;
 };
 
+export type DigitalCommunication = {
+  protocol: string;
+  baudRate: number;
+  dataBits: number;
+  stopBits: number;
+  parity: "None" | "Even" | "Odd";
+};
+
+export type SanityImage = {
+  _type: "image";
+  asset: { _ref: string; _type: "reference" };
+  hotspot?: { x: number; y: number; height: number; width: number };
+  crop?: { top: number; bottom: number; left: number; right: number };
+};
+
 export type Product = {
   model: string;
+  slug: { current: string };
   series: "analogue" | "digital" | "specialized";
   function: "MFC" | "MFM";
-  formFactor: "M" | "MS";
+  productLabel: LocalizedString;
+  features: LocalizedString[];
   connections: Connection[];
   massFlowSpecs: MassFlowSpecs;
+  digitalCommunication?: DigitalCommunication;
+  images?: SanityImage[];
+  dimensionDrawing?: SanityImage;
 };

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -7,9 +7,9 @@ export const productBySlugQuery = defineQuery(`
     series,
     "function": function,
     "productLabel": {
-      "ko": productLabel[language == "ko"][0].value,
-      "en": productLabel[language == "en"][0].value,
-      "zh": productLabel[language == "zh"][0].value
+      "ko": coalesce(productLabel[language == "ko"][0].value, productLabel[language == "en"][0].value),
+      "en": coalesce(productLabel[language == "en"][0].value, productLabel[language == "ko"][0].value),
+      "zh": coalesce(productLabel[language == "zh"][0].value, productLabel[language == "en"][0].value)
     },
     features,
     connections,

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -3,10 +3,19 @@ import { defineQuery } from "next-sanity";
 export const productBySlugQuery = defineQuery(`
   *[_type == "product" && slug.current == $slug][0]{
     model,
+    slug,
     series,
     "function": function,
-    formFactor,
+    "productLabel": {
+      "ko": productLabel[language == "ko"][0].value,
+      "en": productLabel[language == "en"][0].value,
+      "zh": productLabel[language == "zh"][0].value
+    },
+    features,
     connections,
-    massFlowSpecs
+    massFlowSpecs,
+    digitalCommunication,
+    images,
+    dimensionDrawing
   }
 `);


### PR DESCRIPTION
## Summary

- Moves Sanity from "scaffolded" to "operational" — schema is now locked against 5 real catalog products instead of M3030VA alone
- Wires `sanity-plugin-internationalized-array` (was installed but never registered) for KO/EN/ZH product labels
- Adds `pnpm seed:products` — idempotent, re-runs are no-ops; `--force` flag for explicit overwrites
- Switches M3030VA product page from local fixture import to GROQ query

## Schema changes (locked decisions)

| Change | Reason |
|---|---|
| `responseTime` → optional | MFM (MD30M) has no response time field — meters don't control |
| Drop `formFactor` | Derivable from model name; was redundant entry burden |
| Add `productLabel` (i18n via plugin) | Catalog descriptor pill ("Mass Flow Controller", "Digital MFM", "MFC with Display") had no schema slot |
| Add `features` (flat `{ko,en,zh}[]`) | 8–9 per product, varies by model (LD030C has different list) |
| Add `digitalCommunication?` (object) | RS-485 spec block on digital series only |
| Sync TS type with Sanity | `slug`, `images`, `dimensionDrawing` now declared |

## Why hybrid i18n (plugin for productLabel, flat object for features)

`sanity-plugin-internationalized-array` shines for single localized strings (productLabel gets a tab-switcher UI). But for arrays of localized strings (features), each row would need its own tab-switching widget — slower than the flat shape where staff sees KO/EN/ZH side-by-side per row. Best UX per field.

## Translation placeholders

Fixtures duplicate English text into all 3 locale fields. Korean staff fills in real translations directly in Sanity Studio after seeding — no fabricated translations committed.

## What this unblocks

- #9 — category pages now have real density across 4 categories (1 analogue, 3 digital, 1 specialized)
- #31 — design pass against actual product variety, not lorem ipsum
- Future product additions go through the same pipeline (`pnpm seed:products --force`)

## Test plan

- [ ] `pnpm build` static-generates M3030VA page for ko/en/zh from Sanity
- [ ] `pnpm dev` then visit `/studio` — 5 products listed with KO/EN/ZH translation tabs on `productLabel`
- [ ] `pnpm seed:products` (no flags) is a no-op on re-run
- [ ] `pnpm seed:products --force` overwrites all 5
- [ ] `/[locale]/products/analogue-mfc/m3030va` renders identical to before fixture-to-Sanity swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)