### PR TITLE
feat(company): single-scroll /company with side-nav scroll-spy (closes #29)

### DIFF
--- a/docs/linetech-slice-2-plan.md
+++ b/docs/linetech-slice-2-plan.md
@@ -77,6 +77,20 @@ Plan originally specced 5 homepage category cards (title + count + image). The d
 
 ✅ **Resolved (2026-04-24, refined 2026-04-26):** catalog taxonomy is **4 (function × type)** — Analogue MFC, Digital MFC, MFM, Specialized. Buyers shop by function ("I need a digital MFC"), not by internal SKU series (M/MD/LD/LTI mean nothing to new customers). Series stays as a filter/facet *within* a category, not as the category itself. Homepage Series section keeps the design's 4-series visual as a secondary entry point; mega-menu and category pages route on the 4-way function taxonomy. Accessories (LTI readouts, FC-050S, PR-030) surface as a callout block on the `/products` index page rather than as a top-level category — too few SKUs to earn nav real-estate, and they're system support rather than peer to MFC/MFM.
 
+### Company section IA — single scroller with anchored sections (closes #29)
+
+Issue #29 asked three questions: single scroller vs page-per-topic; whether Certifications should get a nav spotlight; and whether Company needs a dropdown at all.
+
+✅ **Resolved (2026-04-27):** **single scroller** at `/company` with four anchored sections (`#greeting`, `#history`, `#certifications`, `#location`); a sticky side-nav drives scroll-spy active state; mega-menu links and the spotlight card all point to the matching anchor.
+
+- **Route:** `/company` only. The four sections render top-to-bottom on one page; deep links use anchor URLs (`/company#certifications` etc.) and stay shareable.
+- **Why not page-per-topic:** four standalone routes for what is effectively one institutional narrative bloated the IA — Greeting and Location especially are filler pages by themselves. A single scroller reads as a continuous "About Line Tech" story, mobile-friendly, and the four-section structure is preserved visually via section dividers and the side-nav. Anchored URLs preserve the deep-link case for RFQs (`/company#certifications` works the same as `/company/certifications` for sharing).
+- **Side-nav scroll-spy:** sticky `CompanySideNav` is a client component running an `IntersectionObserver` (rootMargin `-88px / -60%`) so the active item tracks scroll position. Hidden behind `prefers-reduced-motion` for the smooth-scroll behavior.
+- **Certifications spotlight:** kept inside the Company mega-menu featured card (`shell.ts`) pointing at `/company#certifications` — credibility surface without inflating global nav.
+- **Dropdown stays:** mega-menu still useful as a discovery surface for the four sections (vs forcing users to scroll to find them).
+- **"Greeting" voice:** institutional copy without CEO photo or signature — no portrait or signed-letter assets needed from the client.
+- **Certifications content gap:** the legacy site has 13 unlabeled cert JPGs but only 3 have recovered text labels (ISO 9001, CE, INNOBIZ). Initial build ships those 3 as full cards plus a footnote acknowledging 10 additional conformity documents available on request. A Sanity-driven expansion is a phase-2 task (filed below).
+
 ---
 
 ## Deferred / follow-ups
@@ -85,6 +99,7 @@ Plan originally specced 5 homepage category cards (title + count + image). The d
 - **Header search wiring** — visual shell ships now, actual search → phase 2 (depends on Sanity index).
 - **Theme/accent toggles** — design has `[data-theme="dark"]` and `[data-accent-mode="yellow"]` hooks but no UI trigger. Hardcoded to `light` / `blue` for now.
 - **Utility bar** — design CSS supports a top utility strip (`.pd-top__util` with hours/contacts) but design's `PageShell.jsx` doesn't render it. Skipping unless requested.
+- **Certifications detail (10 unnamed)** — legacy site has 13 cert JPGs; only 3 have recovered text. `/company/certifications` ships with the 3 named + footnote. Phase 2: collect names/issuers/dates for the remaining 10 from the client and surface them, ideally Sanity-managed.
 
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "nav": {
-    "products": "Products"
+    "products": "Products",
+    "company": "Company"
   },
   "common": {
     "download": "Download",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,6 +1,7 @@
 {
   "nav": {
-    "products": "제품"
+    "products": "제품",
+    "company": "회사소개"
   },
   "common": {
     "download": "다운로드",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,6 +1,7 @@
 {
   "nav": {
-    "products": "产品"
+    "products": "产品",
+    "company": "公司介绍"
   },
   "common": {
     "download": "下载",

--- a/src/app/[locale]/company/page.tsx
+++ b/src/app/[locale]/company/page.tsx
@@ -1,0 +1,191 @@
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { CompanyShell } from "@/components/company/CompanyShell";
+import {
+  LT_COMPANY,
+  type CompanyContent,
+  type CompanyLocationLabels,
+  type CompanyLocationOffice,
+} from "@/lib/content/company";
+import type { Locale } from "@/lib/content/home";
+
+type Props = { params: Promise<{ locale: Locale }> };
+
+/** Founding, first-in-Korea MFC, and the two cert milestones get a filled
+ * dot on the timeline. Everything else is a hollow tick. */
+const MILESTONE_DATES = new Set(["1997.03", "2003.03", "2017.08", "2018.03"]);
+
+export default async function CompanyPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+  ]);
+
+  const c = LT_COMPANY[locale];
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("company") },
+  ];
+
+  return (
+    <CompanyShell locale={locale} breadcrumbs={breadcrumbs}>
+      <Greeting c={c} />
+      <History c={c} />
+      <Certifications c={c} />
+      <Location c={c} />
+    </CompanyShell>
+  );
+}
+
+function Greeting({ c }: { c: CompanyContent }) {
+  return (
+    <section id="greeting" className="co-section">
+      <header className="co-sechd">
+        <div className="co-sechd__kicker">{c.greeting.kicker}</div>
+        <h1 className="co-sechd__title">{c.greeting.title}</h1>
+      </header>
+      <div className="co-greeting__layout">
+        <div className="co-greeting__body">
+          {c.greeting.paragraphs.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </div>
+        <aside
+          className="co-greeting__facts"
+          aria-label={c.greeting.factsHeading}
+        >
+          <div className="co-greeting__factsHeading">
+            {c.greeting.factsHeading}
+          </div>
+          <dl className="co-greeting__factList">
+            {c.greeting.facts.map((fact) => (
+              <div key={fact.k} className="co-greeting__fact">
+                <dt className="co-greeting__factK">{fact.k}</dt>
+                <dd className="co-greeting__factL">{fact.l}</dd>
+              </div>
+            ))}
+          </dl>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function History({ c }: { c: CompanyContent }) {
+  return (
+    <section id="history" className="co-section">
+      <header className="co-sechd">
+        <div className="co-sechd__kicker">{c.history.kicker}</div>
+        <h2 className="co-sechd__title">{c.history.title}</h2>
+        <p className="co-sechd__sub">{c.history.sub}</p>
+      </header>
+      <ol className="co-timeline">
+        {c.history.rows.map((row) => {
+          const isMilestone = MILESTONE_DATES.has(row.date);
+          return (
+            <li
+              key={row.date}
+              className={
+                "co-timeline__row" +
+                (isMilestone ? " co-timeline__row--milestone" : "")
+              }
+            >
+              <span className="co-timeline__date">{row.date}</span>
+              <span className="co-timeline__event">{row.event}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function Certifications({ c }: { c: CompanyContent }) {
+  return (
+    <section id="certifications" className="co-section">
+      <header className="co-sechd">
+        <div className="co-sechd__kicker">{c.certifications.kicker}</div>
+        <h2 className="co-sechd__title">{c.certifications.title}</h2>
+        <p className="co-sechd__sub">{c.certifications.sub}</p>
+      </header>
+      <ul className="co-certs">
+        {c.certifications.named.map((cert) => (
+          <li key={cert.id} className="co-cert">
+            <div className="co-cert__head">
+              <h3 className="co-cert__name">{cert.name}</h3>
+              <span className="co-cert__date">{cert.date}</span>
+            </div>
+            <p className="co-cert__issuer">{cert.issuer}</p>
+            <p className="co-cert__blurb">{cert.blurb}</p>
+          </li>
+        ))}
+      </ul>
+      <p className="co-certs__footnote">{c.certifications.footnote}</p>
+    </section>
+  );
+}
+
+function Location({ c }: { c: CompanyContent }) {
+  return (
+    <section id="location" className="co-section">
+      <header className="co-sechd">
+        <div className="co-sechd__kicker">{c.location.kicker}</div>
+        <h2 className="co-sechd__title">{c.location.title}</h2>
+        <p className="co-sechd__sub">{c.location.sub}</p>
+      </header>
+      <div className="co-locations">
+        <OfficeCard office={c.location.hq} labels={c.location.labels} />
+        {c.location.subsidiary && (
+          <OfficeCard
+            office={c.location.subsidiary}
+            labels={c.location.labels}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+type OfficeCardProps = {
+  office: CompanyLocationOffice;
+  labels: CompanyLocationLabels;
+};
+
+function OfficeCard({ office, labels }: OfficeCardProps) {
+  return (
+    <article className="co-office">
+      <div className="co-office__heading">{office.heading}</div>
+      <h3 className="co-office__name">{office.name}</h3>
+      <dl className="co-office__rows">
+        <dt className="co-office__label">{labels.address}</dt>
+        <dd className="co-office__value">{office.address}</dd>
+        {office.phone && (
+          <>
+            <dt className="co-office__label">{labels.phone}</dt>
+            <dd className="co-office__value">
+              <a href={`tel:${office.phone.replace(/\s+/g, "")}`}>
+                {office.phone}
+              </a>
+            </dd>
+          </>
+        )}
+        {office.fax && (
+          <>
+            <dt className="co-office__label">{labels.fax}</dt>
+            <dd className="co-office__value">{office.fax}</dd>
+          </>
+        )}
+        {office.email && (
+          <>
+            <dt className="co-office__label">{labels.email}</dt>
+            <dd className="co-office__value">
+              <a href={`mailto:${office.email}`}>{office.email}</a>
+            </dd>
+          </>
+        )}
+      </dl>
+    </article>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,6 +130,16 @@
 }
 
 /* ─── Base ─────────────────────────────────────────────────────────── */
+html {
+  /* Smooth in-page anchor scroll for any page using `#section` links
+   * (e.g. /company side-nav). Reduced-motion override below. */
+  scroll-behavior: smooth;
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
 html,
 body {
   margin: 0;

--- a/src/components/company/CompanyShell.tsx
+++ b/src/components/company/CompanyShell.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import {
+  Breadcrumbs,
+  type BreadcrumbItem,
+} from "@/components/layout/Breadcrumbs";
+import { LT_COMPANY } from "@/lib/content/company";
+import type { Locale } from "@/lib/content/home";
+import { CompanySideNav } from "./CompanySideNav";
+import "./company-shell.css";
+
+type Props = {
+  locale: Locale;
+  breadcrumbs: BreadcrumbItem[];
+  children: ReactNode;
+};
+
+export function CompanyShell({ locale, breadcrumbs, children }: Props) {
+  const c = LT_COMPANY[locale];
+
+  return (
+    <main className="lt-wrap">
+      <Breadcrumbs items={breadcrumbs} />
+      <div className="co">
+        <CompanySideNav heading={c.navHeading} items={c.nav} />
+        <div className="co-main">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/company/CompanySideNav.tsx
+++ b/src/components/company/CompanySideNav.tsx
@@ -58,9 +58,7 @@ export function CompanySideNav({ heading, items }: Props) {
               <li key={item.id} className="co-nav__item">
                 <a
                   href={item.href}
-                  className={
-                    "co-nav__link" + (isCurrent ? " is-current" : "")
-                  }
+                  className={"co-nav__link" + (isCurrent ? " is-current" : "")}
                   aria-current={isCurrent ? "true" : undefined}
                 >
                   {item.label}

--- a/src/components/company/CompanySideNav.tsx
+++ b/src/components/company/CompanySideNav.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { CompanyNavItem } from "@/lib/content/company";
+
+type Props = {
+  heading: string;
+  items: CompanyNavItem[];
+};
+
+/**
+ * Sticky side-nav for /company. Each item is an in-page anchor (`#greeting`,
+ * etc.); IntersectionObserver picks the section currently spanning a hairline
+ * scan band at 30% of viewport height. A Set tracks each section's current
+ * intersection state across events — a single fired entry isn't enough to
+ * decide active state, since other sections may still be intersecting and
+ * just didn't change.
+ */
+export function CompanySideNav({ heading, items }: Props) {
+  const [active, setActive] = useState<string>(items[0]?.id ?? "");
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const intersecting = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            intersecting.add(entry.target.id);
+          } else {
+            intersecting.delete(entry.target.id);
+          }
+        }
+        const next = items.find((item) => intersecting.has(item.id));
+        if (next) setActive(next.id);
+      },
+      { rootMargin: "-30% 0px -70% 0px" },
+    );
+
+    for (const item of items) {
+      const el = document.getElementById(item.id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <aside className="co-aside" aria-label={heading}>
+      <div className="co-aside__heading">{heading}</div>
+      <nav className="co-nav">
+        <ul className="co-nav__list">
+          {items.map((item) => {
+            const isCurrent = item.id === active;
+            return (
+              <li key={item.id} className="co-nav__item">
+                <a
+                  href={item.href}
+                  className={
+                    "co-nav__link" + (isCurrent ? " is-current" : "")
+                  }
+                  aria-current={isCurrent ? "true" : undefined}
+                >
+                  {item.label}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/company/company-shell.css
+++ b/src/components/company/company-shell.css
@@ -1,0 +1,372 @@
+/* Line Tech — /company shell: side-nav + content frame.
+ * Mirrors the home-shell convention (`.ho-*`) under a `.co-*` namespace. */
+
+.co {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 64px;
+  padding-top: 32px;
+  align-items: start;
+}
+
+.co-aside {
+  position: sticky;
+  top: 96px;
+  /* Align the side-nav heading with the first section's heading by matching
+   * the section's top padding (56px). */
+  padding-top: 56px;
+}
+.co-aside__heading {
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  margin-bottom: 16px;
+}
+:lang(ko) .co-aside__heading,
+:lang(zh) .co-aside__heading {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.co-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.co-nav__item {
+  margin: 0;
+}
+.co-nav__link {
+  display: block;
+  padding: 7px 0 7px 14px;
+  margin-left: -16px;
+  font: 400 14px/1.45 var(--lt-sans);
+  color: var(--pd-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease;
+}
+.co-nav__link:hover {
+  color: var(--pd-fg-strong);
+}
+.co-nav__link.is-current {
+  color: var(--pd-fg-strong);
+  border-left-color: var(--pd-primary);
+}
+
+.co-main {
+  min-width: 0;
+}
+
+/* Each anchor target. scroll-margin-top accounts for the 72px sticky header
+ * (+ 16px breathing room) so anchored links don't tuck the heading under it.
+ * Even-indexed sections get a subtle surface tint to break the four-section
+ * scroll into distinct visual zones. */
+.co-section {
+  scroll-margin-top: 88px;
+  padding: 56px 32px;
+  border-radius: 4px;
+}
+.co-section + .co-section {
+  margin-top: 16px;
+}
+.co-section:nth-child(odd) {
+  background: var(--pd-surface-2);
+}
+
+/* Section heads inside /company pages — same shape as home, separate
+ * namespace so future tweaks don't cascade. */
+.co-sechd {
+  margin-bottom: 32px;
+}
+.co-sechd__kicker {
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  margin-bottom: 14px;
+}
+:lang(ko) .co-sechd__kicker,
+:lang(zh) .co-sechd__kicker {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.co-sechd__title {
+  margin: 0 0 12px;
+  font: 500 36px/1.1 var(--lt-sans);
+  letter-spacing: -0.02em;
+  color: var(--pd-fg-strong);
+  max-width: 760px;
+}
+.co-sechd__sub {
+  margin: 0;
+  max-width: 620px;
+  font-size: 16px;
+  color: var(--pd-muted);
+  line-height: 1.55;
+}
+
+/* Greeting: paragraphs on the left, fact sidebar on the right. */
+.co-greeting__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 240px;
+  gap: 56px;
+  align-items: start;
+}
+.co-greeting__body {
+  max-width: 680px;
+}
+.co-greeting__body p {
+  margin: 0 0 18px;
+  font: 400 17px/1.65 var(--lt-sans);
+  color: var(--pd-fg-strong);
+}
+.co-greeting__body p:last-child {
+  margin-bottom: 0;
+}
+.co-greeting__facts {
+  border-left: 2px solid var(--pd-rule);
+  padding: 4px 0 4px 24px;
+}
+.co-greeting__factsHeading {
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  margin-bottom: 20px;
+}
+:lang(ko) .co-greeting__factsHeading,
+:lang(zh) .co-greeting__factsHeading {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.co-greeting__factList {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.co-greeting__fact {
+  margin: 0;
+}
+.co-greeting__factK {
+  margin: 0;
+  font: 500 26px/1.05 var(--lt-sans);
+  letter-spacing: -0.02em;
+  color: var(--pd-fg-strong);
+}
+.co-greeting__factL {
+  margin: 4px 0 0;
+  font: 400 13px/1.4 var(--lt-sans);
+  color: var(--pd-muted);
+}
+
+/* History timeline — vertical rail with date columns. */
+.co-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: 1px solid var(--pd-rule);
+}
+.co-timeline__row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 32px;
+  padding: 18px 0 18px 28px;
+  align-items: baseline;
+}
+.co-timeline__row + .co-timeline__row {
+  border-top: 1px solid var(--pd-rule);
+}
+.co-timeline__row::before {
+  content: "";
+  position: absolute;
+  left: -5px;
+  top: 26px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--pd-surface);
+  border: 2px solid var(--pd-rule);
+}
+.co-timeline__row--milestone::before {
+  background: var(--pd-primary);
+  border-color: var(--pd-primary);
+}
+.co-timeline__date {
+  font: 500 13px var(--lt-mono);
+  color: var(--pd-primary);
+  letter-spacing: 0.04em;
+}
+:lang(ko) .co-timeline__date,
+:lang(zh) .co-timeline__date {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+}
+.co-timeline__event {
+  font: 400 16px/1.5 var(--lt-sans);
+  color: var(--pd-fg-strong);
+}
+
+/* Certifications: 3 cards stacked. */
+.co-certs {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 720px;
+}
+.co-cert {
+  border: 1px solid var(--pd-rule);
+  border-radius: 4px;
+  padding: 24px 28px;
+  background: var(--pd-surface);
+}
+.co-cert__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.co-cert__name {
+  margin: 0;
+  font: 600 22px/1.2 var(--lt-sans);
+  color: var(--pd-fg-strong);
+  letter-spacing: -0.01em;
+}
+.co-cert__date {
+  font: 500 12px var(--lt-mono);
+  color: var(--pd-muted);
+  letter-spacing: 0.04em;
+}
+:lang(ko) .co-cert__date,
+:lang(zh) .co-cert__date {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+}
+.co-cert__issuer {
+  margin: 0 0 10px;
+  font: 500 13px/1.4 var(--lt-sans);
+  color: var(--pd-primary);
+}
+.co-cert__blurb {
+  margin: 0;
+  font: 400 15px/1.55 var(--lt-sans);
+  color: var(--pd-muted);
+}
+.co-certs__footnote {
+  margin: 24px 0 0;
+  padding: 16px 20px;
+  border-left: 2px solid var(--pd-rule);
+  font: 400 14px/1.55 var(--lt-sans);
+  color: var(--pd-muted);
+  max-width: 720px;
+}
+
+/* Location: HQ + optional subsidiary card. */
+.co-locations {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 720px;
+}
+.co-office {
+  border: 1px solid var(--pd-rule);
+  border-radius: 4px;
+  padding: 24px 28px;
+  background: var(--pd-surface);
+}
+.co-office__heading {
+  margin: 0 0 6px;
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+}
+:lang(ko) .co-office__heading,
+:lang(zh) .co-office__heading {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.co-office__name {
+  margin: 0 0 14px;
+  font: 600 20px/1.25 var(--lt-sans);
+  color: var(--pd-fg-strong);
+  letter-spacing: -0.01em;
+}
+.co-office__rows {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 8px 16px;
+  font: 400 15px/1.5 var(--lt-sans);
+}
+.co-office__label {
+  color: var(--pd-muted);
+  font-weight: 500;
+}
+.co-office__value {
+  color: var(--pd-fg-strong);
+}
+.co-office__value a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--pd-rule);
+  text-underline-offset: 3px;
+}
+.co-office__value a:hover {
+  text-decoration-color: var(--pd-primary);
+}
+
+@media (max-width: 900px) {
+  .co {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .co-aside {
+    position: static;
+    padding-top: 16px;
+  }
+  .co-nav__list {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+  }
+  .co-nav__link {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    padding: 6px 0;
+    margin: 0;
+  }
+  .co-nav__link.is-current {
+    border-left: none;
+    border-bottom-color: var(--pd-primary);
+  }
+  .co-section {
+    padding: 40px 20px;
+  }
+  .co-section + .co-section {
+    margin-top: 12px;
+  }
+  .co-sechd__title {
+    font-size: 28px;
+  }
+  .co-greeting__layout {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .co-timeline__row {
+    grid-template-columns: 80px 1fr;
+    gap: 16px;
+  }
+}

--- a/src/lib/content/company.ts
+++ b/src/lib/content/company.ts
@@ -1,0 +1,518 @@
+/**
+ * Line Tech — /company page content (single-scroller, four sections × 3 locales).
+ *
+ * Sections (rendered top-to-bottom on `/company`, side-nav uses anchor hrefs):
+ *  - #greeting          institutional intro (no CEO photo / signature)
+ *  - #history           1997.03 → 2020.06 timeline
+ *  - #certifications    3 named certs + footnote (per IA decision in
+ *                       docs/linetech-slice-2-plan.md, only 3 of 13 legacy
+ *                       certs have recovered text labels)
+ *  - #location          Daejeon HQ + (ZH only) Wuxi subsidiary
+ *
+ * Source notes:
+ *  - History rows from docs/current-site-audit.md §7.
+ *  - Address / contact from docs/current-site-audit.md §2.
+ *  - Wuxi subsidiary surfaced on ZH only, matching footer convention.
+ */
+import type { Locale } from "./home";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type CompanySectionId =
+  | "greeting"
+  | "history"
+  | "certifications"
+  | "location";
+
+/** One row of the side-nav shared across all /company sub-routes. */
+export type CompanyNavItem = {
+  id: CompanySectionId;
+  href: string;
+  label: string;
+};
+
+export type CompanyGreetingFact = {
+  /** The eye-grabbing value (e.g., "1997", "13"). */
+  k: string;
+  /** The qualifying label (e.g., "Founded", "Certifications"). */
+  l: string;
+};
+
+export type CompanyGreeting = {
+  kicker: string;
+  title: string;
+  /** Multi-paragraph body. Renderer joins with paragraph breaks. */
+  paragraphs: string[];
+  /** Heading shown above the fact sidebar. */
+  factsHeading: string;
+  /** 4 quick facts surfaced beside the paragraphs (year founded, first MFC,
+   * R&D partner, cert count). */
+  facts: CompanyGreetingFact[];
+};
+
+export type CompanyHistoryRow = {
+  /** "1997.03"-style stamp; locale-independent formatting. */
+  date: string;
+  /** Event description. */
+  event: string;
+};
+
+export type CompanyHistory = {
+  kicker: string;
+  title: string;
+  sub: string;
+  rows: CompanyHistoryRow[];
+};
+
+export type CompanyCert = {
+  /** Stable slug for keys + future linking. */
+  id: string;
+  /** Short title (e.g., "ISO 9001"). */
+  name: string;
+  /** Issuing body / standard description. */
+  issuer: string;
+  /** Date obtained, "YYYY.MM" format. */
+  date: string;
+  /** One-line description of what the cert verifies. */
+  blurb: string;
+};
+
+export type CompanyCertifications = {
+  kicker: string;
+  title: string;
+  sub: string;
+  /** The 3 named certs with full text. */
+  named: CompanyCert[];
+  /** Footnote acknowledging the additional 10 documents. */
+  footnote: string;
+};
+
+export type CompanyLocationOffice = {
+  /** Heading: "Headquarters" / "Subsidiary". */
+  heading: string;
+  /** Company name as displayed (canonical Korean spelling on KO). */
+  name: string;
+  address: string;
+  phone?: string;
+  fax?: string;
+  email?: string;
+};
+
+export type CompanyLocationLabels = {
+  address: string;
+  phone: string;
+  fax: string;
+  email: string;
+};
+
+export type CompanyLocation = {
+  kicker: string;
+  title: string;
+  sub: string;
+  /** Row labels shared by every office card. */
+  labels: CompanyLocationLabels;
+  hq: CompanyLocationOffice;
+  /** Wuxi subsidiary — only present on ZH. */
+  subsidiary?: CompanyLocationOffice;
+};
+
+export type CompanyContent = {
+  /** Side-nav items in display order. */
+  nav: CompanyNavItem[];
+  /** Section heading shown above the side-nav. */
+  navHeading: string;
+  greeting: CompanyGreeting;
+  history: CompanyHistory;
+  certifications: CompanyCertifications;
+  location: CompanyLocation;
+};
+
+// ─── Shared (locale-independent) ────────────────────────────────────────────
+
+/**
+ * Timeline event keys → date stamps. The date format ("1997.03") is shared
+ * across locales; only the event description is localized.
+ */
+const HISTORY_DATES = [
+  "1997.03",
+  "2000.01",
+  "2003.03",
+  "2006.06",
+  "2015.09",
+  "2016.01",
+  "2016.12",
+  "2017.08",
+  "2018.03",
+  "2019.03",
+  "2019.11",
+  "2020.06",
+] as const;
+
+// ─── Content ────────────────────────────────────────────────────────────────
+
+export const LT_COMPANY: Record<Locale, CompanyContent> = {
+  ko: {
+    navHeading: "회사 안내",
+    nav: [
+      { id: "greeting", href: "#greeting", label: "인사말" },
+      { id: "history", href: "#history", label: "발자취" },
+      { id: "certifications", href: "#certifications", label: "인증" },
+      { id: "location", href: "#location", label: "오시는 길" },
+    ],
+    greeting: {
+      kicker: "01 — 인사말",
+      title: "안녕하십니까, 라인테크입니다.",
+      paragraphs: [
+        "1997년 설립 이래 라인테크는 자체 기술로 질량유량 제어기와 측정기를 개발·생산하며, 정밀 측정이 필요한 산업 현장에서 25년 이상 신뢰를 쌓아 왔습니다.",
+        "KAIST와의 공동연구를 기반으로 2003년 국내 최초로 MFC와 MFM 양산에 성공한 이후, 반도체·디스플레이·바이오·연료전지 공정 라인에서 표준이 되는 정밀 제어 솔루션을 공급해 왔습니다.",
+        "검증된 기술과 확실한 사후 지원을 통해 고객의 공정에 신뢰성을 더하는 일, 그것이 라인테크가 지난 25년 동안 지켜 온 약속입니다.",
+      ],
+      factsHeading: "라인테크의 발자취",
+      facts: [
+        { k: "1997", l: "설립 연도" },
+        { k: "2003", l: "국내 최초 MFC 양산" },
+        { k: "KAIST", l: "공동 연구 파트너" },
+        { k: "13종", l: "보유 인증" },
+      ],
+    },
+    history: {
+      kicker: "02 — 발자취",
+      title: "1997년부터, 한 분야에 집중해 왔습니다.",
+      sub: "설립 이후 주요 성과를 시간순으로 정리했습니다.",
+      rows: [
+        { date: HISTORY_DATES[0], event: "라인테크 설립" },
+        { date: HISTORY_DATES[1], event: "KAIST 공동연구 시작" },
+        {
+          date: HISTORY_DATES[2],
+          event: "국내 최초 MFC · MFM 모델 자체 개발",
+        },
+        {
+          date: HISTORY_DATES[3],
+          event: "첫 해외 수출 (중국 상하이)",
+        },
+        { date: HISTORY_DATES[4], event: "기업부설연구소 설립" },
+        {
+          date: HISTORY_DATES[5],
+          event: "Read Out Unit (LTI 시리즈) 개발",
+        },
+        {
+          date: HISTORY_DATES[6],
+          event: "측정 범위 확대 — 150 · 500 · 1,000 · 2,500 SLPM",
+        },
+        { date: HISTORY_DATES[7], event: "CE · ISO 9001 인증 획득" },
+        { date: HISTORY_DATES[8], event: "INNOBIZ 인증 획득" },
+        {
+          date: HISTORY_DATES[9],
+          event: "측정 범위 확대 — 5,000 SLPM",
+        },
+        {
+          date: HISTORY_DATES[10],
+          event: "첫 해외 공인 대리점 계약 (인도)",
+        },
+        { date: HISTORY_DATES[11], event: "EX · LD · LM 시리즈 개발" },
+      ],
+    },
+    certifications: {
+      kicker: "03 — 인증",
+      title: "검증된 품질 시스템.",
+      sub: "주요 인증 3종을 명시합니다. 그 외 적합성 증빙 문서는 요청 시 제공해 드립니다.",
+      named: [
+        {
+          id: "iso-9001",
+          name: "ISO 9001",
+          issuer: "국제표준화기구 (ISO)",
+          date: "2017.08",
+          blurb:
+            "품질경영시스템 국제 표준. 설계부터 생산, 출하 후 지원까지 일관된 품질 절차를 검증합니다.",
+        },
+        {
+          id: "ce",
+          name: "CE",
+          issuer: "EU 적합성 선언",
+          date: "2017.08",
+          blurb:
+            "유럽 경제 지역 내 공급을 위한 안전·전자기 적합성 요구사항을 충족함을 선언합니다.",
+        },
+        {
+          id: "innobiz",
+          name: "INNOBIZ",
+          issuer: "중소벤처기업부",
+          date: "2018.03",
+          blurb:
+            "기술혁신형 중소기업으로 선정. 기술경쟁력과 미래 성장 가능성을 정부에서 인증받았습니다.",
+        },
+      ],
+      footnote:
+        "위 3종 외에도 라인테크의 품질 시스템 안에는 RoHS · REACH 등 10건의 적합성 증빙 문서가 운용되고 있으며, 필요 시 영업 담당자를 통해 사본을 제공해 드립니다.",
+    },
+    location: {
+      kicker: "04 — 오시는 길",
+      title: "대전 본사",
+      sub: "대덕연구개발특구 안에 위치한 본사 및 생산 시설.",
+      labels: {
+        address: "주소",
+        phone: "전화",
+        fax: "팩스",
+        email: "이메일",
+      },
+      hq: {
+        heading: "본사 · 공장",
+        name: "주식회사 라인테크",
+        address: "대전광역시 유성구 대덕대로 806 (34055)",
+        phone: "042-624-0700",
+        fax: "042-638-2211",
+        email: "linetech@line-tech.co.kr",
+      },
+    },
+  },
+
+  en: {
+    navHeading: "About Line Tech",
+    nav: [
+      { id: "greeting", href: "#greeting", label: "Greeting" },
+      { id: "history", href: "#history", label: "History" },
+      {
+        id: "certifications",
+        href: "#certifications",
+        label: "Certifications",
+      },
+      { id: "location", href: "#location", label: "Location" },
+    ],
+    greeting: {
+      kicker: "01 — Greeting",
+      title: "Welcome to Line Tech.",
+      paragraphs: [
+        "Since 1997, Line Tech has designed and built mass flow controllers and meters using technology developed in-house — earning the trust of process engineers for more than 25 years across industries that demand precision measurement.",
+        "Through our R&D collaboration with KAIST, we became the first Korean manufacturer to mass-produce MFCs and MFMs in 2003. Our instruments have set a reliable measurement standard across semiconductor, display, biotech, and fuel-cell process lines ever since.",
+        "Proven technology paired with attentive after-sales support — that has been our commitment for the last quarter-century, and it remains the standard we hold ourselves to with every customer.",
+      ],
+      factsHeading: "Line Tech in brief",
+      facts: [
+        { k: "1997", l: "Founded" },
+        { k: "2003", l: "First Korean MFC produced" },
+        { k: "KAIST", l: "R&D collaboration partner" },
+        { k: "13", l: "Certifications held" },
+      ],
+    },
+    history: {
+      kicker: "02 — History",
+      title: "One discipline, since 1997.",
+      sub: "Milestones from the company's founding to the present.",
+      rows: [
+        { date: HISTORY_DATES[0], event: "Line Tech Inc. founded" },
+        {
+          date: HISTORY_DATES[1],
+          event: "R&D collaboration with KAIST begins",
+        },
+        {
+          date: HISTORY_DATES[2],
+          event: "First MFC / MFM models developed (first in Korea)",
+        },
+        {
+          date: HISTORY_DATES[3],
+          event: "First international sale (Shanghai, China)",
+        },
+        { date: HISTORY_DATES[4], event: "Corporate R&D Center established" },
+        {
+          date: HISTORY_DATES[5],
+          event: "Read Out Unit (LTI series) developed",
+        },
+        {
+          date: HISTORY_DATES[6],
+          event:
+            "Capacity extended — 150 · 500 · 1,000 · 2,500 SLPM",
+        },
+        {
+          date: HISTORY_DATES[7],
+          event: "CE and ISO 9001 certifications obtained",
+        },
+        { date: HISTORY_DATES[8], event: "Certified as INNOBIZ" },
+        { date: HISTORY_DATES[9], event: "Capacity extended — 5,000 SLPM" },
+        {
+          date: HISTORY_DATES[10],
+          event: "First international licensed distributor (India)",
+        },
+        { date: HISTORY_DATES[11], event: "EX · LD · LM series developed" },
+      ],
+    },
+    certifications: {
+      kicker: "03 — Certifications",
+      title: "A documented quality system.",
+      sub: "Three core certifications are listed below. Additional conformity documents are available on request.",
+      named: [
+        {
+          id: "iso-9001",
+          name: "ISO 9001",
+          issuer: "International Organization for Standardization",
+          date: "2017.08",
+          blurb:
+            "International standard for quality management — covers design, production, and after-sales support under a single audited system.",
+        },
+        {
+          id: "ce",
+          name: "CE",
+          issuer: "EU Declaration of Conformity",
+          date: "2017.08",
+          blurb:
+            "Declares that our products meet the safety and electromagnetic-compatibility requirements for supply within the European Economic Area.",
+        },
+        {
+          id: "innobiz",
+          name: "INNOBIZ",
+          issuer: "Korean Ministry of SMEs and Startups",
+          date: "2018.03",
+          blurb:
+            "Government recognition awarded to technology-driven Korean SMEs with proven competitiveness and growth potential.",
+        },
+      ],
+      footnote:
+        "Beyond the three above, Line Tech maintains 10 additional conformity documents within its quality system — including RoHS and REACH declarations. Copies are provided on request through your sales contact.",
+    },
+    location: {
+      kicker: "04 — Location",
+      title: "Daejeon headquarters.",
+      sub: "Headquarters and production located within the Daedeok Innopolis research cluster.",
+      labels: {
+        address: "Address",
+        phone: "Phone",
+        fax: "Fax",
+        email: "Email",
+      },
+      hq: {
+        heading: "Headquarters · Factory",
+        name: "Line Tech Inc.",
+        address: "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea",
+        phone: "+82-42-624-0700",
+        fax: "+82-42-638-2211",
+        email: "linetech@line-tech.co.kr",
+      },
+    },
+  },
+
+  zh: {
+    navHeading: "关于莱因",
+    nav: [
+      { id: "greeting", href: "#greeting", label: "问候语" },
+      { id: "history", href: "#history", label: "发展历程" },
+      {
+        id: "certifications",
+        href: "#certifications",
+        label: "资质认证",
+      },
+      { id: "location", href: "#location", label: "联系地址" },
+    ],
+    greeting: {
+      kicker: "01 — 问候语",
+      title: "您好，欢迎了解莱因。",
+      paragraphs: [
+        "自 1997 年成立以来，莱因始终以自主技术为基础，专注于质量流量控制器与流量计的研发与制造，在对精度有严格要求的工艺现场积累了 25 年以上的信赖。",
+        "通过与韩国科学技术院 (KAIST) 的联合研发，我们于 2003 年成为韩国首家量产 MFC 与 MFM 的厂商，此后在半导体、显示、生物制药与燃料电池工艺线上持续作为可靠的测量基准被采用。",
+        "经过验证的技术，配合细致的售后支持 — 这是莱因 25 年来对每一位客户工艺始终如一的承诺。",
+      ],
+      factsHeading: "莱因关键数据",
+      facts: [
+        { k: "1997", l: "成立年份" },
+        { k: "2003", l: "国内首款 MFC 量产" },
+        { k: "KAIST", l: "联合研发伙伴" },
+        { k: "13 项", l: "已获认证" },
+      ],
+    },
+    history: {
+      kicker: "02 — 发展历程",
+      title: "自 1997 年起，专注一个领域。",
+      sub: "公司创立至今的主要发展节点。",
+      rows: [
+        { date: HISTORY_DATES[0], event: "莱因公司成立" },
+        {
+          date: HISTORY_DATES[1],
+          event: "与 KAIST 启动联合研发",
+        },
+        {
+          date: HISTORY_DATES[2],
+          event: "韩国首款 MFC · MFM 量产 (国内首家)",
+        },
+        {
+          date: HISTORY_DATES[3],
+          event: "首次海外销售 (中国上海)",
+        },
+        { date: HISTORY_DATES[4], event: "设立企业附设研究所" },
+        {
+          date: HISTORY_DATES[5],
+          event: "开发 LTI 系列显示单元 (Read Out Unit)",
+        },
+        {
+          date: HISTORY_DATES[6],
+          event: "量程扩展至 150 · 500 · 1,000 · 2,500 SLPM",
+        },
+        {
+          date: HISTORY_DATES[7],
+          event: "获得 CE 与 ISO 9001 认证",
+        },
+        { date: HISTORY_DATES[8], event: "获得 INNOBIZ 认证" },
+        { date: HISTORY_DATES[9], event: "量程扩展至 5,000 SLPM" },
+        {
+          date: HISTORY_DATES[10],
+          event: "首家海外授权代理 (印度)",
+        },
+        { date: HISTORY_DATES[11], event: "开发 EX · LD · LM 系列" },
+      ],
+    },
+    certifications: {
+      kicker: "03 — 资质认证",
+      title: "经过认证的质量体系。",
+      sub: "以下列出三项核心资质。其余符合性证明文件可按需提供。",
+      named: [
+        {
+          id: "iso-9001",
+          name: "ISO 9001",
+          issuer: "国际标准化组织 (ISO)",
+          date: "2017.08",
+          blurb:
+            "国际通用的质量管理体系标准，覆盖设计、生产与售后服务的全流程审计。",
+        },
+        {
+          id: "ce",
+          name: "CE",
+          issuer: "欧盟符合性声明",
+          date: "2017.08",
+          blurb:
+            "声明产品符合在欧洲经济区销售所需的安全与电磁兼容要求。",
+        },
+        {
+          id: "innobiz",
+          name: "INNOBIZ",
+          issuer: "韩国中小企业部",
+          date: "2018.03",
+          blurb:
+            "韩国政府授予具备技术竞争力与成长潜力的技术创新型中小企业的资质。",
+        },
+      ],
+      footnote:
+        "除上述三项外，莱因质量体系内另维护包括 RoHS 与 REACH 在内的 10 份符合性证明文件，可通过销售对接人按需提供。",
+    },
+    location: {
+      kicker: "04 — 联系地址",
+      title: "大田总部",
+      sub: "总部与生产基地位于大德研发特区内。",
+      labels: {
+        address: "地址",
+        phone: "电话",
+        fax: "传真",
+        email: "邮箱",
+      },
+      hq: {
+        heading: "总部 · 工厂",
+        name: "株式会社莱因",
+        address: "韩国大田广域市儒城区大德大路 806 号 (34055)",
+        phone: "+82-42-624-0700",
+        fax: "+82-42-638-2211",
+        email: "linetech@line-tech.co.kr",
+      },
+      subsidiary: {
+        heading: "中国子公司",
+        name: "莱因精密技术（无锡）有限公司",
+        address: "江苏省无锡市锡山区锡沪东荟智企业中心 6 号楼 117 号",
+      },
+    },
+  },
+};

--- a/src/lib/content/company.ts
+++ b/src/lib/content/company.ts
@@ -319,8 +319,7 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         },
         {
           date: HISTORY_DATES[6],
-          event:
-            "Capacity extended — 150 · 500 · 1,000 · 2,500 SLPM",
+          event: "Capacity extended — 150 · 500 · 1,000 · 2,500 SLPM",
         },
         {
           date: HISTORY_DATES[7],
@@ -475,8 +474,7 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
           name: "CE",
           issuer: "欧盟符合性声明",
           date: "2017.08",
-          blurb:
-            "声明产品符合在欧洲经济区销售所需的安全与电磁兼容要求。",
+          blurb: "声明产品符合在欧洲经济区销售所需的安全与电磁兼容要求。",
         },
         {
           id: "innobiz",

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -161,19 +161,19 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "회사 안내",
           links: [
-            { href: "/company", label: "인사말", desc: "CEO 메시지" },
+            { href: "/company#greeting", label: "인사말", desc: "CEO 메시지" },
             {
-              href: "/company/history",
-              label: "연혁",
+              href: "/company#history",
+              label: "발자취",
               desc: "1997년부터 현재까지",
             },
             {
-              href: "/company/certifications",
+              href: "/company#certifications",
               label: "인증",
               desc: "ISO · CE · INNOBIZ 외",
             },
             {
-              href: "/company/location",
+              href: "/company#location",
               label: "오시는 길",
               desc: "대전 본사 위치",
             },
@@ -182,7 +182,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             eyebrow: "신뢰",
             title: "13종 인증",
             blurb: "ISO 9001 · CE · INNOBIZ · RoHS / REACH 외 9종.",
-            href: "/company/certifications",
+            href: "/company#certifications",
             cta: "전체 인증 보기",
           },
         },
@@ -319,22 +319,22 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           heading: "About Line Tech",
           links: [
             {
-              href: "/company",
+              href: "/company#greeting",
               label: "Greeting",
               desc: "Message from the CEO",
             },
             {
-              href: "/company/history",
+              href: "/company#history",
               label: "History",
               desc: "From 1997 to today",
             },
             {
-              href: "/company/certifications",
+              href: "/company#certifications",
               label: "Certifications",
               desc: "ISO · CE · INNOBIZ and more",
             },
             {
-              href: "/company/location",
+              href: "/company#location",
               label: "Location",
               desc: "Daejeon headquarters",
             },
@@ -344,7 +344,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             title: "13 certifications",
             blurb:
               "ISO 9001, CE, INNOBIZ, RoHS / REACH and 9 more — the full set procurement teams ask for.",
-            href: "/company/certifications",
+            href: "/company#certifications",
             cta: "View all certifications",
           },
         },
@@ -477,19 +477,19 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           kind: "resources",
           heading: "关于莱因",
           links: [
-            { href: "/company", label: "问候语", desc: "CEO 致辞" },
+            { href: "/company#greeting", label: "问候语", desc: "CEO 致辞" },
             {
-              href: "/company/history",
+              href: "/company#history",
               label: "发展历程",
               desc: "自 1997 年至今",
             },
             {
-              href: "/company/certifications",
+              href: "/company#certifications",
               label: "资质认证",
               desc: "ISO · CE · INNOBIZ 等",
             },
             {
-              href: "/company/location",
+              href: "/company#location",
               label: "联系地址",
               desc: "大田总部位置",
             },
@@ -498,7 +498,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             eyebrow: "信赖",
             title: "13 项资质认证",
             blurb: "ISO 9001 · CE · INNOBIZ · RoHS / REACH 等 13 项认证文件。",
-            href: "/company/certifications",
+            href: "/company#certifications",
             cta: "查看全部认证",
           },
         },


### PR DESCRIPTION
## Summary

Resolves #29. The /company section was previously specced as either single-scroller or page-per-topic — picked **single scroller** because Greeting and Location are filler on their own, and the four sections read better as one institutional narrative. Deep links still work via `/company#section` anchors.

- **Greeting** — intro paragraphs + 4-fact sidebar (1997 founded, 2003 first Korean MFC, KAIST partner, 13 certifications)
- **History** — 12-row timeline 1997.03 → 2020.06; filled dots on founding / first-MFC / cert milestones
- **Certifications** — 3 named cards (ISO 9001, CE, INNOBIZ) + footnote for the 10 unrecovered cert labels (filed as phase-2 work in slice-2 plan)
- **Location** — Daejeon HQ on all locales; Wuxi subsidiary on ZH only
- Sticky side-nav with IntersectionObserver scroll-spy (hairline scan band at 30% of viewport — exactly one section active at a time)
- Alternating tinted/white section backgrounds
- Mega-menu Company links + spotlight card retargeted to `/company#anchor`
- KO label `연혁` → `발자취` per native review

## Test plan

- [ ] `/ko/company`, `/en/company`, `/zh/company` render with all four sections
- [ ] Side-nav active state tracks the section being read while scrolling
- [ ] Side-nav anchor clicks scroll smoothly with correct top offset (header doesn't cover the heading)
- [ ] `/zh/company` shows the Wuxi subsidiary card; KO/EN do not
- [ ] Mega-menu "Company" links + the "13 certifications" spotlight card jump to `/company#certifications`
- [ ] `/company#certifications` direct URL lands at the right section
- [ ] Mobile <900px: side-nav becomes a horizontal pill row above the content
- [ ] `npm run typecheck` / `npm run lint` / `npm run build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)