### PR TITLE
fix(content): correct HQ city to Daejeon

### DIFF
--- a/docs/handoff/data/home.jsx
+++ b/docs/handoff/data/home.jsx
@@ -14,7 +14,7 @@ const LT_HOME = {
       badge: 'KAIST 공동연구 기반 · 국내 최초',
     },
     stats: [
-      { k: '1997', l: '설립 연도', sub: '경기도 화성시' },
+      { k: '1997', l: '설립 연도', sub: '대전광역시 유성구' },
       { k: '2003', l: '국내 최초 자체 MFC 양산', sub: 'M-Series' },
       { k: '0.01–5000', l: 'SLPM 측정 범위', sub: '전 시리즈 합산' },
       { k: '±0.25%', l: '반복 정밀도', sub: '전 제품 공통' },
@@ -80,7 +80,7 @@ const LT_HOME = {
       badge: 'Founded on KAIST collaboration · First in Korea',
     },
     stats: [
-      { k: '1997', l: 'Founded',                   sub: 'Hwaseong, Gyeonggi' },
+      { k: '1997', l: 'Founded',                   sub: 'Daejeon, Korea' },
       { k: '2003', l: 'First Korean MFC produced', sub: 'M-Series' },
       { k: '0.01–5000', l: 'SLPM flow range',      sub: 'across all series' },
       { k: '±0.25 %', l: 'Repeatability',          sub: 'every product' },
@@ -146,7 +146,7 @@ const LT_HOME = {
       badge: '基于 KAIST 合作研究 · 韩国首家',
     },
     stats: [
-      { k: '1997', l: '成立年份',                 sub: '京畿道华城市' },
+      { k: '1997', l: '成立年份',                 sub: '韩国大田' },
       { k: '2003', l: '韩国首款自产 MFC',         sub: 'M 系列' },
       { k: '0.01–5000', l: 'SLPM 流量范围',       sub: '全系列合计' },
       { k: '±0.25 %', l: '重复精度',              sub: '全系一致' },

--- a/docs/handoff/data/locales.jsx
+++ b/docs/handoff/data/locales.jsx
@@ -111,7 +111,7 @@ const LT_LOCALES = {
     },
     footer: {
       sig: '라인테크 주식회사 · Line Tech Co., Ltd.',
-      addr: '경기도 화성시 동탄산단 6-3길',
+      addr: '대전광역시 유성구 대덕대로 806 (34055)',
       rights: '© 2026 Line Tech. 모든 권리 보유.',
     },
   },
@@ -223,7 +223,7 @@ const LT_LOCALES = {
     },
     footer: {
       sig: 'Line Tech Co., Ltd.',
-      addr: 'Dongtan Industrial Complex 6-3, Hwaseong, Gyeonggi',
+      addr: '806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea',
       rights: '© 2026 Line Tech. All rights reserved.',
     },
   },
@@ -335,7 +335,7 @@ const LT_LOCALES = {
     },
     footer: {
       sig: 'Line Tech 株式会社',
-      addr: '京畿道华城市东滩产业园 6-3',
+      addr: '韩国大田广域市儒城区大德大路 806 号 (34055)',
       rights: '© 2026 Line Tech. 版权所有。',
     },
   },

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -52,7 +52,7 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       badge: "KAIST 공동연구 기반 · 국내 최초",
     },
     stats: [
-      { k: "1997", l: "설립 연도", sub: "경기도 화성시" },
+      { k: "1997", l: "설립 연도", sub: "대전광역시 유성구" },
       { k: "2003", l: "국내 최초 자체 MFC 양산", sub: "M-Series" },
       { k: "0.01–5000", l: "SLPM 측정 범위", sub: "전 시리즈 합산" },
       { k: "±0.25%", l: "반복 정밀도", sub: "전 제품 공통" },
@@ -150,7 +150,7 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       badge: "Founded on KAIST collaboration · First in Korea",
     },
     stats: [
-      { k: "1997", l: "Founded", sub: "Hwaseong, Gyeonggi" },
+      { k: "1997", l: "Founded", sub: "Daejeon, Korea" },
       { k: "2003", l: "First Korean MFC produced", sub: "M-Series" },
       { k: "0.01–5000", l: "SLPM flow range", sub: "across all series" },
       { k: "±0.25 %", l: "Repeatability", sub: "every product" },
@@ -242,7 +242,7 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       badge: "基于 KAIST 合作研究 · 韩国首家",
     },
     stats: [
-      { k: "1997", l: "成立年份", sub: "京畿道华城市" },
+      { k: "1997", l: "成立年份", sub: "韩国大田" },
       { k: "2003", l: "韩国首款自产 MFC", sub: "M 系列" },
       { k: "0.01–5000", l: "SLPM 流量范围", sub: "全系列合计" },
       { k: "±0.25 %", l: "重复精度", sub: "全系一致" },


### PR DESCRIPTION
## Summary
- The home page stats tile (`src/lib/content/home.ts`) and the frozen handoff prototype data (`docs/handoff/data/{home,locales}.jsx`) had a fabricated Hwaseong / 경기도 화성시 / 京畿道华城市 address.
- Line Tech HQ is **806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea** — the address already used in `contact.ts`, `shell.ts`, and `company.ts`.
- This brings the three stragglers in line with the rest of the codebase. Three locales each, identical pattern.

## Test plan
- [ ] Visit `/`, `/en`, `/zh` and confirm the 1997 stats tile reads "대전광역시 유성구" / "Daejeon, Korea" / "韩国大田"
- [ ] Skim the rest of the home page for any other stale Hwaseong references (none expected — `grep` is clean)
- [ ] No code paths consume `docs/handoff/data/*.jsx` at runtime, so no app behavior should change

🤖 Generated with [Claude Code](https://claude.com/claude-code)