### PR TITLE
style(header): bump header sizing for stronger presence

### DIFF
--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -16,14 +16,14 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: 0 32px;
-  height: 56px;
+  height: 72px;
   display: flex;
   align-items: center;
   gap: 28px;
   transition: height 0.2s ease;
 }
 .pd-top.is-scrolled .pd-top__inner {
-  height: 48px;
+  height: 56px;
 }
 
 .pd-top__brand {
@@ -48,7 +48,7 @@
 }
 
 .pd-top__wordmark {
-  font: 700 16px/1 var(--lt-sans);
+  font: 700 18px/1 var(--lt-sans);
   letter-spacing: 0.01em;
   color: var(--pd-primary);
 }

--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -2,6 +2,10 @@
  * Ported from docs/handoff/styles.css `.pd-top` rules. */
 
 .pd-top {
+  /* Header heights — also consumed by MegaMenu.css for scrim positioning. */
+  --pd-top-h: 72px;
+  --pd-top-h-scrolled: 56px;
+
   position: sticky;
   top: 0;
   z-index: 40;
@@ -16,14 +20,14 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: 0 32px;
-  height: 72px;
+  height: var(--pd-top-h);
   display: flex;
   align-items: center;
   gap: 28px;
   transition: height 0.2s ease;
 }
 .pd-top.is-scrolled .pd-top__inner {
-  height: 56px;
+  height: var(--pd-top-h-scrolled);
 }
 
 .pd-top__brand {
@@ -97,6 +101,10 @@
 }
 
 @media (max-width: 1000px) {
+  .pd-top {
+    --pd-top-h: 60px;
+    --pd-top-h-scrolled: 52px;
+  }
   .pd-top__inner {
     padding: 0 16px;
     gap: 12px;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,7 +20,7 @@ export function Header({ locale }: Props) {
       <div className="pd-top__inner">
         <Link href="/" className="pd-top__brand" aria-label="Line Tech">
           <span className="pd-top__logomark">
-            <Logomark />
+            <Logomark size={28} />
           </span>
           <span className="pd-top__wordmark">
             LINE

--- a/src/components/layout/HeaderNav.css
+++ b/src/components/layout/HeaderNav.css
@@ -16,9 +16,9 @@
   border: 0;
   background: transparent;
   cursor: pointer;
-  font: 500 14px var(--lt-sans);
+  font: 600 16px var(--lt-sans);
   color: var(--pd-fg);
-  padding: 0 14px;
+  padding: 0 16px;
   height: 100%;
   position: relative;
   text-decoration: none;
@@ -28,8 +28,8 @@
 .pd-top__navitem::after {
   content: "";
   position: absolute;
-  left: 14px;
-  right: 14px;
+  left: 16px;
+  right: 16px;
   bottom: -1px;
   height: 2px;
   background: var(--pd-primary);

--- a/src/components/layout/MegaMenu.css
+++ b/src/components/layout/MegaMenu.css
@@ -160,7 +160,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  top: 56px;
+  top: var(--pd-top-h, 72px);
   z-index: 45;
   background: rgba(12, 14, 20, 0.18);
   opacity: 0;
@@ -173,7 +173,7 @@
 }
 .pd-top.is-scrolled ~ * .pd-mega-scrim,
 .pd-top.is-scrolled .pd-mega-scrim {
-  top: 48px;
+  top: var(--pd-top-h-scrolled, 56px);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Top bar felt thin/utility-coded next to the hero content; bump heights and brand/nav typography so the header reads at page-scale.
- `pd-top` inner height 56→72px (scrolled 48→56px), wordmark 16→18px, logomark 22→28px.
- Nav items 500/14px → 600/16px with padding 14→16px (Inter 600 is loaded, no faux bold).

## Test plan
- [ ] Visual check at desktop (≥1000px): header taller, brand + nav read clearly, no overlap with right-side controls
- [ ] Mobile (<1000px): nav still hides, header still compact (only `inner` height + brand size changed)
- [ ] Sticky scroll: confirm 72→56 transition is smooth, no layout jump under the header
- [ ] Locale switcher / quote button still vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)