### PR TITLE
style(typography): site-wide font-size scale via CSS tokens

### DIFF
--- a/src/app/[locale]/contact/contact-page.css
+++ b/src/app/[locale]/contact/contact-page.css
@@ -9,13 +9,13 @@
 }
 .ct__title {
   margin: 8px 0 12px;
-  font: 500 44px/1.1 var(--lt-sans);
+  font: 500 var(--lt-fs-h2)/1.1 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
 }
 .ct__lede {
   margin: 0;
-  font-size: 17px;
+  font-size: var(--lt-fs-md);
   line-height: 1.6;
   color: var(--pd-muted);
 }
@@ -42,7 +42,7 @@
 }
 .ct-info__heading {
   margin: 0 0 20px;
-  font: 500 18px/1.2 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.2 var(--lt-sans);
   letter-spacing: -0.01em;
   color: var(--pd-fg-strong);
 }
@@ -58,14 +58,14 @@
   gap: 4px;
 }
 .ct-info__label {
-  font-size: 12px;
+  font-size: var(--lt-fs-xs);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--pd-muted);
 }
 .ct-info__value {
-  font-size: 15px;
+  font-size: var(--lt-fs-sm);
   line-height: 1.45;
   color: var(--pd-fg-strong);
 }
@@ -93,7 +93,7 @@
 }
 .ct-form__heading {
   margin: 0 0 8px;
-  font: 500 22px/1.2 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.2 var(--lt-sans);
   letter-spacing: -0.01em;
   color: var(--pd-fg-strong);
 }
@@ -103,7 +103,7 @@
   background: var(--lt-accent-50);
   border: 1px solid var(--lt-accent-200);
   border-radius: var(--pd-r-md);
-  font-size: 14px;
+  font-size: var(--lt-fs-sm);
   line-height: 1.5;
   color: var(--lt-accent-900);
 }
@@ -131,12 +131,12 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--lt-fs-xs);
   font-weight: 500;
   color: var(--pd-fg-strong);
 }
 .ct-form__required {
-  font-size: 11px;
+  font-size: var(--lt-fs-xs);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -146,7 +146,7 @@
 .ct-form__textarea,
 .ct-form__select {
   font: inherit;
-  font-size: 15px;
+  font-size: var(--lt-fs-sm);
   color: var(--pd-fg-strong);
   background: var(--pd-surface-2);
   border: 1px solid var(--pd-border-strong);
@@ -190,7 +190,7 @@
   flex-wrap: wrap;
 }
 .ct-form__help {
-  font-size: 13px;
+  font-size: var(--lt-fs-xs);
   color: var(--pd-muted);
   line-height: 1.45;
   flex: 1 1 240px;
@@ -199,7 +199,7 @@
   margin: 14px 0 0;
   padding-top: 14px;
   border-top: 1px solid var(--pd-rule);
-  font-size: 12px;
+  font-size: var(--lt-fs-xs);
   line-height: 1.5;
   color: var(--pd-muted);
 }
@@ -214,13 +214,13 @@
 }
 .ct-dist__heading {
   margin: 0 0 8px;
-  font: 500 28px/1.2 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.2 var(--lt-sans);
   letter-spacing: -0.01em;
   color: var(--pd-fg-strong);
 }
 .ct-dist__lede {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--lt-fs-sm);
   line-height: 1.55;
   color: var(--pd-muted);
 }
@@ -251,14 +251,14 @@
   gap: 6px;
 }
 .ct-dist__region {
-  font-size: 12px;
+  font-size: var(--lt-fs-xs);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--pd-primary);
 }
 .ct-dist__status {
-  font-size: 15px;
+  font-size: var(--lt-fs-sm);
   line-height: 1.45;
   color: var(--pd-fg-strong);
 }
@@ -276,13 +276,13 @@
 }
 .ct-map__heading {
   margin: 0;
-  font: 500 28px/1.2 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.2 var(--lt-sans);
   letter-spacing: -0.01em;
   color: var(--pd-fg-strong);
 }
 .ct-map__caption {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--lt-fs-sm);
   color: var(--pd-muted);
 }
 .ct-map__frame {
@@ -308,7 +308,7 @@
 }
 .ct-map__open {
   justify-self: start;
-  font-size: 14px;
+  font-size: var(--lt-fs-sm);
   font-weight: 500;
   color: var(--pd-primary);
   text-decoration: underline;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,6 +66,18 @@
   --pd-r-md: 6px;
   --pd-r-lg: 10px;
 
+  /* Type scale — use these instead of literal px values.
+   * Body tier (xs–xl) = reusable buckets. Title tier = named by role. */
+  --lt-fs-xs: 13px; /* captions, footnotes, mono labels, locale switcher */
+  --lt-fs-sm: 15px; /* eyebrow, item desc, secondary body, nav links */
+  --lt-fs-md: 17px; /* primary body, hero lede, section sub */
+  --lt-fs-lg: 22px; /* hero eyebrow, item titles, sub-section headings */
+  --lt-fs-xl: 34px; /* stat number */
+  --lt-fs-h2-dense: 40px; /* /company sections (denser two-col layout) */
+  --lt-fs-h2: 48px; /* default section h2 (home, contact) */
+  --lt-fs-feature: 56px; /* feature spotlight (M3030VA) */
+  --lt-fs-hero: 72px; /* hero h1 */
+
   --lt-sans:
     var(--font-sans), -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
     "Malgun Gothic", "PingFang SC", "Microsoft YaHei", "Segoe UI",
@@ -127,6 +139,17 @@
 
   --font-sans: var(--lt-sans);
   --font-mono: var(--lt-mono);
+
+  /* Type scale — exposed as Tailwind text-* utilities */
+  --text-xs: var(--lt-fs-xs);
+  --text-sm: var(--lt-fs-sm);
+  --text-md: var(--lt-fs-md);
+  --text-lg: var(--lt-fs-lg);
+  --text-xl: var(--lt-fs-xl);
+  --text-h2-dense: var(--lt-fs-h2-dense);
+  --text-h2: var(--lt-fs-h2);
+  --text-feature: var(--lt-fs-feature);
+  --text-hero: var(--lt-fs-hero);
 }
 
 /* ─── Base ─────────────────────────────────────────────────────────── */

--- a/src/components/company/company-shell.css
+++ b/src/components/company/company-shell.css
@@ -17,7 +17,7 @@
   padding-top: 56px;
 }
 .co-aside__heading {
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -44,7 +44,7 @@
   display: block;
   padding: 7px 0 7px 14px;
   margin-left: -16px;
-  font: 400 14px/1.45 var(--lt-sans);
+  font: 400 var(--lt-fs-sm)/1.45 var(--lt-sans);
   color: var(--pd-muted);
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -86,7 +86,7 @@
   margin-bottom: 32px;
 }
 .co-sechd__kicker {
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -100,7 +100,7 @@
 }
 .co-sechd__title {
   margin: 0 0 12px;
-  font: 500 36px/1.1 var(--lt-sans);
+  font: 500 var(--lt-fs-h2-dense)/1.1 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
   max-width: 760px;
@@ -108,7 +108,7 @@
 .co-sechd__sub {
   margin: 0;
   max-width: 620px;
-  font-size: 16px;
+  font-size: var(--lt-fs-md);
   color: var(--pd-muted);
   line-height: 1.55;
 }
@@ -125,7 +125,7 @@
 }
 .co-greeting__body p {
   margin: 0 0 18px;
-  font: 400 17px/1.65 var(--lt-sans);
+  font: 400 var(--lt-fs-md)/1.65 var(--lt-sans);
   color: var(--pd-fg-strong);
 }
 .co-greeting__body p:last-child {
@@ -136,7 +136,7 @@
   padding: 4px 0 4px 24px;
 }
 .co-greeting__factsHeading {
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -160,13 +160,13 @@
 }
 .co-greeting__factK {
   margin: 0;
-  font: 500 26px/1.05 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.05 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
 }
 .co-greeting__factL {
   margin: 4px 0 0;
-  font: 400 13px/1.4 var(--lt-sans);
+  font: 400 var(--lt-fs-xs)/1.4 var(--lt-sans);
   color: var(--pd-muted);
 }
 
@@ -204,7 +204,7 @@
   border-color: var(--pd-primary);
 }
 .co-timeline__date {
-  font: 500 13px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-primary);
   letter-spacing: 0.04em;
 }
@@ -214,7 +214,7 @@
   letter-spacing: 0;
 }
 .co-timeline__event {
-  font: 400 16px/1.5 var(--lt-sans);
+  font: 400 var(--lt-fs-md)/1.5 var(--lt-sans);
   color: var(--pd-fg-strong);
 }
 
@@ -240,12 +240,12 @@
 }
 .co-cert__name {
   margin: 0;
-  font: 600 22px/1.2 var(--lt-sans);
+  font: 600 var(--lt-fs-lg)/1.2 var(--lt-sans);
   color: var(--pd-fg-strong);
   letter-spacing: -0.01em;
 }
 .co-cert__date {
-  font: 500 12px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
   letter-spacing: 0.04em;
 }
@@ -256,19 +256,19 @@
 }
 .co-cert__issuer {
   margin: 0 0 10px;
-  font: 500 13px/1.4 var(--lt-sans);
+  font: 500 var(--lt-fs-xs)/1.4 var(--lt-sans);
   color: var(--pd-primary);
 }
 .co-cert__blurb {
   margin: 0;
-  font: 400 15px/1.55 var(--lt-sans);
+  font: 400 var(--lt-fs-sm)/1.55 var(--lt-sans);
   color: var(--pd-muted);
 }
 .co-certs__footnote {
   margin: 24px 0 0;
   padding: 16px 20px;
   border-left: 2px solid var(--pd-rule);
-  font: 400 14px/1.55 var(--lt-sans);
+  font: 400 var(--lt-fs-sm)/1.55 var(--lt-sans);
   color: var(--pd-muted);
   max-width: 720px;
 }
@@ -288,7 +288,7 @@
 }
 .co-office__heading {
   margin: 0 0 6px;
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -301,7 +301,7 @@
 }
 .co-office__name {
   margin: 0 0 14px;
-  font: 600 20px/1.25 var(--lt-sans);
+  font: 600 var(--lt-fs-lg)/1.25 var(--lt-sans);
   color: var(--pd-fg-strong);
   letter-spacing: -0.01em;
 }
@@ -309,7 +309,7 @@
   display: grid;
   grid-template-columns: 80px 1fr;
   gap: 8px 16px;
-  font: 400 15px/1.5 var(--lt-sans);
+  font: 400 var(--lt-fs-sm)/1.5 var(--lt-sans);
 }
 .co-office__label {
   color: var(--pd-muted);
@@ -359,7 +359,7 @@
     margin-top: 12px;
   }
   .co-sechd__title {
-    font-size: 28px;
+    font-size: 32px; /* mobile reduction */
   }
   .co-greeting__layout {
     grid-template-columns: 1fr;

--- a/src/components/home/Applications/Applications.css
+++ b/src/components/home/Applications/Applications.css
@@ -21,18 +21,18 @@
   background: var(--pd-surface-2);
 }
 .ho-applications__num {
-  font: 500 10.5px var(--lt-mono);
+  font: 600 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-primary);
   letter-spacing: 0.1em;
   margin-bottom: 18px;
 }
 .ho-applications__n {
-  font: 500 16px/1.25 var(--lt-sans);
+  font: 500 var(--lt-fs-md)/1.25 var(--lt-sans);
   color: var(--pd-fg-strong);
   letter-spacing: -0.005em;
 }
 .ho-applications__k {
-  font: 400 12px var(--lt-mono);
+  font: 400 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
 }
 

--- a/src/components/home/Contact/Contact.css
+++ b/src/components/home/Contact/Contact.css
@@ -30,14 +30,14 @@
 .ho-contact__title {
   position: relative;
   margin: 0 0 16px;
-  font: 500 44px/1.1 var(--lt-sans);
+  font: 500 var(--lt-fs-h2)/1.1 var(--lt-sans);
   letter-spacing: -0.02em;
 }
 .ho-contact__sub {
   position: relative;
   margin: 0 auto 32px;
   max-width: 540px;
-  font-size: 16px;
+  font-size: var(--lt-fs-md);
   line-height: 1.55;
   color: rgba(255, 255, 255, 0.72);
 }
@@ -63,6 +63,6 @@
     padding: 48px 24px;
   }
   .ho-contact__title {
-    font-size: 32px;
+    font-size: 36px;
   }
 }

--- a/src/components/home/Credentials/Credentials.css
+++ b/src/components/home/Credentials/Credentials.css
@@ -12,7 +12,7 @@
   padding: 14px 20px;
   border: 1px solid var(--pd-border-strong);
   border-radius: var(--pd-r-md);
-  font: 500 14px var(--lt-sans);
+  font: 500 var(--lt-fs-sm) var(--lt-sans);
   color: var(--pd-fg);
 }
 .ho-credentials__dot {

--- a/src/components/home/Feature/Feature.css
+++ b/src/components/home/Feature/Feature.css
@@ -6,7 +6,7 @@
   align-items: center;
 }
 .ho-feature__kicker {
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -14,14 +14,14 @@
 }
 .ho-feature__title {
   margin: 0 0 14px;
-  font: 500 52px/1 var(--lt-sans);
+  font: 500 var(--lt-fs-feature)/1 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
 }
 .ho-feature__sub {
   margin: 0 0 32px;
   max-width: 440px;
-  font-size: 16px;
+  font-size: var(--lt-fs-md);
   line-height: 1.55;
   color: var(--pd-muted);
 }
@@ -49,14 +49,14 @@
 }
 .ho-feature__bullet dt {
   margin: 0;
-  font: 500 11px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 .ho-feature__bullet dd {
   margin: 0;
-  font: 500 14px var(--lt-mono);
+  font: 500 var(--lt-fs-sm) var(--lt-mono);
   color: var(--pd-fg-strong);
   font-variant-numeric: tabular-nums;
 }
@@ -88,7 +88,7 @@
 .ho-feature__chip-bl,
 .ho-feature__chip-br {
   position: absolute;
-  font: 500 10.5px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
   letter-spacing: 0.08em;
 }
@@ -113,7 +113,7 @@
   z-index: 1;
 }
 .ho-feature__lbl {
-  font: 500 11px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   letter-spacing: 0.12em;
   color: var(--pd-muted);
 }
@@ -130,6 +130,6 @@
     grid-template-columns: 1fr;
   }
   .ho-feature__title {
-    font-size: 40px;
+    font-size: 44px; /* mobile reduction */
   }
 }

--- a/src/components/home/Intro/Intro.css
+++ b/src/components/home/Intro/Intro.css
@@ -10,7 +10,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font: 500 11.5px var(--lt-mono);
+  font: 600 var(--lt-fs-lg) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -18,7 +18,7 @@
 }
 .ho-intro__title {
   margin: 0 0 24px;
-  font: 500 72px/1.02 var(--lt-sans);
+  font: 500 var(--lt-fs-hero)/1.02 var(--lt-sans);
   letter-spacing: -0.03em;
   color: var(--pd-fg-strong);
   display: flex;
@@ -31,7 +31,7 @@
 .ho-intro__lede {
   margin: 0 0 32px;
   max-width: 520px;
-  font-size: 17px;
+  font-size: var(--lt-fs-md);
   line-height: 1.55;
   color: var(--pd-muted);
   text-wrap: pretty;
@@ -158,6 +158,6 @@
     padding: 48px 0 64px;
   }
   .ho-intro__title {
-    font-size: 52px;
+    font-size: var(--lt-fs-feature);
   }
 }

--- a/src/components/home/Intro/Intro.tsx
+++ b/src/components/home/Intro/Intro.tsx
@@ -11,7 +11,6 @@ export function Intro({ h }: Props) {
     <section className="ho-intro">
       <div className="ho-intro__left">
         <div className="ho-intro__kicker">
-          <Glyph name="dot" size={10} />
           <span>{h.intro.kicker}</span>
         </div>
         <h1 className="ho-intro__title">

--- a/src/components/home/Series/Series.css
+++ b/src/components/home/Series/Series.css
@@ -29,27 +29,27 @@
   justify-content: space-between;
 }
 .ho-series__code {
-  font: 600 13px var(--lt-mono);
+  font: 600 var(--lt-fs-xs) var(--lt-mono);
   letter-spacing: 0.08em;
   color: var(--pd-primary);
   text-transform: uppercase;
   white-space: nowrap;
 }
 .ho-series__count {
-  font: 500 11px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
   letter-spacing: 0.06em;
   white-space: nowrap;
 }
 .ho-series__name {
   margin: 0;
-  font: 500 22px/1.2 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.2 var(--lt-sans);
   letter-spacing: -0.015em;
   color: var(--pd-fg-strong);
 }
 .ho-series__desc {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--lt-fs-sm);
   color: var(--pd-muted);
   line-height: 1.55;
   flex: 1;
@@ -60,7 +60,7 @@
   justify-content: space-between;
   padding-top: 12px;
   border-top: 1px solid var(--pd-rule);
-  font: 500 12px var(--lt-mono);
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
 }
 .ho-series__range {
   color: var(--pd-fg);

--- a/src/components/home/Stats/Stats.css
+++ b/src/components/home/Stats/Stats.css
@@ -16,18 +16,18 @@
   border-right: 0;
 }
 .ho-stats__k {
-  font: 500 34px/1 var(--lt-sans);
+  font: 500 var(--lt-fs-xl)/1 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
   font-variant-numeric: tabular-nums;
   margin-bottom: 10px;
 }
 .ho-stats__l {
-  font: 500 13px var(--lt-sans);
+  font: 500 var(--lt-fs-sm) var(--lt-sans);
   color: var(--pd-fg);
 }
 .ho-stats__s {
-  font: 400 12px var(--lt-mono);
+  font: 400 var(--lt-fs-xs) var(--lt-mono);
   color: var(--pd-muted);
 }
 

--- a/src/components/home/home-shell.css
+++ b/src/components/home/home-shell.css
@@ -12,7 +12,7 @@
   margin-bottom: 40px;
 }
 .ho-sechd__kicker {
-  font: 500 11px var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -20,7 +20,7 @@
 }
 .ho-sechd__title {
   margin: 0 0 10px;
-  font: 500 40px/1.08 var(--lt-sans);
+  font: 500 var(--lt-fs-h2)/1.08 var(--lt-sans);
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
   max-width: 800px;
@@ -28,7 +28,7 @@
 .ho-sechd__sub {
   margin: 0;
   max-width: 620px;
-  font-size: 16px;
+  font-size: var(--lt-fs-md);
   color: var(--pd-muted);
   line-height: 1.5;
 }
@@ -46,6 +46,6 @@
     padding: 64px 0;
   }
   .ho-sechd__title {
-    font-size: 32px;
+    font-size: 36px; /* mobile reduction */
   }
 }

--- a/src/components/layout/Breadcrumbs.css
+++ b/src/components/layout/Breadcrumbs.css
@@ -1,7 +1,7 @@
 /* Line Tech — breadcrumb trail. Renders on product/category pages. */
 
 .lt-breadcrumbs {
-  font: 400 15px/1.4 var(--lt-sans);
+  font: 400 var(--lt-fs-sm)/1.4 var(--lt-sans);
   color: var(--pd-muted);
 }
 

--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -5,7 +5,7 @@
   margin-top: auto;
   background: var(--lt-neutral-100);
   color: var(--pd-muted);
-  font-size: 12px;
+  font-size: var(--lt-fs-xs);
   line-height: 1.55;
 }
 
@@ -35,7 +35,7 @@
 .pd-foot__sig {
   margin: 0;
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--lt-fs-xs);
   color: var(--pd-fg-strong);
   max-width: 36ch;
 }
@@ -47,7 +47,7 @@
 
 .pd-foot__heading {
   margin: 0 0 12px;
-  font: 600 11px/1 var(--lt-sans);
+  font: 600 var(--lt-fs-xs)/1 var(--lt-sans);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--pd-fg-strong);
@@ -77,7 +77,7 @@
 .pd-foot__label {
   flex: 0 0 28px;
   font-family: var(--lt-mono);
-  font-size: 10.5px;
+  font-size: var(--lt-fs-xs);
   letter-spacing: 0.06em;
   color: var(--pd-muted);
 }
@@ -107,7 +107,7 @@
   display: flex;
   align-items: baseline;
   gap: 18px;
-  font-size: 11.5px;
+  font-size: var(--lt-fs-xs);
 }
 
 @media (max-width: 640px) {

--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -52,7 +52,7 @@
 }
 
 .pd-top__wordmark {
-  font: 700 18px/1 var(--lt-sans);
+  font: 700 var(--lt-fs-md)/1 var(--lt-sans);
   letter-spacing: 0.01em;
   color: var(--pd-primary);
 }

--- a/src/components/layout/HeaderNav.css
+++ b/src/components/layout/HeaderNav.css
@@ -16,7 +16,7 @@
   border: 0;
   background: transparent;
   cursor: pointer;
-  font: 600 16px var(--lt-sans);
+  font: 600 var(--lt-fs-sm) var(--lt-sans);
   color: var(--pd-fg);
   padding: 0 16px;
   height: 100%;

--- a/src/components/layout/LocaleSwitcher.css
+++ b/src/components/layout/LocaleSwitcher.css
@@ -18,7 +18,7 @@
   background: transparent;
   border: 0;
   color: var(--pd-muted);
-  font: 500 12px/1 var(--lt-sans);
+  font: 500 var(--lt-fs-xs)/1 var(--lt-sans);
   letter-spacing: 0.04em;
   padding: 8px 14px;
   border-radius: 999px;

--- a/src/components/layout/MegaMenu.css
+++ b/src/components/layout/MegaMenu.css
@@ -39,7 +39,7 @@
 }
 
 .pd-mega__heading {
-  font: 600 12px/1 var(--lt-sans);
+  font: 600 var(--lt-fs-xs)/1 var(--lt-sans);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--pd-muted);
@@ -86,10 +86,10 @@
 }
 
 .pd-mega__link-label {
-  font: 600 14px/1.2 var(--lt-sans);
+  font: 600 var(--lt-fs-sm)/1.2 var(--lt-sans);
 }
 .pd-mega__link-desc {
-  font: 400 12px/1.3 var(--lt-sans);
+  font: 400 var(--lt-fs-xs)/1.3 var(--lt-sans);
   color: var(--pd-muted);
 }
 
@@ -118,23 +118,23 @@
 }
 
 .pd-mega__featured-eyebrow {
-  font: 600 10px/1 var(--lt-sans);
+  font: 600 var(--lt-fs-xs)/1 var(--lt-sans);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--pd-primary);
 }
 .pd-mega__featured-title {
-  font: 700 15px/1.2 var(--lt-sans);
+  font: 700 var(--lt-fs-sm)/1.2 var(--lt-sans);
   color: var(--pd-fg-strong);
   margin-top: 3px;
 }
 .pd-mega__featured-blurb {
-  font: 400 12px/1.4 var(--lt-sans);
+  font: 400 var(--lt-fs-xs)/1.4 var(--lt-sans);
   color: var(--pd-muted);
   margin-top: 2px;
 }
 .pd-mega__featured-cta {
-  font: 600 12px/1 var(--lt-sans);
+  font: 600 var(--lt-fs-xs)/1 var(--lt-sans);
   color: var(--pd-primary);
   margin-top: 6px;
 }
@@ -142,7 +142,7 @@
 .pd-mega__all {
   display: inline-block;
   margin-top: 8px;
-  font: 600 13px/1 var(--lt-sans);
+  font: 600 var(--lt-fs-xs)/1 var(--lt-sans);
   color: var(--pd-primary);
   text-decoration: none;
 }

--- a/src/components/layout/SearchPanel.css
+++ b/src/components/layout/SearchPanel.css
@@ -74,7 +74,7 @@
   border-radius: var(--pd-r-lg);
   background: transparent;
   color: var(--pd-fg-strong);
-  font: 500 14px/1.4 var(--lt-sans);
+  font: 500 var(--lt-fs-sm)/1.4 var(--lt-sans);
   outline: 0;
   transition:
     border-color 0.15s ease,
@@ -109,7 +109,7 @@
   border-radius: 999px;
   background: var(--pd-surface);
   color: var(--pd-fg);
-  font: 500 12px/1 var(--lt-sans);
+  font: 500 var(--lt-fs-xs)/1 var(--lt-sans);
   cursor: pointer;
   transition:
     border-color 0.15s ease,
@@ -147,7 +147,7 @@
 
   .pd-search__input {
     height: 40px;
-    font-size: 14px;
+    font-size: var(--lt-fs-sm);
   }
 }
 

--- a/src/components/ui/Chip/Chip.css
+++ b/src/components/ui/Chip/Chip.css
@@ -3,9 +3,9 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 10px;
+  padding: 4px 11px;
   border-radius: 999px;
-  font-size: 11.5px;
+  font-size: var(--lt-fs-xs);
   font-weight: 500;
   line-height: 1.4;
   border: 1px solid var(--pd-border);
@@ -13,7 +13,7 @@
   color: var(--pd-fg);
 }
 .lt-chip--sm {
-  font-size: 11px;
+  font-size: var(--lt-fs-xs);
   padding: 2px 9px;
 }
 .lt-chip__dot {


### PR DESCRIPTION
## Summary
- Triggered by the home hero kicker (\`1997년부터 · 질량유량 측정 솔루션\`) reading too small. Audit found 16 different font-sizes scattered sitewide, with the floor at 10.5–12px — anemic on Korean since JetBrains Mono falls back to sans for Hangul, killing the uppercase tracking.
- Define a 9-step type scale in \`globals.css\` (\`--lt-fs-{xs,sm,md,lg,xl,h2-dense,h2,feature,hero}\`) and refactor every component CSS to reference tokens instead of literal px. Mobile breakpoint reductions kept as literals.
- Drop the redundant leading dot glyph in the home hero kicker; the middle-dot in the text already separates the two phrases.
- Header chrome (wordmark, nav) pulled into the same scale on top of #46's presence bump — main's weight/height/logomark changes preserved (those are the real presence drivers); only font-size snaps to tokens.

Net: 16 sizes → 9 scale steps. Floor 10.5/11/12 → 13. Body 14 → 15. Future tweaks are one-line edits in globals.css.

## Test plan
- [ ] Home (\`/ko\`, \`/en\`, \`/zh\`) — hero kicker, section eyebrows, stats, series cards, applications grid, M3030VA feature, credentials, contact CTA all read at the new scale
- [ ] Company (\`/ko/company\`) — side-nav heading, fact numbers, timeline, certs, office cards
- [ ] Contact (\`/ko/contact\`) — page title, info card, form labels, distributors, map
- [ ] Header chrome — top nav, wordmark, locale switcher, search panel, mega menu (hover 제품)
- [ ] Footer — bottom of any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)