### PR TITLE
feat(header): full-screen mobile nav panel below 1000px

### DIFF
--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -100,6 +100,10 @@
   display: inline-block;
 }
 
+.pd-top__hamburger {
+  display: none;
+}
+
 @media (max-width: 1000px) {
   .pd-top {
     --pd-top-h: 60px;
@@ -108,5 +112,13 @@
   .pd-top__inner {
     padding: 0 16px;
     gap: 12px;
+  }
+  .pd-top__divider,
+  .pd-top__right .lt-locale,
+  .pd-top__right .lt-btn {
+    display: none;
+  }
+  .pd-top__hamburger {
+    display: inline-flex;
   }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { LocaleSwitcher } from "./LocaleSwitcher";
 import { Logomark } from "./Logomark";
 import { MegaMenu, MegaMenuScrim } from "./MegaMenu";
 import { SearchTriggerButton } from "./SearchTriggerButton";
+import { MobileNavTrigger } from "./MobileNavTrigger";
 import "./Header.css";
 
 type Props = { locale: Locale };
@@ -16,7 +17,13 @@ export function Header({ locale }: Props) {
   const shell = LT_SHELL[locale];
 
   return (
-    <HeaderShell search={shell.search}>
+    <HeaderShell
+      search={shell.search}
+      mobileNav={shell.mobileNav}
+      navItems={shell.nav}
+      quoteLabel={shell.quoteLabel}
+      locale={locale}
+    >
       <div className="pd-top__inner">
         <Link href="/" className="pd-top__brand" aria-label="Line Tech">
           <span className="pd-top__logomark">
@@ -45,6 +52,10 @@ export function Header({ locale }: Props) {
           >
             {shell.quoteLabel}
           </Button>
+          <MobileNavTrigger
+            openLabel={shell.mobileNav.openLabel}
+            closeLabel={shell.mobileNav.closeLabel}
+          />
         </div>
       </div>
       <MegaMenu items={shell.nav} locale={locale} />

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -4,7 +4,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SearchPanel } from "./SearchPanel";
 import { SearchProvider, type SearchCtx } from "./SearchContext";
 import { HeaderNavProvider, type HeaderNavCtx } from "./HeaderNavContext";
-import type { ShellSearch } from "@/lib/content/shell";
+import { MobileNavProvider, type MobileNavCtx } from "./MobileNavContext";
+import { MobileNav } from "./MobileNav";
+import type {
+  ShellSearch,
+  ShellMobileNav,
+  ShellNavItem,
+} from "@/lib/content/shell";
+import type { Locale } from "@/lib/content/home";
 
 const SCROLL_ON = 40;
 const SCROLL_OFF = 30;
@@ -14,13 +21,26 @@ const CLOSE_DELAY = 120;
 type Props = {
   children: React.ReactNode;
   search: ShellSearch;
+  mobileNav: ShellMobileNav;
+  navItems: ShellNavItem[];
+  quoteLabel: string;
+  locale: Locale;
 };
 
-export function HeaderShell({ children, search }: Props) {
+export function HeaderShell({
+  children,
+  search,
+  mobileNav,
+  navItems,
+  quoteLabel,
+  locale,
+}: Props) {
   const [scrolled, setScrolled] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [openId, setOpenId] = useState<string | null>(null);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const mobileNavTriggerRef = useRef<HTMLButtonElement | null>(null);
   const openTimer = useRef<number | null>(null);
   const closeTimer = useRef<number | null>(null);
 
@@ -54,9 +74,25 @@ export function HeaderShell({ children, search }: Props) {
     triggerRef.current = el;
   }, []);
 
+  const registerMobileNavTrigger = useCallback(
+    (el: HTMLButtonElement | null) => {
+      mobileNavTriggerRef.current = el;
+    },
+    [],
+  );
+
   const searchCtx = useMemo<SearchCtx>(
     () => ({ searchOpen, setSearchOpen, registerSearchTrigger }),
     [searchOpen, registerSearchTrigger],
+  );
+
+  const mobileNavCtx = useMemo<MobileNavCtx>(
+    () => ({
+      mobileNavOpen,
+      setMobileNavOpen,
+      registerMobileNavTrigger,
+    }),
+    [mobileNavOpen, registerMobileNavTrigger],
   );
 
   const navCtx = useMemo<HeaderNavCtx>(() => {
@@ -107,6 +143,7 @@ export function HeaderShell({ children, search }: Props) {
     scrolled && "is-scrolled",
     searchOpen && "is-searchopen",
     openId && "is-menuopen",
+    mobileNavOpen && "is-mnavopen",
   ]
     .filter(Boolean)
     .join(" ");
@@ -114,15 +151,26 @@ export function HeaderShell({ children, search }: Props) {
   return (
     <SearchProvider value={searchCtx}>
       <HeaderNavProvider value={navCtx}>
-        <header className={cls}>
-          {children}
-          <SearchPanel
-            content={search}
-            open={searchOpen}
-            onClose={() => setSearchOpen(false)}
-            triggerRef={triggerRef}
-          />
-        </header>
+        <MobileNavProvider value={mobileNavCtx}>
+          <header className={cls}>
+            {children}
+            <SearchPanel
+              content={search}
+              open={searchOpen}
+              onClose={() => setSearchOpen(false)}
+              triggerRef={triggerRef}
+            />
+            <MobileNav
+              items={navItems}
+              locale={locale}
+              heading={mobileNav.heading}
+              quoteLabel={quoteLabel}
+              open={mobileNavOpen}
+              onClose={() => setMobileNavOpen(false)}
+              triggerRef={mobileNavTriggerRef}
+            />
+          </header>
+        </MobileNavProvider>
       </HeaderNavProvider>
     </SearchProvider>
   );

--- a/src/components/layout/MobileNav.css
+++ b/src/components/layout/MobileNav.css
@@ -1,0 +1,169 @@
+/* Line Tech — full-screen mobile nav panel (#34).
+ * Renders only below 1000px; covers the viewport beneath the sticky header. */
+
+.pd-mnav {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+  display: none;
+}
+
+@media (max-width: 1000px) {
+  .pd-mnav {
+    display: block;
+  }
+}
+
+.pd-mnav.is-open {
+  pointer-events: auto;
+}
+
+.pd-mnav__panel {
+  position: absolute;
+  top: var(--pd-top-h);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--pd-bg);
+  transform: translateY(-8px);
+  opacity: 0;
+  transition:
+    transform 0.18s ease,
+    opacity 0.14s ease;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.pd-top.is-scrolled .pd-mnav__panel {
+  top: var(--pd-top-h-scrolled);
+}
+
+.pd-mnav.is-open .pd-mnav__panel {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.pd-mnav__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 16px 16px 32px;
+  max-width: 480px;
+  margin: 0 auto;
+  min-height: 100%;
+  box-sizing: border-box;
+}
+
+.pd-mnav__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pd-mnav__nav {
+  flex: 0 0 auto;
+}
+
+.pd-mnav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pd-mnav__item {
+  border-bottom: 1px solid var(--pd-border);
+}
+
+.pd-mnav__link {
+  display: block;
+  padding: 16px 4px;
+  color: var(--pd-fg-strong);
+  font: 600 16px/1.3 var(--lt-sans);
+  text-decoration: none;
+}
+.pd-mnav__link:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.pd-mnav__group-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 16px 4px;
+  border: 0;
+  background: transparent;
+  color: var(--pd-fg-strong);
+  font: 600 16px/1.3 var(--lt-sans);
+  cursor: pointer;
+  text-align: left;
+}
+.pd-mnav__group-trigger:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.pd-mnav__chev {
+  flex: 0 0 auto;
+  color: var(--pd-muted);
+  transition: transform 0.18s ease;
+}
+
+.pd-mnav__group-trigger[aria-expanded="true"] .pd-mnav__chev {
+  transform: rotate(180deg);
+}
+
+.pd-mnav__group-body {
+  padding-bottom: 8px;
+}
+
+.pd-mnav__sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 4px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pd-mnav__sublink {
+  display: block;
+  padding: 10px 4px;
+  color: var(--pd-fg);
+  font: 500 14px/1.3 var(--lt-sans);
+  text-decoration: none;
+}
+.pd-mnav__sublink:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.pd-mnav__sublink--all {
+  color: var(--pd-primary);
+  font-weight: 600;
+}
+
+.pd-mnav__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--pd-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pd-mnav__panel,
+  .pd-mnav__chev {
+    transition: none;
+  }
+}

--- a/src/components/layout/MobileNav.test.tsx
+++ b/src/components/layout/MobileNav.test.tsx
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, within, act } from "@testing-library/react";
+import { useRef } from "react";
+import { MobileNav } from "./MobileNav";
+import { LT_SHELL, getProductsCategories } from "@/lib/content/shell";
+
+let pathnameValue = "/";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: { href: unknown; children: React.ReactNode } & Record<
+    string,
+    unknown
+  >) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+  usePathname: () => pathnameValue,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  routing: { locales: ["ko", "en", "zh"] },
+}));
+
+beforeEach(() => {
+  pathnameValue = "/";
+  document.body.innerHTML = "";
+  document.body.style.overflow = "";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function Harness({
+  open,
+  onClose = vi.fn(),
+}: {
+  open: boolean;
+  onClose?: () => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  return (
+    <>
+      <button ref={triggerRef}>trigger</button>
+      <MobileNav
+        items={LT_SHELL.en.nav}
+        locale="en"
+        heading={LT_SHELL.en.mobileNav.heading}
+        quoteLabel={LT_SHELL.en.quoteLabel}
+        open={open}
+        onClose={onClose}
+        triggerRef={triggerRef}
+      />
+    </>
+  );
+}
+
+describe("MobileNav", () => {
+  it("renders all 4 top-level nav items, locale switcher, and Quote button", () => {
+    const { container } = render(<Harness open={true} />);
+
+    LT_SHELL.en.nav.forEach((item) => {
+      expect(
+        within(container).getByText(item.label, { exact: true }),
+      ).toBeInTheDocument();
+    });
+    expect(container.querySelector(".lt-locale")).toBeInTheDocument();
+    expect(within(container).getByText("Quote")).toBeInTheDocument();
+  });
+
+  it("menu items render as accordion triggers, contact renders as a link", () => {
+    const { container } = render(<Harness open={true} />);
+
+    const productsBtn = container.querySelector(
+      '[aria-controls="pd-mnav-section-products"]',
+    );
+    expect(productsBtn?.tagName).toBe("BUTTON");
+    expect(productsBtn).toHaveAttribute("aria-expanded", "false");
+
+    const contact = LT_SHELL.en.nav.find((i) => !i.menu);
+    if (!contact) throw new Error("expected a non-menu nav item");
+    const link = container.querySelector(`a[href="${contact.href}"]`);
+    expect(link?.tagName).toBe("A");
+  });
+
+  it("clicking an accordion trigger toggles aria-expanded and reveals sub-items", () => {
+    const { container } = render(<Harness open={true} />);
+
+    const trigger = container.querySelector(
+      '[aria-controls="pd-mnav-section-products"]',
+    ) as HTMLButtonElement;
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    const body = container.querySelector(
+      "#pd-mnav-section-products",
+    ) as HTMLElement;
+    expect(body).toHaveAttribute("hidden");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(body).not.toHaveAttribute("hidden");
+
+    const cats = getProductsCategories("en");
+    cats.forEach((c) => {
+      expect(within(body).getByText(c.label)).toBeInTheDocument();
+    });
+    expect(within(body).getByText("See all products")).toBeInTheDocument();
+  });
+
+  it("Resources accordion reveals 4 resource links (no products 'all' link)", () => {
+    const { container } = render(<Harness open={true} />);
+
+    const trigger = container.querySelector(
+      '[aria-controls="pd-mnav-section-resources"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(trigger);
+
+    const body = container.querySelector(
+      "#pd-mnav-section-resources",
+    ) as HTMLElement;
+    ["Catalogues", "CAD drawings", "Manuals", "Certifications"].forEach(
+      (label) => {
+        expect(within(body).getByText(label)).toBeInTheDocument();
+      },
+    );
+    expect(
+      within(body).queryByText(/See all products/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Esc key calls onClose when open", () => {
+    const onClose = vi.fn();
+    render(<Harness open={true} onClose={onClose} />);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on route change (pathname differs from initial)", () => {
+    const onClose = vi.fn();
+    pathnameValue = "/";
+    const { rerender } = render(<Harness open={true} onClose={onClose} />);
+
+    pathnameValue = "/products";
+    act(() => {
+      rerender(<Harness open={true} onClose={onClose} />);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose on initial mount with stable pathname", () => {
+    const onClose = vi.fn();
+    pathnameValue = "/anywhere";
+    render(<Harness open={true} onClose={onClose} />);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("is inert when closed", () => {
+    const { container } = render(<Harness open={false} />);
+    const root = container.querySelector(".pd-mnav") as HTMLElement;
+    expect(root).toHaveAttribute("inert");
+  });
+
+  it("is not inert when open", () => {
+    const { container } = render(<Harness open={true} />);
+    const root = container.querySelector(".pd-mnav") as HTMLElement;
+    expect(root).not.toHaveAttribute("inert");
+  });
+});

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useId, useRef, useState, type RefObject } from "react";
+import { Link, usePathname } from "@/i18n/navigation";
+import { Button } from "@/components/ui/Button";
+import { getProductsCategories, type ShellNavItem } from "@/lib/content/shell";
+import type { Locale } from "@/lib/content/home";
+import { useDialogPanel } from "@/lib/hooks/useDialogPanel";
+import { LocaleSwitcher } from "./LocaleSwitcher";
+import "./MobileNav.css";
+
+const PANEL_ID = "lt-mobile-nav-panel";
+
+type Props = {
+  items: ShellNavItem[];
+  locale: Locale;
+  heading: string;
+  quoteLabel: string;
+  open: boolean;
+  onClose: () => void;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+};
+
+export function MobileNav({
+  items,
+  locale,
+  heading,
+  quoteLabel,
+  open,
+  onClose,
+  triggerRef,
+}: Props) {
+  const headingId = useId();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const pathname = usePathname();
+  const prevPathname = useRef(pathname);
+
+  useDialogPanel({ open, onClose, panelRef, triggerRef });
+
+  useEffect(() => {
+    if (!open) return;
+    const id = window.requestAnimationFrame(() => {
+      const first = panelRef.current?.querySelector<HTMLElement>(
+        "a[href], button:not([disabled])",
+      );
+      first?.focus();
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open]);
+
+  // Close on route change. Compare against previous so the initial mount
+  // doesn't fire a spurious close.
+  useEffect(() => {
+    if (prevPathname.current !== pathname) {
+      prevPathname.current = pathname;
+      onClose();
+    }
+  }, [pathname, onClose]);
+
+  const toggle = (id: string) =>
+    setExpanded((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const rootCls = ["pd-mnav", open && "is-open"].filter(Boolean).join(" ");
+
+  return (
+    <div className={rootCls} inert={!open}>
+      <div
+        ref={panelRef}
+        id={PANEL_ID}
+        className="pd-mnav__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+      >
+        <div className="pd-mnav__inner">
+          <h2 id={headingId} className="pd-mnav__sr">
+            {heading}
+          </h2>
+
+          <nav aria-label="Primary" className="pd-mnav__nav">
+            <ul className="pd-mnav__list">
+              {items.map((item) =>
+                item.menu ? (
+                  <AccordionItem
+                    key={item.id}
+                    item={item}
+                    locale={locale}
+                    isOpen={expanded.has(item.id)}
+                    onToggle={() => toggle(item.id)}
+                  />
+                ) : (
+                  <li key={item.id} className="pd-mnav__item">
+                    <Link href={item.href} className="pd-mnav__link">
+                      {item.label}
+                    </Link>
+                  </li>
+                ),
+              )}
+            </ul>
+          </nav>
+
+          <div className="pd-mnav__footer">
+            <LocaleSwitcher />
+            <Button
+              variant="primary"
+              size="md"
+              href="mailto:linetech@line-tech.co.kr"
+              plain
+            >
+              {quoteLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccordionItem({
+  item,
+  locale,
+  isOpen,
+  onToggle,
+}: {
+  item: ShellNavItem;
+  locale: Locale;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const sectionId = `pd-mnav-section-${item.id}`;
+  const menu = item.menu;
+  if (!menu) return null;
+
+  const sublinks =
+    menu.kind === "products"
+      ? getProductsCategories(locale).map((c) => ({
+          href: c.href,
+          label: c.label,
+        }))
+      : menu.links.map((l) => ({ href: l.href, label: l.label }));
+
+  return (
+    <li className="pd-mnav__item pd-mnav__group">
+      <button
+        type="button"
+        className="pd-mnav__group-trigger"
+        aria-expanded={isOpen}
+        aria-controls={sectionId}
+        onClick={onToggle}
+      >
+        <span>{item.label}</span>
+        <svg
+          className="pd-mnav__chev"
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 5l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+      <div id={sectionId} className="pd-mnav__group-body" hidden={!isOpen}>
+        <ul className="pd-mnav__sublist">
+          {menu.kind === "products" && (
+            <li>
+              <Link
+                href={menu.allHref}
+                className="pd-mnav__sublink pd-mnav__sublink--all"
+              >
+                {menu.allLabel}
+              </Link>
+            </li>
+          )}
+          {sublinks.map((l) => (
+            <li key={l.href}>
+              <Link href={l.href} className="pd-mnav__sublink">
+                {l.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </li>
+  );
+}

--- a/src/components/layout/MobileNavContext.tsx
+++ b/src/components/layout/MobileNavContext.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export type MobileNavCtx = {
+  mobileNavOpen: boolean;
+  setMobileNavOpen: (open: boolean) => void;
+  /** Register the trigger so the panel can return focus on close. */
+  registerMobileNavTrigger: (el: HTMLButtonElement | null) => void;
+};
+
+const Ctx = createContext<MobileNavCtx | null>(null);
+
+export const MobileNavProvider = Ctx.Provider;
+
+export function useMobileNav(): MobileNavCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useMobileNav must be used inside <HeaderShell>");
+  }
+  return ctx;
+}

--- a/src/components/layout/MobileNavTrigger.tsx
+++ b/src/components/layout/MobileNavTrigger.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useMobileNav } from "./MobileNavContext";
+
+const PANEL_ID = "lt-mobile-nav-panel";
+
+type Props = {
+  openLabel: string;
+  closeLabel: string;
+};
+
+export function MobileNavTrigger({ openLabel, closeLabel }: Props) {
+  const { mobileNavOpen, setMobileNavOpen, registerMobileNavTrigger } =
+    useMobileNav();
+  const ref = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    registerMobileNavTrigger(ref.current);
+    return () => registerMobileNavTrigger(null);
+  }, [registerMobileNavTrigger]);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className="pd-top__iconbtn pd-top__hamburger"
+      aria-label={mobileNavOpen ? closeLabel : openLabel}
+      aria-haspopup="dialog"
+      aria-expanded={mobileNavOpen}
+      aria-controls={PANEL_ID}
+      onClick={() => setMobileNavOpen(!mobileNavOpen)}
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 18 18"
+        fill="none"
+        aria-hidden="true"
+      >
+        {mobileNavOpen ? (
+          <>
+            <path
+              d="M4 4l10 10"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M14 4L4 14"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </>
+        ) : (
+          <>
+            <path
+              d="M3 5h12"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M3 9h12"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M3 13h12"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </>
+        )}
+      </svg>
+    </button>
+  );
+}

--- a/src/components/layout/SearchPanel.tsx
+++ b/src/components/layout/SearchPanel.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type RefObject,
-} from "react";
+import { useEffect, useId, useRef, useState, type RefObject } from "react";
 import type { ShellSearch } from "@/lib/content/shell";
+import { useDialogPanel } from "@/lib/hooks/useDialogPanel";
 import "./SearchPanel.css";
 
 type Props = {
@@ -32,68 +26,13 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useState("");
 
+  useDialogPanel({ open, onClose, panelRef, triggerRef });
+
   useEffect(() => {
     if (!open) return;
     const id = window.requestAnimationFrame(() => inputRef.current?.focus());
     return () => window.cancelAnimationFrame(id);
   }, [open]);
-
-  // Restore focus + clear input when closing (only if we were previously open).
-  const wasOpenRef = useRef(false);
-  useEffect(() => {
-    if (open) {
-      wasOpenRef.current = true;
-      return;
-    }
-    if (wasOpenRef.current) {
-      wasOpenRef.current = false;
-      setValue("");
-      const id = window.requestAnimationFrame(() =>
-        triggerRef.current?.focus(),
-      );
-      return () => window.cancelAnimationFrame(id);
-    }
-  }, [open, triggerRef]);
-
-  useEffect(() => {
-    if (!open) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  // Tab trap across the panel's focusable controls.
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key !== "Tab" || !panelRef.current) return;
-      const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-        'input, button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    },
-    [],
-  );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -116,7 +55,6 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
         role="dialog"
         aria-modal="true"
         aria-labelledby={headingId}
-        onKeyDown={handleKeyDown}
       >
         <div className="pd-search__inner">
           <h2 id={headingId} className="pd-search__sr">

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -113,6 +113,16 @@ export type ShellSearch = {
   quickChips: { id: string; label: string }[];
 };
 
+/** Mobile nav panel copy (#34). Renders below 1000px. */
+export type ShellMobileNav = {
+  /** aria-label on the hamburger trigger when the panel is closed. */
+  openLabel: string;
+  /** aria-label on the hamburger trigger when the panel is open. */
+  closeLabel: string;
+  /** Dialog accessible name (visually-hidden, exposed via aria-labelledby). */
+  heading: string;
+};
+
 export type ShellContent = {
   nav: ShellNavItem[];
   /** Top-right "Quote" button label in the header. Mailto target is shared. */
@@ -121,6 +131,8 @@ export type ShellContent = {
   productsCategories: ProductsCategory[];
   /** Header search panel copy (#8). */
   search: ShellSearch;
+  /** Mobile nav panel copy (#34). */
+  mobileNav: ShellMobileNav;
   footer: ShellFooter;
 };
 
@@ -289,6 +301,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "certifications", label: "인증서" },
       ],
     },
+    mobileNav: {
+      openLabel: "메뉴 열기",
+      closeLabel: "메뉴 닫기",
+      heading: "사이트 메뉴",
+    },
     footer: {
       signoff: "정밀 질량유량 솔루션",
       contact: {
@@ -453,6 +470,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "certifications", label: "Certifications" },
       ],
     },
+    mobileNav: {
+      openLabel: "Open menu",
+      closeLabel: "Close menu",
+      heading: "Site menu",
+    },
     footer: {
       signoff: "Mass Flow Solutions",
       contact: {
@@ -604,6 +626,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "calibration", label: "校准" },
         { id: "certifications", label: "认证文件" },
       ],
+    },
+    mobileNav: {
+      openLabel: "打开菜单",
+      closeLabel: "关闭菜单",
+      heading: "站点菜单",
     },
     footer: {
       signoff: "精密质量流量解决方案",

--- a/src/lib/hooks/useDialogPanel.test.ts
+++ b/src/lib/hooks/useDialogPanel.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { useDialogPanel } from "./useDialogPanel";
+
+function setupPanel() {
+  const panel = document.createElement("div");
+  const a = document.createElement("button");
+  a.textContent = "first";
+  const b = document.createElement("button");
+  b.textContent = "middle";
+  const c = document.createElement("button");
+  c.textContent = "last";
+  panel.append(a, b, c);
+  document.body.append(panel);
+  return { panel, first: a, middle: b, last: c };
+}
+
+function setupTrigger() {
+  const t = document.createElement("button");
+  t.textContent = "trigger";
+  document.body.append(t);
+  return t;
+}
+
+const flushRaf = () => new Promise((resolve) => setTimeout(resolve, 32));
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.body.style.overflow = "";
+});
+
+function renderDialog(opts: {
+  open: boolean;
+  onClose: () => void;
+  panel: HTMLElement;
+  trigger: HTMLElement;
+}) {
+  return renderHook(
+    ({ open }) => {
+      const panelRef = useRef<HTMLElement | null>(opts.panel);
+      const triggerRef = useRef<HTMLElement | null>(opts.trigger);
+      useDialogPanel({ open, onClose: opts.onClose, panelRef, triggerRef });
+    },
+    { initialProps: { open: opts.open } },
+  );
+}
+
+describe("useDialogPanel", () => {
+  it("locks body scroll while open and restores on close", () => {
+    document.body.style.overflow = "scroll";
+    const { panel } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+
+    const { rerender } = renderDialog({ open: true, onClose, panel, trigger });
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender({ open: false });
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("Escape calls onClose when open", () => {
+    const { panel } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+    renderDialog({ open: true, onClose, panel, trigger });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape is a no-op when closed", () => {
+    const { panel } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+    renderDialog({ open: false, onClose, panel, trigger });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("returns focus to trigger after open→close", async () => {
+    const { panel } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+    const { rerender } = renderDialog({
+      open: true,
+      onClose,
+      panel,
+      trigger,
+    });
+
+    rerender({ open: false });
+    await flushRaf();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not steal focus on initial closed render", async () => {
+    const { panel } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+
+    const elsewhere = document.createElement("button");
+    document.body.append(elsewhere);
+    elsewhere.focus();
+
+    renderDialog({ open: false, onClose, panel, trigger });
+    await flushRaf();
+    expect(document.activeElement).toBe(elsewhere);
+  });
+
+  it("Tab on last focusable wraps to first", () => {
+    const { panel, first, last } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+    renderDialog({ open: true, onClose, panel, trigger });
+
+    last.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("Shift+Tab on first focusable wraps to last", () => {
+    const { panel, first, last } = setupPanel();
+    const trigger = setupTrigger();
+    const onClose = vi.fn();
+    renderDialog({ open: true, onClose, panel, trigger });
+
+    first.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/src/lib/hooks/useDialogPanel.ts
+++ b/src/lib/hooks/useDialogPanel.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+type Options = {
+  open: boolean;
+  onClose: () => void;
+  panelRef: RefObject<HTMLElement | null>;
+  triggerRef: RefObject<HTMLElement | null>;
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Wires the four behaviors every modal/panel dialog in this codebase needs:
+ *   - Body scroll lock while open
+ *   - Escape key closes
+ *   - Tab cycles within the panel (focus trap)
+ *   - Focus returns to the trigger when the panel closes
+ *
+ * Components keep their own auto-focus-on-open since the focus target differs
+ * per dialog (search focuses an input, mobile nav focuses the first link).
+ */
+export function useDialogPanel({
+  open,
+  onClose,
+  panelRef,
+  triggerRef,
+}: Options) {
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    panel.addEventListener("keydown", onKey);
+    return () => panel.removeEventListener("keydown", onKey);
+  }, [open, panelRef]);
+
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      return;
+    }
+    if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      const id = window.requestAnimationFrame(() =>
+        triggerRef.current?.focus(),
+      );
+      return () => window.cancelAnimationFrame(id);
+    }
+  }, [open, triggerRef]);
+}


### PR DESCRIPTION
Closes #34.

## Summary

- Adds hamburger trigger + full-screen mobile nav panel that renders below the 1000px breakpoint where the desktop header was previously hiding without a fallback.
- Panel contains the 4 top-level nav items (with mega-menu sections rendered as accordions), the locale switcher, and the Quote button. Search trigger stays visible in the header.
- Extracts the focus-trap / Esc / scroll-lock / focus-restore primitives into a new `useDialogPanel` hook in `src/lib/hooks/`. `SearchPanel` switched over in the same change so both dialogs share one implementation.

## Test plan

- [ ] Resize across the 1000px breakpoint — desktop header unchanged above; hamburger appears below
- [ ] Tap hamburger → full-screen panel slides down; tap again or hit Esc → closes
- [ ] Each menu item expands its accordion (Products = 4 categories + "see all"; Resources / Company = 4 links each); Contact is a direct link
- [ ] Tab cycles only within the panel; focus returns to the hamburger on close
- [ ] Tap any nav link → panel closes on route change
- [ ] All 3 locales (ko / en / zh) render with localized labels
- [ ] `prefers-reduced-motion: reduce` removes the slide motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)