### PR TITLE
feat(contact): pre-fill form when arriving from a product page

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -2,12 +2,23 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
-import type { ContactFormCopy } from "@/lib/content/contact";
+import type { ContactFormCopy, InquiryTypeId } from "@/lib/content/contact";
 
-type Props = { form: ContactFormCopy; privacyNotice: string };
+type ContactFormDefaults = {
+  inquiryType: InquiryTypeId;
+  extraField: string;
+  subject: string;
+  message: string;
+};
 
-export function ContactForm({ form, privacyNotice }: Props) {
-  const [type, setType] = useState<string>("");
+type Props = {
+  form: ContactFormCopy;
+  privacyNotice: string;
+  defaults?: ContactFormDefaults;
+};
+
+export function ContactForm({ form, privacyNotice, defaults }: Props) {
+  const [type, setType] = useState<string>(defaults?.inquiryType ?? "");
   const selected = form.inquiryTypeOptions.find((o) => o.id === type);
   const extra = selected?.extraField;
 
@@ -60,6 +71,9 @@ export function ContactForm({ form, privacyNotice }: Props) {
               type="text"
               required={extra.required}
               placeholder={extra.placeholder}
+              defaultValue={
+                type === defaults?.inquiryType ? defaults.extraField : undefined
+              }
               className="ct-form__input"
             />
           </div>
@@ -138,6 +152,7 @@ export function ContactForm({ form, privacyNotice }: Props) {
             name="subject"
             type="text"
             placeholder={form.placeholders.subject}
+            defaultValue={defaults?.subject}
             className="ct-form__input"
           />
         </div>
@@ -155,6 +170,7 @@ export function ContactForm({ form, privacyNotice }: Props) {
             required
             rows={6}
             placeholder={form.placeholders.message}
+            defaultValue={defaults?.message}
             className="ct-form__textarea"
           />
         </div>

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -5,6 +5,9 @@ import { Button } from "@/components/ui/Button";
 import { LT_CONTACT } from "@/lib/content/contact";
 import { LT_SHELL } from "@/lib/content/shell";
 import type { Locale } from "@/lib/content/home";
+import type { Product } from "@/lib/types/product";
+import { sanityClient } from "@/sanity/client";
+import { productByModelQuery } from "@/sanity/queries";
 import { ContactForm } from "./ContactForm";
 import "./contact-page.css";
 
@@ -18,7 +21,10 @@ const MAP_EMBED_URLS: Record<Locale, string> = {
   zh: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3211.3139873492805!2d127.3753097!3d36.4015979!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35654a04e7c961ab%3A0xe91272f47a8f5e5!2sLine%20Tech!5e0!3m2!1szh-CN!2sus!4v1777338907476!5m2!1szh-CN!2sus",
 };
 
-type Props = { params: Promise<{ locale: Locale }> };
+type Props = {
+  params: Promise<{ locale: Locale }>;
+  searchParams: Promise<{ product?: string | string[] }>;
+};
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
@@ -29,14 +35,39 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function ContactPage({ params }: Props) {
+export default async function ContactPage({ params, searchParams }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
+
+  const { product: rawProductParam } = await searchParams;
+  const productParam = Array.isArray(rawProductParam)
+    ? rawProductParam[0]
+    : rawProductParam;
+  const product = productParam
+    ? ((await sanityClient.fetch(productByModelQuery, {
+        model: productParam,
+      })) as Product | null)
+    : null;
 
   const tCommon = await getTranslations("common");
   const c = LT_CONTACT[locale];
   const info = LT_SHELL[locale].footer.contact;
   const { form } = c;
+
+  const defaults = product
+    ? {
+        inquiryType: "sales" as const,
+        extraField: product.model,
+        subject: form.productInquiry.subject.replaceAll(
+          "{model}",
+          product.model,
+        ),
+        message: form.productInquiry.message.replaceAll(
+          "{model}",
+          product.model,
+        ),
+      }
+    : undefined;
 
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },
@@ -77,7 +108,11 @@ export default async function ContactPage({ params }: Props) {
             </h2>
             <p className="ct-form__notice">{form.notice}</p>
 
-            <ContactForm form={form} privacyNotice={c.privacyNotice} />
+            <ContactForm
+              form={form}
+              privacyNotice={c.privacyNotice}
+              defaults={defaults}
+            />
           </section>
 
           <aside className="ct-info" aria-labelledby="ct-info-heading">

--- a/src/components/products/ProductHero/ProductHero.tsx
+++ b/src/components/products/ProductHero/ProductHero.tsx
@@ -40,7 +40,7 @@ export function ProductHero({
           <Button
             variant="primary"
             size="lg"
-            href="/contact"
+            href={`/contact?product=${encodeURIComponent(product.model)}`}
             trailingGlyph={<Glyph name="arrow-right" size={14} />}
           >
             {quoteLabel}

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -47,6 +47,14 @@ export type ContactFormCopy = {
   required: string;
   submit: string;
   submitDisabledHelp: string;
+  /**
+   * Templates used when the contact form is reached from a product page via
+   * `?product=<model>`. `{model}` is replaced at render time.
+   */
+  productInquiry: {
+    subject: string;
+    message: string;
+  };
 };
 
 export type DistributorRegion = {
@@ -156,6 +164,10 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       submit: "문의 보내기",
       submitDisabledHelp:
         "제출 백엔드는 현재 작업 중입니다. 위 이메일 주소로 보내주시면 즉시 회신드리겠습니다.",
+      productInquiry: {
+        subject: "견적 문의: {model}",
+        message: "{model}에 대한 견적 및 자세한 정보를 받고 싶습니다.",
+      },
     },
     privacyNotice:
       "문의 내용은 개인정보처리방침에 따라 처리되며 제3자에 공유되지 않습니다.",
@@ -257,6 +269,11 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       submit: "Send inquiry",
       submitDisabledHelp:
         "Submission backend is in progress. Please email the address above for an immediate reply.",
+      productInquiry: {
+        subject: "Inquiry: {model}",
+        message:
+          "I'd like to request a quote and more information about the {model}.",
+      },
     },
     privacyNotice:
       "We'll handle your message per our privacy policy and won't share your details with third parties.",
@@ -362,6 +379,10 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       submit: "发送咨询",
       submitDisabledHelp:
         "提交后端正在开发中。请使用上方邮箱直接联系我们以获得即时回复。",
+      productInquiry: {
+        subject: "询价：{model}",
+        message: "我想了解关于 {model} 的报价和更多信息。",
+      },
     },
     privacyNotice: "您的信息将依据我们的隐私政策处理，不会与第三方共享。",
     distributors: {

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -29,3 +29,9 @@ export const productsBySeriesQuery = defineQuery(`
     ${PRODUCT_PROJECTION}
   }
 `);
+
+export const productByModelQuery = defineQuery(`
+  *[_type == "product" && lower(model) == lower($model)][0]{
+    ${PRODUCT_PROJECTION}
+  }
+`);


### PR DESCRIPTION
## Summary

- Quote CTA on product detail pages now passes the product model as `?product=<model>`
- Contact page validates the param against the Sanity catalog (case-insensitive `lower()` match) — unknown models silently fall back to a blank form
- Pre-fills inquiry type (sales), model field, subject, and message in all three locales (ko/en/zh)

Closes #52.

## Changes

- `src/sanity/queries.ts` — new `productByModelQuery`
- `src/lib/content/contact.ts` — `productInquiry.subject` + `.message` templates with `{model}` placeholder per locale
- `src/app/[locale]/contact/page.tsx` — reads `searchParams.product`, fetches via Sanity, builds defaults
- `src/app/[locale]/contact/ContactForm.tsx` — accepts optional `defaults` prop; seeds inquiry type state, model field, subject, and message
- `src/components/products/ProductHero/ProductHero.tsx` — quote CTA href appends `?product=...` (URL-encoded)

## Test plan

- [x] `npm run build` passes; contact page is now `ƒ` (dynamic, expected since searchParams forces dynamic rendering)
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `/en/contact` — blank form, no defaults
- [x] `/en/contact?product=M3030VA` — sales selected, typeDetail=M3030VA, English subject + message
- [x] `/ko/contact?product=M3030VA` — Korean templates render
- [x] `/zh/contact?product=M3030VA` — Chinese templates render
- [x] `/en/contact?product=m3030va` (lowercase) — still pre-fills, canonical model from DB
- [x] `/en/contact?product=foo` — blank form, no error
- [x] From `/en/products/analogue/m3030va`, "Get a quote" href = `/en/contact?product=M3030VA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)