### PR TITLE
fix(home): polish KO copy + reorder homepage sections

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -23,8 +23,8 @@ export default async function HomePage({ params }: Props) {
         <Intro h={h} />
         <Stats h={h} />
         <Series h={h} />
-        <Feature h={h} />
         <Applications h={h} />
+        <Feature h={h} />
         <Credentials h={h} />
         <Contact h={h} />
       </div>

--- a/src/lib/content/company.ts
+++ b/src/lib/content/company.ts
@@ -177,7 +177,7 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
     },
     history: {
       kicker: "02 — 발자취",
-      title: "1997년부터, 한 분야에 집중해 왔습니다.",
+      title: "1997년 설립 이래, 한 분야에 집중해 왔습니다.",
       sub: "설립 이후 주요 성과를 시간순으로 정리했습니다.",
       rows: [
         { date: HISTORY_DATES[0], event: "라인테크 설립" },

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -43,7 +43,7 @@ export type HomeContent = {
 export const LT_HOME: Record<Locale, HomeContent> = {
   ko: {
     intro: {
-      kicker: "1997년부터 · 질량유량 측정 솔루션",
+      kicker: "1997년 설립 · 질량유량 측정 솔루션",
       title1: "신뢰할 수 있는 기술과",
       title2: "확실한 애프터서비스.",
       lede: "한국 최초의 자체 생산 MFC·MFM 제조사. 반도체, 디스플레이, 바이오, 연료전지 공정 현장에서 25년 이상 검증된 정밀 질량유량 제어.",

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -177,7 +177,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             {
               href: "/company#history",
               label: "발자취",
-              desc: "1997년부터 현재까지",
+              desc: "1997년 설립 이후",
             },
             {
               href: "/company#certifications",


### PR DESCRIPTION
## Summary
- Replace awkward Korean phrasing **"1997년부터"** with **"1997년 설립"** in three places (home intro kicker, company history section title, shell mega-menu description)
- Swap homepage render order so **Applications (02)** appears before **Feature (03 — Featured model)**, matching the on-page `01 → 04` kicker numbering

## Test plan
- [ ] CI passes (lint + typecheck + tests + build)
- [ ] Visit `/` — confirm intro kicker reads "1997년 설립 · 질량유량 측정 솔루션"
- [ ] Confirm homepage section order: Intro → Stats → Series (01) → Applications (02) → Feature (03) → Credentials (04) → Contact
- [ ] Visit `/company` — confirm history title reads "1997년 설립 이래, 한 분야에 집중해 왔습니다."
- [ ] Open header mega-menu under 회사소개 — confirm 발자취 description reads "1997년 설립 이후"

🤖 Generated with [Claude Code](https://claude.com/claude-code)