### PR TITLE
restyle(products): align category page to design handoff

### DIFF
--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -55,7 +55,6 @@ export default async function CategoryPage({ params }: Props) {
     response: tProducts("table.response"),
     fitting: tProducts("table.fitting"),
   };
-  const viewLabel = tProducts("table.view");
   const emptyLabel = tProducts("emptyStack");
 
   return (
@@ -75,7 +74,6 @@ export default async function CategoryPage({ params }: Props) {
         category={category}
         locale={locale}
         emptyLabel={emptyLabel}
-        viewLabel={viewLabel}
         headers={headers}
       />
       <ProductStack
@@ -85,7 +83,6 @@ export default async function CategoryPage({ params }: Props) {
         category={category}
         locale={locale}
         emptyLabel={emptyLabel}
-        viewLabel={viewLabel}
         headers={headers}
       />
     </main>

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -50,7 +50,6 @@ export default async function ProductsListPage({ params }: Props) {
     fitting: tProducts("table.fitting"),
   };
   const emptyLabel = tProducts("emptyStack");
-  const viewLabel = tProducts("table.view");
 
   return (
     <main className="lt-wrap lt-products-list">
@@ -85,7 +84,6 @@ export default async function ProductsListPage({ params }: Props) {
               category={slug}
               locale={typedLocale}
               emptyLabel={emptyLabel}
-              viewLabel={viewLabel}
               headers={headers}
             />
             <ProductStack
@@ -95,7 +93,6 @@ export default async function ProductsListPage({ params }: Props) {
               category={slug}
               locale={typedLocale}
               emptyLabel={emptyLabel}
-              viewLabel={viewLabel}
               headers={headers}
             />
           </section>

--- a/src/components/layout/Breadcrumbs.css
+++ b/src/components/layout/Breadcrumbs.css
@@ -46,6 +46,6 @@
 }
 
 .lt-breadcrumbs__item--current {
-  color: var(--pd-primary);
+  color: var(--pd-fg-strong);
   font-weight: 500;
 }

--- a/src/components/layout/HeaderNav.test.tsx
+++ b/src/components/layout/HeaderNav.test.tsx
@@ -4,6 +4,10 @@ import { HeaderNav } from "./HeaderNav";
 import { HeaderNavProvider, type HeaderNavCtx } from "./HeaderNavContext";
 import { LT_SHELL } from "@/lib/content/shell";
 
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 vi.mock("@/i18n/navigation", () => ({
   Link: ({
     href,

--- a/src/components/layout/MobileNav.test.tsx
+++ b/src/components/layout/MobileNav.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/i18n/navigation", () => ({
 
 vi.mock("next-intl", () => ({
   useLocale: () => "en",
+  useTranslations: () => (key: string) => key,
 }));
 
 vi.mock("@/i18n/routing", () => ({

--- a/src/components/products/CategoryHero/CategoryHero.css
+++ b/src/components/products/CategoryHero/CategoryHero.css
@@ -3,46 +3,32 @@
   grid-template-columns: 1fr;
   gap: 48px;
   padding: 24px 0 32px;
-  border-bottom: 1px solid var(--pd-border);
+  border-bottom: 1px solid var(--pd-rule);
   margin-bottom: 24px;
 }
 .lt-cat-hero__lead {
   max-width: 720px;
 }
 .lt-cat-hero__kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
-  letter-spacing: 0.14em;
+  display: block;
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--pd-primary);
   margin-bottom: 14px;
 }
-.lt-cat-hero__kicker-num {
-  display: inline-block;
-  padding: 2px 6px;
-  border: 1px solid var(--pd-primary);
-  border-radius: 2px;
-  color: var(--pd-primary);
-}
 .lt-cat-hero__title {
   margin: 0 0 12px;
-  font: 500 var(--lt-fs-h2-dense) / 1.05 var(--lt-sans);
-  letter-spacing: -0.02em;
+  font: 500 var(--lt-fs-h2-dense) / 1.1 var(--lt-sans);
+  letter-spacing: -0.015em;
   color: var(--pd-fg-strong);
-  display: flex;
-  align-items: baseline;
-  gap: 14px;
-  flex-wrap: wrap;
 }
 .lt-cat-hero__code {
-  font: 600 var(--lt-fs-lg) var(--lt-mono);
+  font-family: var(--lt-mono);
+  font-size: inherit;
+  font-weight: 500;
   letter-spacing: 0.02em;
   color: var(--pd-primary);
-  padding: 4px 10px;
-  border: 1px solid var(--pd-primary);
-  border-radius: 3px;
 }
 .lt-cat-hero__lede {
   margin: 0;

--- a/src/components/products/CategoryHero/CategoryHero.tsx
+++ b/src/components/products/CategoryHero/CategoryHero.tsx
@@ -19,8 +19,7 @@ export function CategoryHero({
     <header className="lt-cat-hero">
       <div className="lt-cat-hero__lead">
         <div className="lt-cat-hero__kicker">
-          <span className="lt-cat-hero__kicker-num">{kickerNum}</span>
-          <span>{kickerLabel}</span>
+          {kickerNum} — {kickerLabel}
         </div>
         <h1 className="lt-cat-hero__title">
           {title} <span className="lt-cat-hero__code">{code}</span>

--- a/src/components/products/ProductRow/ProductRow.css
+++ b/src/components/products/ProductRow/ProductRow.css
@@ -5,9 +5,9 @@
 .lt-prod-row__cell {
   align-items: center;
   display: flex;
-  padding: 10px 12px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--pd-rule);
-  font-size: var(--lt-fs-xs);
+  font-size: var(--lt-fs-sm);
   color: var(--pd-fg);
   background: transparent;
   transition: background 0.15s;
@@ -22,12 +22,10 @@
 .lt-prod-row__cell--thumb {
   color: var(--pd-muted);
   justify-content: center;
-}
-.lt-prod-row:has(.lt-prod-row__cell:hover) .lt-prod-row__cell--thumb {
-  color: var(--pd-primary);
+  opacity: 0.5;
 }
 .lt-prod-row__cell--code {
-  font: 600 var(--lt-fs-xs) var(--lt-mono);
+  font: 500 var(--lt-fs-sm) var(--lt-mono);
   color: var(--pd-fg-strong);
   letter-spacing: 0.01em;
 }
@@ -51,32 +49,20 @@
   font-family: var(--lt-mono);
   font-variant-numeric: tabular-nums;
   color: var(--pd-fg-strong);
-  font-size: var(--lt-fs-xs);
+  font-size: var(--lt-fs-sm);
 }
 .lt-prod-row__cell--fit {
   color: var(--pd-muted);
-}
-.lt-prod-row__cell--act {
-  justify-content: flex-end;
-}
-.lt-prod-row__view {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font: 600 var(--lt-fs-xs) var(--lt-sans);
-  color: var(--pd-primary);
-  opacity: 0;
-  transition: opacity 0.15s;
-  text-decoration: none;
-}
-.lt-prod-row:has(.lt-prod-row__cell:hover) .lt-prod-row__view,
-.lt-prod-row:has(.lt-prod-row__cell :focus-visible) .lt-prod-row__view {
-  opacity: 1;
 }
 
 @media (max-width: 1024px) {
   .lt-prod-row__cell--resp,
   .lt-prod-row__cell--fit {
+    display: none;
+  }
+}
+@media (max-width: 640px) {
+  .lt-prod-row__cell--thumb {
     display: none;
   }
 }

--- a/src/components/products/ProductRow/ProductRow.tsx
+++ b/src/components/products/ProductRow/ProductRow.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@/i18n/navigation";
-import { Glyph } from "@/components/ui/Glyph";
 import { ProductThumb } from "../ProductThumb";
 import type { Product } from "@/lib/types/product";
 import type { CategorySlug } from "@/lib/categories";
@@ -9,7 +8,6 @@ type Props = {
   product: Product;
   category: CategorySlug;
   locale: "ko" | "en" | "zh";
-  viewLabel: string;
 };
 
 function fittingSummary(connections: Product["connections"]): string {
@@ -21,7 +19,7 @@ function fittingSummary(connections: Product["connections"]): string {
   return [...types].join(" · ");
 }
 
-export function ProductRow({ product, category, locale, viewLabel }: Props) {
+export function ProductRow({ product, category, locale }: Props) {
   const href = `/products/${category}/${product.slug.current}`;
   const label = product.productLabel[locale];
   const range = product.massFlowSpecs.flowRange.display;
@@ -31,7 +29,10 @@ export function ProductRow({ product, category, locale, viewLabel }: Props) {
 
   return (
     <tr className="lt-prod-row">
-      <td className="lt-prod-row__cell lt-prod-row__cell--thumb">
+      <td
+        className="lt-prod-row__cell lt-prod-row__cell--thumb"
+        aria-hidden="true"
+      >
         <ProductThumb />
       </td>
       <th scope="row" className="lt-prod-row__cell lt-prod-row__cell--code">
@@ -46,12 +47,6 @@ export function ProductRow({ product, category, locale, viewLabel }: Props) {
       <td className="lt-prod-row__cell lt-prod-row__cell--acc">{accuracy}</td>
       <td className="lt-prod-row__cell lt-prod-row__cell--resp">{response}</td>
       <td className="lt-prod-row__cell lt-prod-row__cell--fit">{fitting}</td>
-      <td className="lt-prod-row__cell lt-prod-row__cell--act">
-        <Link href={href} className="lt-prod-row__view">
-          {viewLabel}
-          <Glyph name="arrow-right" size={11} />
-        </Link>
-      </td>
     </tr>
   );
 }

--- a/src/components/products/ProductStack/ProductStack.css
+++ b/src/components/products/ProductStack/ProductStack.css
@@ -1,15 +1,16 @@
 .lt-prod-stack {
-  margin-bottom: 40px;
+  margin-bottom: 64px;
 }
 .lt-prod-stack__hd {
-  margin-bottom: 8px;
-  padding-bottom: 10px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--pd-rule);
 }
 .lt-prod-stack__kicker {
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
-  letter-spacing: 0.14em;
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--pd-muted);
+  color: var(--pd-primary);
   margin-bottom: 4px;
 }
 .lt-prod-stack__title {
@@ -27,7 +28,7 @@
   padding: 1px 7px;
   border: 1px solid var(--pd-border);
   border-radius: 999px;
-  background: var(--pd-surface-2);
+  background: var(--pd-surface);
 }
 
 /* Real <table> with grid layout. thead/tbody/tr use display:contents so the
@@ -35,7 +36,7 @@
  * table accessibility semantics with display:contents. */
 .lt-prod-stack__table {
   display: grid;
-  grid-template-columns: 56px 96px 1fr 220px 96px 72px 96px 72px;
+  grid-template-columns: 56px 96px 2fr 3fr 2fr 1.5fr 2fr;
   border-collapse: collapse;
   width: 100%;
 }
@@ -62,10 +63,9 @@
 .lt-prod-stack__head-cell {
   display: flex;
   align-items: center;
-  padding: 10px 12px;
+  padding: 14px 16px;
   border-top: 1px solid var(--pd-border-strong);
   border-bottom: 1px solid var(--pd-border-strong);
-  background: var(--pd-surface-2);
   font: 500 var(--lt-fs-xs) var(--lt-mono);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -92,17 +92,20 @@
   text-transform: none;
 }
 
-@media (max-width: 1280px) {
-  .lt-prod-stack__table {
-    grid-template-columns: 56px 88px 1fr 200px 88px 64px 80px 60px;
-  }
-}
 @media (max-width: 1024px) {
   .lt-prod-stack__table {
-    grid-template-columns: 56px 88px 1fr 1fr 88px 60px;
+    grid-template-columns: 48px 88px 2fr 3fr 2fr;
   }
   .lt-prod-stack__head-cell--resp,
   .lt-prod-stack__head-cell--fit {
+    display: none;
+  }
+}
+@media (max-width: 640px) {
+  .lt-prod-stack__table {
+    grid-template-columns: 88px 2fr 3fr 2fr;
+  }
+  .lt-prod-stack__head-cell--thumb {
     display: none;
   }
 }

--- a/src/components/products/ProductStack/ProductStack.tsx
+++ b/src/components/products/ProductStack/ProductStack.tsx
@@ -10,7 +10,6 @@ type Props = {
   category: CategorySlug;
   locale: "ko" | "en" | "zh";
   emptyLabel: string;
-  viewLabel: string;
   headers: {
     model: string;
     description: string;
@@ -28,7 +27,6 @@ export function ProductStack({
   category,
   locale,
   emptyLabel,
-  viewLabel,
   headers,
 }: Props) {
   return (
@@ -89,12 +87,6 @@ export function ProductStack({
               >
                 {headers.fitting}
               </th>
-              <th
-                scope="col"
-                className="lt-prod-stack__head-cell lt-prod-stack__head-cell--act"
-              >
-                <span className="lt-prod-stack__sr-only">{viewLabel}</span>
-              </th>
             </tr>
           </thead>
           <tbody>
@@ -104,7 +96,6 @@ export function ProductStack({
                 product={p}
                 category={category}
                 locale={locale}
-                viewLabel={viewLabel}
               />
             ))}
           </tbody>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -8,9 +8,9 @@ export const CATEGORIES: Record<
   CategorySlug,
   { kickerNum: string; code: string; series: Product["series"] }
 > = {
-  analogue: { kickerNum: "01", code: "M / MS", series: "analogue" },
+  analogue: { kickerNum: "01", code: "M·MS", series: "analogue" },
   digital: { kickerNum: "02", code: "MD", series: "digital" },
-  specialized: { kickerNum: "03", code: "LD / LM", series: "specialized" },
+  specialized: { kickerNum: "03", code: "LD·LM", series: "specialized" },
 };
 
 export function isCategorySlug(s: string): s is CategorySlug {


### PR DESCRIPTION
## Summary

- **CategoryHero**: kicker becomes bare `01 — CONTROLLERS` (11px mono blue, em-dash format); drops boxed number and bordered series-code badge; code renders as inline mono span inside the h1
- **ProductStack**: kicker 11px/primary-blue, table header border-only (no background fill), count chip uses lighter surface token, section bottom margin bumped to 64px
- **ProductRow**: padding 14×16px, proportional `fr` grid replacing fixed `px` columns, 15px body font, hover view-link column removed, ProductThumb placeholder restored and dimmed; 640px breakpoint grid now matches the head row
- **Breadcrumbs**: current item color → `pd-fg-strong` (was primary blue)
- **categories.ts**: separator → middot with no surrounding spaces (`M·MS`, `LD·LM`)

## Test plan

- [ ] Visit `/en/products/analogue`, `/ko/products/analogue`, `/zh/products/analogue`
- [ ] Kicker reads `01 — ANALOGUE`, 11px mono blue, no box around the number
- [ ] Series code (`M·MS`) appears inline with title in mono, no border/badge
- [ ] Table header has top + bottom borders only, no background fill
- [ ] Row columns fill container width proportionally; range column widest
- [ ] Breadcrumb current item is dark, not blue
- [ ] CJK locales: kicker drops mono and letter-spacing (regression check)
- [ ] Spot-check one PDP (`/products/analogue/m3030va`) — only Breadcrumb color change visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)