### PR TITLE
feat(seo): add llms.txt manifest and per-product spec exports (#70)

### DIFF
--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,13 @@
+import { buildLlmsManifest } from "@/lib/seo/llmsManifest";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
+
+export async function GET() {
+  const content = await buildLlmsManifest(siteUrl);
+  return new Response(content, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/src/app/products/[slug]/spec.json/route.ts
+++ b/src/app/products/[slug]/spec.json/route.ts
@@ -1,0 +1,29 @@
+import { sanityClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { productBySlugQuery } from "@/sanity/queries";
+import { SanityProductSchema } from "@/lib/types/product";
+import { ALL_PRODUCTS } from "@/lib/fixtures/products";
+import { buildSpecJson } from "@/lib/seo/specSheet";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
+
+export function generateStaticParams() {
+  return ALL_PRODUCTS.map((p) => ({ slug: p.slug.current }));
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await ctx.params;
+  const raw = await fetchSanity(
+    () => sanityClient.fetch(productBySlugQuery, { slug }),
+    { name: "specJson", params: { slug } },
+  );
+  const product = raw ? SanityProductSchema.parse(raw) : null;
+  if (!product) return new Response("Not found", { status: 404 });
+  return Response.json(buildSpecJson(product, siteUrl));
+}

--- a/src/app/products/[slug]/spec.md/route.ts
+++ b/src/app/products/[slug]/spec.md/route.ts
@@ -1,0 +1,31 @@
+import { sanityClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { productBySlugQuery } from "@/sanity/queries";
+import { SanityProductSchema } from "@/lib/types/product";
+import { ALL_PRODUCTS } from "@/lib/fixtures/products";
+import { buildSpecMarkdown } from "@/lib/seo/specSheet";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
+
+export function generateStaticParams() {
+  return ALL_PRODUCTS.map((p) => ({ slug: p.slug.current }));
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await ctx.params;
+  const raw = await fetchSanity(
+    () => sanityClient.fetch(productBySlugQuery, { slug }),
+    { name: "specMd", params: { slug } },
+  );
+  const product = raw ? SanityProductSchema.parse(raw) : null;
+  if (!product) return new Response("Not found", { status: 404 });
+  return new Response(buildSpecMarkdown(product, siteUrl), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/src/lib/seo/llmsManifest.ts
+++ b/src/lib/seo/llmsManifest.ts
@@ -1,0 +1,128 @@
+import { sanityClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { allProductsQuery } from "@/sanity/queries";
+import { SanityProductSchema } from "@/lib/types/product";
+import { categoryForSeries } from "@/lib/categories";
+import type { Product } from "@/lib/types/product";
+
+const CATEGORY_META: Record<
+  "analogue" | "digital" | "specialized",
+  { heading: string; code: string; description: string }
+> = {
+  analogue: {
+    heading: "Analogue series (M / MS)",
+    code: "M·MS",
+    description:
+      "Workhorse MFCs and MFMs for standard lab and industrial lines. Simple 0–5 V or 4–20 mA signal. 20+ years field-proven. Best choice when no digital bus is required.",
+  },
+  digital: {
+    heading: "Digital series (MD)",
+    code: "MD",
+    description:
+      "When you need ±0.25% FS accuracy, 8-point linearization, or RS-485 / Modbus RTU for bus integration. Sub-second response. Preferred for semiconductor process lines.",
+  },
+  specialized: {
+    heading: "Specialized series (LD / LM)",
+    code: "LD·LM",
+    description:
+      "Hazardous locations, display-integrated units, MEMS sensors. Choose when standard variants don't fit the environment.",
+  },
+};
+
+function productLine(product: Product, siteUrl: string): string {
+  const category = categoryForSeries(product.series);
+  const slug = product.slug.current;
+  const pageUrl = `${siteUrl}/en/products/${category}/${slug}`;
+  const jsonUrl = `${siteUrl}/products/${slug}/spec.json`;
+  const mdUrl = `${siteUrl}/products/${slug}/spec.md`;
+
+  const fnLabel =
+    product.function === "MFC" ? "Mass Flow Controller" : "Mass Flow Meter";
+  const flowRange = product.massFlowSpecs.flowRange?.display;
+  const accuracy = product.massFlowSpecs.accuracy?.display;
+
+  const features = product.features
+    .map((f: { en?: string }) => f.en)
+    .filter(Boolean)
+    .slice(0, 3)
+    .join("; ");
+
+  const detail = [
+    `${fnLabel}`,
+    flowRange && `flow range ${flowRange}`,
+    accuracy && `accuracy ${accuracy}`,
+    features,
+  ]
+    .filter(Boolean)
+    .join(". ");
+
+  return `- [${product.model}](${pageUrl}) — ${detail}. [Spec JSON](${jsonUrl}) · [Spec sheet](${mdUrl})`;
+}
+
+export async function buildLlmsManifest(siteUrl: string): Promise<string> {
+  const raw = await fetchSanity(() => sanityClient.fetch(allProductsQuery), {
+    name: "llmsManifest",
+  });
+
+  const products = (Array.isArray(raw) ? raw : [])
+    .map((p) => {
+      try {
+        return SanityProductSchema.parse(p);
+      } catch {
+        return null;
+      }
+    })
+    .filter((p): p is Product => p !== null);
+
+  const byCategory = {
+    analogue: products.filter((p) => p.series === "analogue"),
+    digital: products.filter((p) => p.series === "digital"),
+    specialized: products.filter((p) => p.series === "specialized"),
+  };
+
+  const lines: string[] = [
+    "# Line Tech",
+    "",
+    "> Korean manufacturer of Mass Flow Controllers (MFC) and Mass Flow Meters (MFM).",
+    "> Precision flow instrumentation for semiconductor, biotech, fuel-cell, and",
+    "> process-industry applications. Headquartered in Daejeon, South Korea since 1997.",
+    "> ISO-certified. 13 product certifications. Direct sales with application engineering support.",
+    "",
+    "## Company",
+    "",
+    `- [Company overview](${siteUrl}/en/company): History, capabilities, certifications, and team`,
+    `- [Contact & inquiry](${siteUrl}/en/contact): Sales inquiry form and direct contact`,
+    "",
+    "## Products",
+    "",
+  ];
+
+  for (const series of ["analogue", "digital", "specialized"] as const) {
+    const list = byCategory[series];
+    if (list.length === 0) continue;
+    const meta = CATEGORY_META[series];
+    lines.push(`### ${meta.heading}`, "");
+    lines.push(meta.description, "");
+
+    const mfcs = list.filter((p) => p.function === "MFC");
+    const mfms = list.filter((p) => p.function === "MFM");
+
+    if (mfcs.length > 0) {
+      lines.push("**Mass Flow Controllers**", "");
+      for (const p of mfcs) lines.push(productLine(p, siteUrl));
+      lines.push("");
+    }
+    if (mfms.length > 0) {
+      lines.push("**Mass Flow Meters**", "");
+      for (const p of mfms) lines.push(productLine(p, siteUrl));
+      lines.push("");
+    }
+  }
+
+  lines.push("## Optional", "");
+  lines.push(`- [Korean site](${siteUrl}/ko): 한국어 제품 카탈로그`);
+  lines.push(`- [Chinese site](${siteUrl}/zh): 中文产品目录`);
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/src/lib/seo/llmsManifest.ts
+++ b/src/lib/seo/llmsManifest.ts
@@ -68,7 +68,12 @@ export async function buildLlmsManifest(siteUrl: string): Promise<string> {
     .map((p) => {
       try {
         return SanityProductSchema.parse(p);
-      } catch {
+      } catch (err) {
+        console.error(
+          "[llmsManifest] failed to parse product",
+          (p as { model?: unknown })?.model ?? "unknown",
+          err,
+        );
         return null;
       }
     })

--- a/src/lib/seo/specSheet.ts
+++ b/src/lib/seo/specSheet.ts
@@ -58,8 +58,7 @@ export function buildSpecJson(
   for (const key of SPEC_ORDER) {
     const spec = product.massFlowSpecs[key];
     if (spec) {
-      const { ...rest } = spec;
-      specifications[key] = rest as Record<string, unknown>;
+      specifications[key] = spec as Record<string, unknown>;
     }
   }
 
@@ -76,7 +75,10 @@ export function buildSpecJson(
         zh: f.zh,
       }),
     ),
-    connections: product.connections,
+    connections: product.connections.map(({ type, length }) => ({
+      type,
+      length,
+    })),
     specifications,
     digitalCommunication: product.digitalCommunication ?? undefined,
     canonicalUrl: `${siteUrl}/en/products/${category}/${slug}`,

--- a/src/lib/seo/specSheet.ts
+++ b/src/lib/seo/specSheet.ts
@@ -1,0 +1,152 @@
+import { categoryForSeries } from "@/lib/categories";
+import type { Product, MassFlowSpecs } from "@/lib/types/product";
+
+const SPEC_LABELS: Record<keyof MassFlowSpecs, string> = {
+  flowRange: "Flow range",
+  responseTime: "Response time",
+  accuracy: "Accuracy",
+  repeatability: "Repeatability",
+  ioSignal: "I/O signal",
+  supplyPower: "Supply power",
+  maxPressure: "Max pressure",
+  tempRange: "Temperature range",
+  leakRate: "Leak rate",
+  controlRange: "Control range",
+};
+
+const SPEC_ORDER: Array<keyof MassFlowSpecs> = [
+  "flowRange",
+  "accuracy",
+  "repeatability",
+  "responseTime",
+  "controlRange",
+  "ioSignal",
+  "supplyPower",
+  "maxPressure",
+  "tempRange",
+  "leakRate",
+];
+
+const SERIES_LABELS: Record<Product["series"], string> = {
+  analogue: "Analogue",
+  digital: "Digital",
+  specialized: "Specialized",
+};
+
+export type SpecJsonPayload = {
+  model: string;
+  slug: string;
+  series: Product["series"];
+  function: Product["function"];
+  productLabel: { ko: string; en: string; zh: string };
+  features: { en?: string; ko?: string; zh?: string }[];
+  connections: { type: string; length: string }[];
+  specifications: Partial<Record<keyof MassFlowSpecs, Record<string, unknown>>>;
+  digitalCommunication?: Product["digitalCommunication"];
+  canonicalUrl: string;
+  alternates: { ko: string; zh: string };
+};
+
+export function buildSpecJson(
+  product: Product,
+  siteUrl: string,
+): SpecJsonPayload {
+  const category = categoryForSeries(product.series);
+  const slug = product.slug.current;
+
+  const specifications: SpecJsonPayload["specifications"] = {};
+  for (const key of SPEC_ORDER) {
+    const spec = product.massFlowSpecs[key];
+    if (spec) {
+      const { ...rest } = spec;
+      specifications[key] = rest as Record<string, unknown>;
+    }
+  }
+
+  return {
+    model: product.model,
+    slug,
+    series: product.series,
+    function: product.function,
+    productLabel: product.productLabel,
+    features: product.features.map(
+      (f: { en?: string; ko?: string; zh?: string }) => ({
+        en: f.en,
+        ko: f.ko,
+        zh: f.zh,
+      }),
+    ),
+    connections: product.connections,
+    specifications,
+    digitalCommunication: product.digitalCommunication ?? undefined,
+    canonicalUrl: `${siteUrl}/en/products/${category}/${slug}`,
+    alternates: {
+      ko: `${siteUrl}/ko/products/${category}/${slug}`,
+      zh: `${siteUrl}/zh/products/${category}/${slug}`,
+    },
+  };
+}
+
+export function buildSpecMarkdown(product: Product, siteUrl: string): string {
+  const category = categoryForSeries(product.series);
+  const slug = product.slug.current;
+  const seriesLabel = SERIES_LABELS[product.series];
+  const canonicalUrl = `${siteUrl}/en/products/${category}/${slug}`;
+  const koUrl = `${siteUrl}/ko/products/${category}/${slug}`;
+  const zhUrl = `${siteUrl}/zh/products/${category}/${slug}`;
+
+  const lines: string[] = [
+    `# ${product.model} — ${seriesLabel} Mass Flow ${product.function === "MFC" ? "Controller" : "Meter"}`,
+    "",
+    `**Series:** ${seriesLabel} · **Function:** ${product.function === "MFC" ? "Mass Flow Controller (MFC)" : "Mass Flow Meter (MFM)"}`,
+    `**Product name:** ${product.productLabel.en}`,
+    `**Canonical page:** ${canonicalUrl}`,
+    "",
+  ];
+
+  const features = product.features
+    .map((f: { en?: string }) => f.en)
+    .filter(Boolean) as string[];
+  if (features.length > 0) {
+    lines.push("## Features", "");
+    for (const f of features) lines.push(`- ${f}`);
+    lines.push("");
+  }
+
+  lines.push("## Specifications", "");
+  lines.push("| Spec | Value |");
+  lines.push("|---|---|");
+  for (const key of SPEC_ORDER) {
+    const spec = product.massFlowSpecs[key];
+    if (spec) {
+      lines.push(`| ${SPEC_LABELS[key]} | ${spec.display} |`);
+    }
+  }
+  lines.push("");
+
+  if (product.connections.length > 0) {
+    lines.push("## Connections", "");
+    for (const c of product.connections) {
+      lines.push(`- ${c.type} — body length ${c.length}`);
+    }
+    lines.push("");
+  }
+
+  const dc = product.digitalCommunication;
+  if (dc?.protocol) {
+    lines.push("## Digital communication", "");
+    lines.push(`- Protocol: ${dc.protocol}`);
+    if (dc.baudRate) lines.push(`- Baud rate: ${dc.baudRate}`);
+    if (dc.dataBits) lines.push(`- Data bits: ${dc.dataBits}`);
+    if (dc.stopBits) lines.push(`- Stop bits: ${dc.stopBits}`);
+    if (dc.parity) lines.push(`- Parity: ${dc.parity}`);
+    lines.push("");
+  }
+
+  lines.push("---");
+  lines.push(
+    `*Source: line-tech.co · English spec sheet for AI agents. Korean: ${koUrl} · Chinese: ${zhUrl}*`,
+  );
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Add `/llms.txt` — curated Markdown index for AI agents (llmstxt.org convention), listing all products grouped by series with flow range, accuracy, and top 3 features
- Add `/products/[slug]/spec.json` — structured JSON spec export per product with all 3 locale labels, 10 spec fields, and canonical + alternate URLs
- Add `/products/[slug]/spec.md` — English Markdown spec sheet per product for LLM consumption without HTML scraping
- All routes are static (`force-static` + `generateStaticParams`), rebuilt on each Vercel deploy via existing deploy hook

## Test plan
- `GET /llms.txt` → valid Markdown, all product series present, links resolve
- `GET /products/m3030va/spec.json` → valid JSON, `jq .` parses cleanly, spec fields populated, no `_key` in connections
- `GET /products/m3030va/spec.md` → `Content-Type: text/markdown`, spec table matches product page values
- `GET /products/nonexistent/spec.json` → 404
- `pnpm build` → ~20 static entries each for spec.json and spec.md, 1 for llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)