### PR TITLE
fix(nits): category hero, accessories nav, CSP map embed, visual polish

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -62,18 +62,15 @@
     "categories": {
       "analogue": {
         "title": "Analogue series",
-        "lede": "Proven analogue mass flow controllers and meters.",
-        "ledeAccent": ""
+        "lede": "Proven analogue mass flow controllers and meters."
       },
       "digital": {
         "title": "Digital series",
-        "lede": "8-point linearization. ±0.25% F.S. accuracy. Sub-second response. RS-485 / Modbus RTU.",
-        "ledeAccent": ""
+        "lede": "8-point linearization. ±0.25% F.S. accuracy. Sub-second response. RS-485 / Modbus RTU."
       },
       "specialized": {
         "title": "Specialized series",
-        "lede": "Display-integrated, explosion-proof, and MEMS variants for demanding environments.",
-        "ledeAccent": ""
+        "lede": "Display-integrated, explosion-proof, and MEMS variants for demanding environments."
       }
     },
     "stack": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,25 +62,28 @@
     "categories": {
       "analogue": {
         "title": "Analogue series",
-        "lede": "Proven analogue mass flow controllers and meters. M and MS series — the workhorses behind two decades of process lines."
+        "lede": "Proven analogue mass flow controllers and meters.",
+        "ledeAccent": ""
       },
       "digital": {
         "title": "Digital series",
-        "lede": "8-point linearization. ±0.25% F.S. accuracy. Sub-second response. RS-485 / Modbus RTU."
+        "lede": "8-point linearization. ±0.25% F.S. accuracy. Sub-second response. RS-485 / Modbus RTU.",
+        "ledeAccent": ""
       },
       "specialized": {
         "title": "Specialized series",
-        "lede": "Display-integrated, explosion-proof, and MEMS variants for demanding environments."
+        "lede": "Display-integrated, explosion-proof, and MEMS variants for demanding environments.",
+        "ledeAccent": ""
       }
     },
     "stack": {
       "controllers": {
-        "title": "Controllers",
-        "subtitle": "Mass Flow Controllers · MFC"
+        "title": "Mass Flow Controllers · MFC",
+        "subtitle": "Controllers"
       },
       "meters": {
-        "title": "Meters",
-        "subtitle": "Mass Flow Meters · MFM"
+        "title": "Mass Flow Meters · MFM",
+        "subtitle": "Meters"
       }
     },
     "table": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -62,25 +62,28 @@
     "categories": {
       "analogue": {
         "title": "아날로그 시리즈",
-        "lede": "검증된 아날로그 질량유량 제어기 및 측정기. 20년간 공정 라인을 지켜온 M · MS 시리즈."
+        "lede": "검증된 아날로그 질량유량 제어기 및 측정기.",
+        "ledeAccent": ""
       },
       "digital": {
         "title": "디지털 시리즈",
-        "lede": "8점 선형화. ±0.25 % F.S. 정확도. 1초 미만 응답. RS-485 · Modbus RTU."
+        "lede": "8점 선형화. ±0.25 % F.S. 정확도. 1초 미만 응답. RS-485 · Modbus RTU.",
+        "ledeAccent": ""
       },
       "specialized": {
         "title": "특수 시리즈",
-        "lede": "디스플레이 일체형, 방폭, MEMS 등 까다로운 환경을 위한 특수 사양 라인업."
+        "lede": "디스플레이 일체형, 방폭, MEMS 등 까다로운 환경을 위한 특수 사양 라인업.",
+        "ledeAccent": ""
       }
     },
     "stack": {
       "controllers": {
-        "title": "Controllers",
-        "subtitle": "질량유량 제어기 · MFC"
+        "title": "질량유량 제어기 · MFC",
+        "subtitle": "Controllers"
       },
       "meters": {
-        "title": "Meters",
-        "subtitle": "질량유량 측정기 · MFM"
+        "title": "질량유량 측정기 · MFM",
+        "subtitle": "Meters"
       }
     },
     "table": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -62,18 +62,15 @@
     "categories": {
       "analogue": {
         "title": "아날로그 시리즈",
-        "lede": "검증된 아날로그 질량유량 제어기 및 측정기.",
-        "ledeAccent": ""
+        "lede": "검증된 아날로그 질량유량 제어기 및 측정기."
       },
       "digital": {
         "title": "디지털 시리즈",
-        "lede": "8점 선형화. ±0.25 % F.S. 정확도. 1초 미만 응답. RS-485 · Modbus RTU.",
-        "ledeAccent": ""
+        "lede": "8점 선형화. ±0.25 % F.S. 정확도. 1초 미만 응답. RS-485 · Modbus RTU."
       },
       "specialized": {
         "title": "특수 시리즈",
-        "lede": "디스플레이 일체형, 방폭, MEMS 등 까다로운 환경을 위한 특수 사양 라인업.",
-        "ledeAccent": ""
+        "lede": "디스플레이 일체형, 방폭, MEMS 등 까다로운 환경을 위한 특수 사양 라인업."
       }
     },
     "stack": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -62,25 +62,28 @@
     "categories": {
       "analogue": {
         "title": "模拟系列",
-        "lede": "经过验证的模拟质量流量控制器和测量仪。M / MS 系列 — 二十年工艺线的中流砥柱。"
+        "lede": "经过验证的模拟质量流量控制器和测量仪。",
+        "ledeAccent": ""
       },
       "digital": {
         "title": "数字系列",
-        "lede": "8 点线性化。±0.25 % F.S. 精度。亚秒级响应。RS-485 · Modbus RTU。"
+        "lede": "8 点线性化。±0.25 % F.S. 精度。亚秒级响应。RS-485 · Modbus RTU。",
+        "ledeAccent": ""
       },
       "specialized": {
         "title": "特殊系列",
-        "lede": "集成显示、防爆、MEMS 等针对苛刻环境的特殊型号产品线。"
+        "lede": "集成显示、防爆、MEMS 等针对苛刻环境的特殊型号产品线。",
+        "ledeAccent": ""
       }
     },
     "stack": {
       "controllers": {
-        "title": "Controllers",
-        "subtitle": "质量流量控制器 · MFC"
+        "title": "质量流量控制器 · MFC",
+        "subtitle": "Controllers"
       },
       "meters": {
-        "title": "Meters",
-        "subtitle": "质量流量测量仪 · MFM"
+        "title": "质量流量测量仪 · MFM",
+        "subtitle": "Meters"
       }
     },
     "table": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -62,18 +62,15 @@
     "categories": {
       "analogue": {
         "title": "模拟系列",
-        "lede": "经过验证的模拟质量流量控制器和测量仪。",
-        "ledeAccent": ""
+        "lede": "经过验证的模拟质量流量控制器和测量仪。"
       },
       "digital": {
         "title": "数字系列",
-        "lede": "8 点线性化。±0.25 % F.S. 精度。亚秒级响应。RS-485 · Modbus RTU。",
-        "ledeAccent": ""
+        "lede": "8 点线性化。±0.25 % F.S. 精度。亚秒级响应。RS-485 · Modbus RTU。"
       },
       "specialized": {
         "title": "特殊系列",
-        "lede": "集成显示、防爆、MEMS 等针对苛刻环境的特殊型号产品线。",
-        "ledeAccent": ""
+        "lede": "集成显示、防爆、MEMS 等针对苛刻环境的特殊型号产品线。"
       }
     },
     "stack": {

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,7 @@ const cspDirectives = [
   `img-src 'self' data: blob: ${SANITY_CDN}`,
   "font-src 'self' data:",
   `connect-src 'self' ${SANITY_CDN} https://*.sanity.io https://vitals.vercel-insights.com`,
-  "frame-src https://challenges.cloudflare.com",
+  "frame-src https://challenges.cloudflare.com https://www.google.com/maps/",
   "frame-ancestors 'self'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/src/app/[locale]/company/page.tsx
+++ b/src/app/[locale]/company/page.tsx
@@ -10,6 +10,25 @@ import {
 import type { Locale } from "@/lib/content/home";
 import { buildCompanyMetadata } from "@/lib/seo";
 
+function MapPinIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="13"
+      height="13"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
 type Props = { params: Promise<{ locale: Locale }> };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -175,7 +194,25 @@ function OfficeCard({ office, labels }: OfficeCardProps) {
       <h3 className="co-office__name">{office.name}</h3>
       <dl className="co-office__rows">
         <dt className="co-office__label">{labels.address}</dt>
-        <dd className="co-office__value">{office.address}</dd>
+        <dd className="co-office__value">
+          {office.address}
+          {office.mapLinks && (
+            <div className="co-office__maplinks">
+              {office.mapLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  className="co-office__maplink"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <MapPinIcon />
+                  <span>{link.label}</span>
+                </a>
+              ))}
+            </div>
+          )}
+        </dd>
         {office.phone && (
           <>
             <dt className="co-office__label">{labels.phone}</dt>

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -105,7 +105,6 @@ export default async function CategoryPage({ params }: Props) {
       <main className="lt-wrap">
         <Breadcrumbs items={breadcrumbs} />
         <CategoryHero
-          kickerNum={cat.kickerNum}
           kickerLabel={tProducts("kicker")}
           title={tProducts(`categories.${category}.title`)}
           code={cat.code}

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -82,7 +82,6 @@ export default async function ProductsListPage({ params }: Props) {
         return (
           <section key={slug} className="lt-products-list__section">
             <CategoryHero
-              kickerNum={cat.kickerNum}
               kickerLabel={tProducts("kicker")}
               title={tProducts(`categories.${slug}.title`)}
               code={cat.code}

--- a/src/components/accessories/AccessoriesSideNav.tsx
+++ b/src/components/accessories/AccessoriesSideNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { AccessoriesNavNode } from "@/lib/content/accessories";
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
  * while preserving group/leaf semantics in the rendered DOM.
  */
 export function AccessoriesSideNav({ heading, items }: Props) {
-  const flat = flattenNav(items);
+  const flat = useMemo(() => flattenNav(items), [items]);
   const [active, setActive] = useState<string>(flat[0]?.id ?? "");
 
   useEffect(() => {

--- a/src/components/accessories/AccessoriesSideNav.tsx
+++ b/src/components/accessories/AccessoriesSideNav.tsx
@@ -27,8 +27,13 @@ export function AccessoriesSideNav({ heading, items }: Props) {
 
     const intersecting = new Set<string>();
 
+    const isNearBottom = () =>
+      window.scrollY + window.innerHeight >=
+      document.documentElement.scrollHeight - 64;
+
     const observer = new IntersectionObserver(
       (entries) => {
+        if (isNearBottom()) return;
         for (const entry of entries) {
           if (entry.isIntersecting) {
             intersecting.add(entry.target.id);
@@ -47,7 +52,17 @@ export function AccessoriesSideNav({ heading, items }: Props) {
       if (el) observer.observe(el);
     }
 
-    return () => observer.disconnect();
+    const onScroll = () => {
+      if (isNearBottom() && flat.length > 0) {
+        setActive(flat[flat.length - 1].id);
+      }
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", onScroll);
+    };
   }, [flat]);
 
   return (

--- a/src/components/accessories/accessories-shell.css
+++ b/src/components/accessories/accessories-shell.css
@@ -67,7 +67,7 @@
 .acc-nav__sublink {
   padding: 5px 0 5px 12px;
   margin-left: -14px;
-  font: 400 var(--lt-fs-xs)/1.4 var(--lt-sans);
+  font: 400 14px/1.4 var(--lt-sans);
   color: var(--pd-muted);
 }
 .acc-nav__link:hover,
@@ -119,6 +119,7 @@
   letter-spacing: -0.02em;
   color: var(--pd-fg-strong);
   max-width: 760px;
+  white-space: pre-line;
 }
 .acc-sechd__sub {
   margin: 0;

--- a/src/components/company/company-shell.css
+++ b/src/components/company/company-shell.css
@@ -17,7 +17,7 @@
   padding-top: 56px;
 }
 .co-aside__heading {
-  font: 600 var(--lt-fs-sm) var(--lt-mono);
+  font: 600 var(--lt-fs-md) var(--lt-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pd-primary);
@@ -44,7 +44,7 @@
   display: block;
   padding: 7px 0 7px 14px;
   margin-left: -16px;
-  font: 400 var(--lt-fs-sm)/1.45 var(--lt-sans);
+  font: 400 var(--lt-fs-md)/1.45 var(--lt-sans);
   color: var(--pd-muted);
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -108,7 +108,7 @@
 .co-sechd__sub {
   margin: 0;
   max-width: 620px;
-  font-size: var(--lt-fs-md);
+  font-size: var(--lt-fs-sm);
   color: var(--pd-muted);
   line-height: 1.55;
 }
@@ -204,7 +204,7 @@
   border-color: var(--pd-primary);
 }
 .co-timeline__date {
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
+  font: 500 var(--lt-fs-sm) var(--lt-mono);
   color: var(--pd-primary);
   letter-spacing: 0.04em;
 }
@@ -326,6 +326,30 @@
 }
 .co-office__value a:hover {
   text-decoration-color: var(--pd-primary);
+}
+.co-office__maplinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 6px;
+}
+.co-office__value .co-office__maplink {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--lt-fs-xs);
+  color: var(--pd-primary);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+.co-office__value .co-office__maplink svg {
+  color: var(--pd-primary);
+  transition: color 120ms ease;
+  flex-shrink: 0;
+}
+.co-office__value .co-office__maplink:hover,
+.co-office__value .co-office__maplink:hover svg {
+  color: var(--pd-primary-dark);
 }
 
 @media (max-width: 900px) {

--- a/src/components/home/Series/Series.css
+++ b/src/components/home/Series/Series.css
@@ -22,9 +22,6 @@
 .ho-series__card:hover {
   background: var(--pd-surface-2);
 }
-.ho-series__card.is-highlight {
-  background: color-mix(in oklab, var(--pd-primary) 5%, var(--pd-surface));
-}
 .ho-series__top {
   display: flex;
   align-items: center;

--- a/src/components/layout/HeaderNav/HeaderNav.css
+++ b/src/components/layout/HeaderNav/HeaderNav.css
@@ -7,6 +7,7 @@
   gap: 2px;
   margin-left: 16px;
   height: 100%;
+  cursor: pointer;
 }
 
 .pd-top__navitem {

--- a/src/components/layout/MegaMenu/MegaMenu.css
+++ b/src/components/layout/MegaMenu/MegaMenu.css
@@ -14,8 +14,7 @@
 .pd-mega__panel {
   position: absolute;
   top: 8px;
-  inset-inline: 0;
-  margin-inline: auto;
+  left: 0;
   width: min(880px, calc(100% - 32px));
   background: var(--pd-surface);
   border: 1px solid var(--pd-border);

--- a/src/components/layout/MegaMenu/MegaMenu.tsx
+++ b/src/components/layout/MegaMenu/MegaMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Link } from "@/i18n/navigation";
 import { getProductsCategories } from "@/lib/content/shell";
 import type {
@@ -16,16 +17,39 @@ type Props = { items: ShellNavItem[]; locale: Locale };
 
 export function MegaMenu({ items, locale }: Props) {
   const { openId, onItemEnter, onItemLeave } = useHeaderNav();
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Cursor entering the panel cancels the close-grace timer that fired when
-  // the cursor left the nav row. `onItemEnter(openId)` is a no-op state-wise
-  // but clears the timer (see HeaderShell ctx).
+  useEffect(() => {
+    const position = () => {
+      if (!containerRef.current) return;
+      const containerRect = containerRef.current.getBoundingClientRect();
+      items.forEach((item) => {
+        if (!item.menu) return;
+        const button = document.querySelector(
+          `[aria-controls="pd-mega-${item.id}"]`,
+        ) as HTMLElement | null;
+        const panel = document.getElementById(
+          `pd-mega-${item.id}`,
+        ) as HTMLElement | null;
+        if (!button || !panel) return;
+        const buttonLeft =
+          button.getBoundingClientRect().left - containerRect.left;
+        const maxLeft = containerRect.width - panel.offsetWidth - 16;
+        panel.style.left = `${Math.min(buttonLeft, maxLeft)}px`;
+      });
+    };
+    position();
+    window.addEventListener("resize", position);
+    return () => window.removeEventListener("resize", position);
+  }, [items]);
+
   const handleEnter = () => {
     if (openId) onItemEnter(openId);
   };
 
   return (
     <div
+      ref={containerRef}
       className="pd-mega"
       onMouseEnter={handleEnter}
       onMouseLeave={onItemLeave}

--- a/src/components/products/CategoryHero/CategoryHero.css
+++ b/src/components/products/CategoryHero/CategoryHero.css
@@ -2,32 +2,27 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 48px;
-  padding: 24px 0 32px;
+  padding: 32px 28px 40px;
   border-bottom: 1px solid var(--pd-rule);
-  margin-bottom: 24px;
+  margin: 0 -28px 24px;
+  background: var(--pd-surface-2);
+  border-radius: 4px 4px 0 0;
 }
 .lt-cat-hero__lead {
   max-width: 720px;
 }
 .lt-cat-hero__kicker {
   display: block;
-  font: 500 11px var(--lt-mono);
-  letter-spacing: 0.12em;
+  font: 500 11px var(--lt-sans);
+  letter-spacing: 0.02em;
   text-transform: uppercase;
-  color: var(--pd-primary);
-  margin-bottom: 14px;
+  color: var(--pd-muted);
+  margin-bottom: 8px;
 }
 .lt-cat-hero__title {
   margin: 0 0 12px;
   font: 500 var(--lt-fs-h2-dense) / 1.1 var(--lt-sans);
   letter-spacing: -0.015em;
-  color: var(--pd-fg-strong);
-}
-.lt-cat-hero__code {
-  font-family: var(--lt-mono);
-  font-size: inherit;
-  font-weight: 500;
-  letter-spacing: 0.02em;
   color: var(--pd-primary);
 }
 .lt-cat-hero__lede {
@@ -40,7 +35,6 @@
 
 :lang(ko) .lt-cat-hero__kicker,
 :lang(zh) .lt-cat-hero__kicker {
-  font-family: var(--lt-sans);
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   text-transform: none;
 }

--- a/src/components/products/CategoryHero/CategoryHero.tsx
+++ b/src/components/products/CategoryHero/CategoryHero.tsx
@@ -1,29 +1,20 @@
 import "./CategoryHero.css";
 
 type Props = {
-  kickerNum: string;
   kickerLabel: string;
   title: string;
   code: string;
   lede: string;
 };
 
-export function CategoryHero({
-  kickerNum,
-  kickerLabel,
-  title,
-  code,
-  lede,
-}: Props) {
+export function CategoryHero({ kickerLabel, title, code, lede }: Props) {
   return (
     <header className="lt-cat-hero">
       <div className="lt-cat-hero__lead">
         <div className="lt-cat-hero__kicker">
-          {kickerNum} — {kickerLabel}
+          {code} — {kickerLabel}
         </div>
-        <h1 className="lt-cat-hero__title">
-          {title} <span className="lt-cat-hero__code">{code}</span>
-        </h1>
+        <h1 className="lt-cat-hero__title">{title}</h1>
         <p className="lt-cat-hero__lede">{lede}</p>
       </div>
     </header>

--- a/src/components/products/ProductStack/ProductStack.css
+++ b/src/components/products/ProductStack/ProductStack.css
@@ -19,7 +19,7 @@
   letter-spacing: -0.01em;
   color: var(--pd-fg-strong);
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 10px;
 }
 .lt-prod-stack__count {

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -6,11 +6,11 @@ export type CategorySlug = (typeof CATEGORY_SLUGS)[number];
 
 export const CATEGORIES: Record<
   CategorySlug,
-  { kickerNum: string; code: string; series: Product["series"] }
+  { code: string; series: Product["series"] }
 > = {
-  analogue: { kickerNum: "01", code: "M·MS", series: "analogue" },
-  digital: { kickerNum: "02", code: "MD", series: "digital" },
-  specialized: { kickerNum: "03", code: "LD·LM", series: "specialized" },
+  analogue: { code: "M·MS", series: "analogue" },
+  digital: { code: "MD", series: "digital" },
+  specialized: { code: "LD·LM", series: "specialized" },
 };
 
 export function isCategorySlug(s: string): s is CategorySlug {

--- a/src/lib/content/accessories.ts
+++ b/src/lib/content/accessories.ts
@@ -130,7 +130,7 @@ export const LT_ACCESSORIES: Record<Locale, AccessoriesContent> = {
           { id: "pr-030", href: "#pr-030", label: "PR-030" },
         ],
       },
-      { id: "contact", href: "#contact", label: "Get in touch" },
+      { id: "contact", href: "#contact", label: "Contact" },
     ],
     breadcrumbAccessories: "Accessories",
     hero: {

--- a/src/lib/content/accessories.ts
+++ b/src/lib/content/accessories.ts
@@ -306,7 +306,7 @@ export const LT_ACCESSORIES: Record<Locale, AccessoriesContent> = {
     },
     readouts: {
       kicker: "01 — 표시기",
-      title: "실시간 유량 신호를 표시하는 패널 장착형 디스플레이.",
+      title: "실시간 유량 신호를 표시하는\n패널 장착형 디스플레이.",
       sub: "두 LTI 모델 모두 라인테크 MFC 또는 MFM의 0–5 V 출력을 입력으로 받아 4자리 7-세그먼트 디스플레이에 유량을 표시합니다. 형태에 따라 선택하십시오 — 소형 패널 일체형(LTI-200) 또는 PC 소프트웨어를 지원하는 랙 마운트형(LTI-1000).",
       items: [
         {

--- a/src/lib/content/company.ts
+++ b/src/lib/content/company.ts
@@ -87,6 +87,11 @@ export type CompanyCertifications = {
   footnote: string;
 };
 
+export type CompanyMapLink = {
+  label: string;
+  href: string;
+};
+
 export type CompanyLocationOffice = {
   /** Heading: "Headquarters" / "Subsidiary". */
   heading: string;
@@ -96,6 +101,7 @@ export type CompanyLocationOffice = {
   phone?: string;
   fax?: string;
   email?: string;
+  mapLinks?: CompanyMapLink[];
 };
 
 export type CompanyLocationLabels = {
@@ -262,6 +268,20 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         phone: "042-624-0700",
         fax: "042-638-2211",
         email: "linetech@line-tech.co.kr",
+        mapLinks: [
+          {
+            label: "카카오맵",
+            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+          },
+          {
+            label: "네이버지도",
+            href: "https://map.naver.com/v5/search/대전광역시 유성구 대덕대로 806",
+          },
+          {
+            label: "구글지도",
+            href: "https://maps.google.com/maps?q=대전광역시+유성구+대덕대로+806",
+          },
+        ],
       },
     },
   },
@@ -384,6 +404,20 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         phone: "+82-42-624-0700",
         fax: "+82-42-638-2211",
         email: "linetech@line-tech.co.kr",
+        mapLinks: [
+          {
+            label: "Kakao Maps",
+            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+          },
+          {
+            label: "Naver Maps",
+            href: "https://map.naver.com/v5/search/대전광역시 유성구 대덕대로 806",
+          },
+          {
+            label: "Google Maps",
+            href: "https://maps.google.com/maps?q=대전광역시+유성구+대덕대로+806",
+          },
+        ],
       },
     },
   },
@@ -505,11 +539,35 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         phone: "+82-42-624-0700",
         fax: "+82-42-638-2211",
         email: "linetech@line-tech.co.kr",
+        mapLinks: [
+          {
+            label: "Kakao地图",
+            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+          },
+          {
+            label: "谷歌地图",
+            href: "https://maps.google.com/maps?q=대전광역시+유성구+대덕대로+806",
+          },
+        ],
       },
       subsidiary: {
         heading: "中国子公司",
         name: "莱因精密技术（无锡）有限公司",
         address: "江苏省无锡市锡山区锡沪东荟智企业中心 6 号楼 117 号",
+        mapLinks: [
+          {
+            label: "高德地图",
+            href: "https://uri.amap.com/search?keyword=江苏省无锡市锡山区锡沪东荟智企业中心6号楼117号",
+          },
+          {
+            label: "百度地图",
+            href: "https://map.baidu.com/search/江苏省无锡市锡山区锡沪东荟智企业中心6号楼117号",
+          },
+          {
+            label: "谷歌地图",
+            href: "https://maps.google.com/maps?q=江苏省无锡市锡山区锡沪东荟智企业中心6号楼117号",
+          },
+        ],
       },
     },
   },

--- a/src/lib/content/company.ts
+++ b/src/lib/content/company.ts
@@ -271,11 +271,11 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         mapLinks: [
           {
             label: "카카오맵",
-            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+            href: "https://map.kakao.com/link/search/%EB%8C%80%EC%A0%84%EA%B4%91%EC%97%AD%EC%8B%9C%20%EC%9C%A0%EC%84%B1%EA%B5%AC%20%EB%8C%80%EB%8D%95%EB%8C%80%EB%A1%9C%20806",
           },
           {
             label: "네이버지도",
-            href: "https://map.naver.com/v5/search/대전광역시 유성구 대덕대로 806",
+            href: "https://map.naver.com/v5/search/%EB%8C%80%EC%A0%84%EA%B4%91%EC%97%AD%EC%8B%9C%20%EC%9C%A0%EC%84%B1%EA%B5%AC%20%EB%8C%80%EB%8D%95%EB%8C%80%EB%A1%9C%20806",
           },
           {
             label: "구글지도",
@@ -407,11 +407,11 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         mapLinks: [
           {
             label: "Kakao Maps",
-            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+            href: "https://map.kakao.com/link/search/%EB%8C%80%EC%A0%84%EA%B4%91%EC%97%AD%EC%8B%9C%20%EC%9C%A0%EC%84%B1%EA%B5%AC%20%EB%8C%80%EB%8D%95%EB%8C%80%EB%A1%9C%20806",
           },
           {
             label: "Naver Maps",
-            href: "https://map.naver.com/v5/search/대전광역시 유성구 대덕대로 806",
+            href: "https://map.naver.com/v5/search/%EB%8C%80%EC%A0%84%EA%B4%91%EC%97%AD%EC%8B%9C%20%EC%9C%A0%EC%84%B1%EA%B5%AC%20%EB%8C%80%EB%8D%95%EB%8C%80%EB%A1%9C%20806",
           },
           {
             label: "Google Maps",
@@ -542,7 +542,7 @@ export const LT_COMPANY: Record<Locale, CompanyContent> = {
         mapLinks: [
           {
             label: "Kakao地图",
-            href: "https://map.kakao.com/link/search/대전광역시 유성구 대덕대로 806",
+            href: "https://map.kakao.com/link/search/%EB%8C%80%EC%A0%84%EA%B4%91%EC%97%AD%EC%8B%9C%20%EC%9C%A0%EC%84%B1%EA%B5%AC%20%EB%8C%80%EB%8D%95%EB%8C%80%EB%A1%9C%20806",
           },
           {
             label: "谷歌地图",

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -202,7 +202,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
 
   en: {
     breadcrumbLabel: "Contact",
-    title: "Get in touch",
+    title: "Contact Us",
     lede: "Product questions, technical support, partnership ideas — whatever brings you here, we'll reply within two business days.",
     infoHeading: "Contact details",
     hoursLabel: "Hours",
@@ -217,7 +217,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       notice:
         "Our online submission system is being upgraded. For an immediate response, please email us directly using the address above.",
       fields: {
-        inquiryType: "What's this about?",
+        inquiryType: "Topic",
         name: "Name",
         email: "Email",
         company: "Company",

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -148,7 +148,7 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     intro: {
       kicker: "Since 1997 · Mass Flow Solutions",
       title1: "Reliable technology,",
-      title2: "supreme service.",
+      title2: "trusted service.",
       lede: "Korea's first domestic manufacturer of mass flow controllers and meters. Proven for over 25 years across semiconductor, display, biotech, and fuel-cell process lines.",
       ctaPrimary: "View M3030VA product",
       ctaSecondary: "Full catalog (PDF)",


### PR DESCRIPTION
## Summary
- CategoryHero: replace numbered kicker with series code (M·MS), switch kicker font to sans, remove redundant code from h1 title
- Accessories side nav: fix last-item (문의) scroll-spy not activating; bump sub-link font size; add intentional line break in readouts section title
- CSP: add `https://www.google.com/maps/` to `frame-src` so the contact page map embed loads
- Company page: add map links (Kakao, Naver, Google) to office address cards
- ProductStack: fix count badge vertical alignment (baseline → center)
- Header nav: consistent pointer cursor across inter-item gaps

## Test plan
- [ ] `/ko/products/analogue` — kicker shows "M·MS — 제품 시리즈", no code in h1
- [ ] `/ko/products/accessories` — scroll to 문의, left accent activates
- [ ] `/contact` — Google Maps iframe loads
- [ ] `/company` — map links appear on HQ card
- [ ] Header nav — pointer cursor consistent across all items

🤖 Generated with [Claude Code](https://claude.com/claude-code)