### PR TITLE
fix(a11y): accessibility tree audit — semantic landmarks, lists, focus (#76)

### DIFF
--- a/src/app/[locale]/company/page.tsx
+++ b/src/app/[locale]/company/page.tsx
@@ -61,11 +61,14 @@ function Greeting({ c }: { c: CompanyContent }) {
         </div>
         <aside
           className="co-greeting__facts"
-          aria-label={c.greeting.factsHeading}
+          aria-labelledby="co-greeting-facts-heading"
         >
-          <div className="co-greeting__factsHeading">
+          <h2
+            id="co-greeting-facts-heading"
+            className="co-greeting__factsHeading"
+          >
             {c.greeting.factsHeading}
-          </div>
+          </h2>
           <dl className="co-greeting__factList">
             {c.greeting.facts.map((fact) => (
               <div key={fact.k} className="co-greeting__fact">

--- a/src/components/home/Applications/Applications.tsx
+++ b/src/components/home/Applications/Applications.tsx
@@ -9,17 +9,17 @@ export function Applications({ h }: Props) {
   return (
     <section className="ho-sec">
       <SectionHead kicker={applications.kicker} title={applications.title} />
-      <div className="ho-applications">
+      <ul className="ho-applications">
         {applications.items.map((a, i) => (
-          <div className="ho-applications__cell" key={a.n}>
+          <li className="ho-applications__cell" key={a.n}>
             <div className="ho-applications__num">
               {String(i + 1).padStart(2, "0")}
             </div>
             <div className="ho-applications__n">{a.n}</div>
             <div className="ho-applications__k">{a.k}</div>
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/src/components/home/Credentials/Credentials.tsx
+++ b/src/components/home/Credentials/Credentials.tsx
@@ -9,14 +9,14 @@ export function Credentials({ h }: Props) {
   return (
     <section className="ho-sec">
       <SectionHead kicker={credentials.kicker} title={credentials.title} />
-      <div className="ho-credentials">
+      <ul className="ho-credentials">
         {credentials.items.map((it) => (
-          <div key={it} className="ho-credentials__item">
-            <span className="ho-credentials__dot" />
+          <li key={it} className="ho-credentials__item">
+            <span className="ho-credentials__dot" aria-hidden="true" />
             <span>{it}</span>
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/src/components/home/Stats/Stats.tsx
+++ b/src/components/home/Stats/Stats.tsx
@@ -5,14 +5,14 @@ type Props = { h: HomeContent };
 
 export function Stats({ h }: Props) {
   return (
-    <section className="ho-stats">
+    <ul className="ho-stats">
       {h.stats.map((s, i) => (
-        <div className="ho-stats__cell" key={i}>
+        <li className="ho-stats__cell" key={i}>
           <div className="ho-stats__k">{s.k}</div>
           <div className="ho-stats__l">{s.l}</div>
           <div className="ho-stats__s">{s.sub}</div>
-        </div>
+        </li>
       ))}
-    </section>
+    </ul>
   );
 }

--- a/src/components/layout/Header/HeaderShell.tsx
+++ b/src/components/layout/Header/HeaderShell.tsx
@@ -91,11 +91,16 @@ export function HeaderShell({
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpenId(null);
+      if (e.key !== "Escape" || !openId) return;
+      const trigger = document.querySelector<HTMLButtonElement>(
+        `[aria-controls="pd-mega-${openId}"]`,
+      );
+      setOpenId(null);
+      trigger?.focus();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [openId]);
 
   const closeSearch = useCallback(() => setSearchOpen(false), []);
 

--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -13,9 +13,9 @@ export async function PageShell({ locale, children }: Props) {
         {t("main")}
       </a>
       <Header locale={locale} />
-      <div id="lt-main" tabIndex={-1}>
+      <main id="lt-main" tabIndex={-1}>
         {children}
-      </div>
+      </main>
       <Footer locale={locale} />
     </>
   );


### PR DESCRIPTION
## Summary
- `PageShell`: skip-link target changed from `<div>` to `<main>` — page now has a real `main` landmark
- `Stats`, `Credentials`, `Applications` (home): repeated tile divs converted to `<ul>/<li>` so screen readers announce list count
- `Company` greeting: facts heading `div` → `<h2>` with `aria-labelledby` on the `<aside>`, enabling heading navigation
- `HeaderShell`: Escape key now restores focus to the mega-menu trigger button instead of punting focus to `<body>`

## Test plan
- Tab once on any page → "Skip to main content" link appears → Enter → focus lands on `<main>`
- Home page: Stats / Credentials / Applications sections look visually identical (no bullet bleed from list reset)
- `/company`: Greeting facts panel looks identical; DevTools Accessibility tree shows the `<aside>` labelled by the `<h2>`
- Desktop header: Tab to a nav trigger → Enter to open mega menu → Tab into panel → Escape → focus returns to trigger button

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)