### PR TITLE
feat(products): featured product showcase on category pages (#83)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -90,7 +90,15 @@
       "fitting": "Fitting",
       "view": "View"
     },
-    "emptyStack": "No products in this category yet."
+    "emptyStack": "No products in this category yet.",
+    "showcase": {
+      "sectionLabel": "Featured products",
+      "viewProduct": "View product",
+      "modelLabel": "Model",
+      "functionLabel": "Function",
+      "highlightLabel": "Highlight",
+      "slidesLabel": "Slides"
+    }
   },
   "pdp": {
     "tabs": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,7 +97,9 @@
       "modelLabel": "Model",
       "functionLabel": "Function",
       "highlightLabel": "Highlight",
-      "slidesLabel": "Slides"
+      "slidesLabel": "Slides",
+      "slidesAriaLabel": "Featured product slides",
+      "slideAriaLabel": "Slide {n}"
     }
   },
   "pdp": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -90,7 +90,15 @@
       "fitting": "연결",
       "view": "보기"
     },
-    "emptyStack": "이 카테고리에는 아직 등록된 제품이 없습니다."
+    "emptyStack": "이 카테고리에는 아직 등록된 제품이 없습니다.",
+    "showcase": {
+      "sectionLabel": "대표 제품",
+      "viewProduct": "제품 보기",
+      "modelLabel": "모델",
+      "functionLabel": "유형",
+      "highlightLabel": "특징",
+      "slidesLabel": "슬라이드"
+    }
   },
   "pdp": {
     "tabs": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -97,7 +97,9 @@
       "modelLabel": "모델",
       "functionLabel": "유형",
       "highlightLabel": "특징",
-      "slidesLabel": "슬라이드"
+      "slidesLabel": "슬라이드",
+      "slidesAriaLabel": "대표 제품 슬라이드",
+      "slideAriaLabel": "슬라이드 {n}"
     }
   },
   "pdp": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -90,7 +90,15 @@
       "fitting": "接口",
       "view": "查看"
     },
-    "emptyStack": "该类别下暂无产品。"
+    "emptyStack": "该类别下暂无产品。",
+    "showcase": {
+      "sectionLabel": "精选产品",
+      "viewProduct": "查看产品",
+      "modelLabel": "型号",
+      "functionLabel": "类型",
+      "highlightLabel": "亮点",
+      "slidesLabel": "幻灯片"
+    }
   },
   "pdp": {
     "tabs": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -97,7 +97,9 @@
       "modelLabel": "型号",
       "functionLabel": "类型",
       "highlightLabel": "亮点",
-      "slidesLabel": "幻灯片"
+      "slidesLabel": "幻灯片",
+      "slidesAriaLabel": "精选产品幻灯片",
+      "slideAriaLabel": "幻灯片 {n}"
     }
   },
   "pdp": {

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -13,7 +13,22 @@ export default defineConfig({
   dataset,
   basePath: "/studio",
   plugins: [
-    structureTool(),
+    structureTool({
+      structure: (S) =>
+        S.list()
+          .title("Content")
+          .items([
+            S.documentTypeListItem("product").title("Products"),
+            S.divider(),
+            S.listItem()
+              .title("Category Showcases")
+              .child(
+                S.document()
+                  .schemaType("categoryShowcase")
+                  .documentId("category-showcases"),
+              ),
+          ]),
+    }),
     internationalizedArray({
       languages: [
         { id: "ko", title: "한국어" },

--- a/sanity/schemaTypes/categoryShowcase.ts
+++ b/sanity/schemaTypes/categoryShowcase.ts
@@ -1,0 +1,97 @@
+import { defineType, defineField, defineArrayMember } from "sanity";
+
+export const categoryShowcase = defineType({
+  name: "categoryShowcase",
+  title: "Category Showcases",
+  type: "document",
+  fields: [
+    defineField({
+      name: "analogue",
+      title: "Analogue series",
+      type: "array",
+      of: [
+        defineArrayMember({
+          type: "object",
+          fields: [
+            defineField({
+              name: "product",
+              title: "Product",
+              type: "reference",
+              to: [{ type: "product" }],
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "caption",
+              title: "Caption",
+              type: "string",
+              description:
+                "Short highlight shown on the slide — e.g. '±0.5% F.S. accuracy'",
+            }),
+          ],
+          preview: {
+            select: { title: "product.model", subtitle: "caption" },
+          },
+        }),
+      ],
+    }),
+    defineField({
+      name: "digital",
+      title: "Digital series",
+      type: "array",
+      of: [
+        defineArrayMember({
+          type: "object",
+          fields: [
+            defineField({
+              name: "product",
+              title: "Product",
+              type: "reference",
+              to: [{ type: "product" }],
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "caption",
+              title: "Caption",
+              type: "string",
+              description: "Short highlight shown on the slide.",
+            }),
+          ],
+          preview: {
+            select: { title: "product.model", subtitle: "caption" },
+          },
+        }),
+      ],
+    }),
+    defineField({
+      name: "specialized",
+      title: "Specialized series",
+      type: "array",
+      of: [
+        defineArrayMember({
+          type: "object",
+          fields: [
+            defineField({
+              name: "product",
+              title: "Product",
+              type: "reference",
+              to: [{ type: "product" }],
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "caption",
+              title: "Caption",
+              type: "string",
+              description: "Short highlight shown on the slide.",
+            }),
+          ],
+          preview: {
+            select: { title: "product.model", subtitle: "caption" },
+          },
+        }),
+      ],
+    }),
+  ],
+  preview: {
+    prepare: () => ({ title: "Category Showcases" }),
+  },
+});

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,3 +1,4 @@
 import { product } from "./product";
+import { categoryShowcase } from "./categoryShowcase";
 
-export const schemaTypes = [product];
+export const schemaTypes = [product, categoryShowcase];

--- a/scripts/seed-showcase.ts
+++ b/scripts/seed-showcase.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+
+function loadEnv(path: string) {
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) process.env[m[1]] ??= m[2].trimEnd();
+  }
+}
+
+loadEnv(".env.local");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error("Missing env vars.");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+const FEATURED: Record<string, { model: string; caption: string }[]> = {
+  analogue: [
+    { model: "M3030VA", caption: "±0.5% F.S. accuracy" },
+    { model: "MS3700VA", caption: "5–3,000 sccm flow range" },
+    { model: "M2030VA", caption: "Sub-200 ms response time" },
+  ],
+  digital: [
+    { model: "MD30C", caption: "8-point linearization, RS-485 / Modbus RTU" },
+    { model: "MD100C", caption: "±0.25% F.S. accuracy" },
+    { model: "MD400C", caption: "High-flow digital mass flow control" },
+  ],
+  specialized: [
+    { model: "LD030C", caption: "Display-integrated mass flow controller" },
+    { model: "LM030C", caption: "Display-integrated mass flow meter" },
+  ],
+};
+
+async function run() {
+  // Fetch all product IDs keyed by model
+  const products: { _id: string; model: string }[] = await client.fetch(
+    `*[_type == "product"]{ _id, model }`,
+  );
+  const byModel = Object.fromEntries(
+    products.map((p) => [p.model.toUpperCase(), p._id]),
+  );
+
+  function toEntries(items: { model: string; caption: string }[]) {
+    return items.flatMap(({ model, caption }) => {
+      const id = byModel[model.toUpperCase()];
+      if (!id) {
+        console.warn(`  ⚠ product not found: ${model}`);
+        return [];
+      }
+      return [
+        {
+          _type: "object",
+          _key: model,
+          product: { _type: "reference", _ref: id },
+          caption,
+        },
+      ];
+    });
+  }
+
+  const doc = {
+    _id: "category-showcases",
+    _type: "categoryShowcase",
+    analogue: toEntries(FEATURED.analogue),
+    digital: toEntries(FEATURED.digital),
+    specialized: toEntries(FEATURED.specialized),
+  };
+
+  await client.createOrReplace(doc);
+  console.log("✓ category-showcases created/updated");
+  for (const [cat, entries] of Object.entries(doc)) {
+    if (Array.isArray(entries))
+      console.log(`  ${cat}: ${entries.length} featured`);
+  }
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -13,6 +13,7 @@ import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { SanityProductSchema } from "@/lib/types/product";
 import { CategoryShowcaseSchema } from "@/lib/types/showcase";
+import { resolveProductImage } from "@/lib/productImages";
 import { z } from "zod";
 import { buildCategoryMetadata, siteUrl } from "@/lib/seo";
 import { safeJsonLd } from "@/lib/seo/jsonLd";
@@ -59,7 +60,7 @@ export default async function CategoryPage({ params }: Props) {
     function: e.function,
     flowRange: e.flowRange,
     accuracy: e.accuracy,
-    image: `/products/${e.slug}/product-1.jpg`,
+    image: resolveProductImage(e.slug),
     href: `/${locale}/products/${category}/${e.slug}`,
   }));
 
@@ -140,6 +141,10 @@ export default async function CategoryPage({ params }: Props) {
             accuracyLabel={tProducts("table.accuracy")}
             highlightLabel={tProducts("showcase.highlightLabel")}
             slidesLabel={tProducts("showcase.slidesLabel")}
+            slidesAriaLabel={tProducts("showcase.slidesAriaLabel")}
+            slideAriaLabels={showcaseProducts.map((_, i) =>
+              tProducts("showcase.slideAriaLabel", { n: i + 1 }),
+            )}
           />
         )}
         <ProductStack

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -3,14 +3,16 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { CategoryHero } from "@/components/products/CategoryHero";
+import { CategoryShowcase } from "@/components/products/CategoryShowcase";
 import { ProductStack } from "@/components/products/ProductStack";
 import { sanityClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { productsBySeriesQuery } from "@/sanity/queries";
+import { productsBySeriesQuery, categoryShowcaseQuery } from "@/sanity/queries";
 import { CATEGORIES, CATEGORY_SLUGS, isCategorySlug } from "@/lib/categories";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { SanityProductSchema } from "@/lib/types/product";
+import { CategoryShowcaseSchema } from "@/lib/types/showcase";
 import { z } from "zod";
 import { buildCategoryMetadata, siteUrl } from "@/lib/seo";
 import { safeJsonLd } from "@/lib/seo/jsonLd";
@@ -36,14 +38,30 @@ export default async function CategoryPage({ params }: Props) {
   if (!isCategorySlug(category)) notFound();
 
   const cat = CATEGORIES[category];
-  const products = z
-    .array(SanityProductSchema)
-    .parse(
-      await fetchSanity(
-        () => sanityClient.fetch(productsBySeriesQuery, { series: cat.series }),
-        { name: "productsBySeries", params: { series: cat.series } },
-      ),
-    );
+
+  const [productsRaw, showcaseRaw] = await Promise.all([
+    fetchSanity(
+      () => sanityClient.fetch(productsBySeriesQuery, { series: cat.series }),
+      { name: "productsBySeries", params: { series: cat.series } },
+    ),
+    fetchSanity(() => sanityClient.fetch(categoryShowcaseQuery), {
+      name: "categoryShowcase",
+    }),
+  ]);
+
+  const products = z.array(SanityProductSchema).parse(productsRaw);
+  const showcase = CategoryShowcaseSchema.nullable().parse(showcaseRaw ?? null);
+  const featuredEntries = showcase?.[category] ?? [];
+  const showcaseProducts = featuredEntries.map((e) => ({
+    slug: e.slug,
+    model: e.model,
+    caption: e.caption,
+    function: e.function,
+    flowRange: e.flowRange,
+    accuracy: e.accuracy,
+    image: `/products/${e.slug}/product-1.jpg`,
+    href: `/${locale}/products/${category}/${e.slug}`,
+  }));
 
   const [tCommon, tNav, tBreadcrumb, tProducts] = await Promise.all([
     getTranslations("common"),
@@ -111,6 +129,19 @@ export default async function CategoryPage({ params }: Props) {
           code={cat.code}
           lede={tProducts(`categories.${category}.lede`)}
         />
+        {showcaseProducts.length > 0 && (
+          <CategoryShowcase
+            products={showcaseProducts}
+            viewLabel={tProducts("showcase.viewProduct")}
+            sectionLabel={tProducts("showcase.sectionLabel")}
+            modelLabel={tProducts("showcase.modelLabel")}
+            functionLabel={tProducts("showcase.functionLabel")}
+            flowRangeLabel={tProducts("table.range")}
+            accuracyLabel={tProducts("table.accuracy")}
+            highlightLabel={tProducts("showcase.highlightLabel")}
+            slidesLabel={tProducts("showcase.slidesLabel")}
+          />
+        )}
         <ProductStack
           title={tProducts("stack.controllers.title")}
           subtitle={tProducts("stack.controllers.subtitle")}

--- a/src/components/products/CategoryShowcase/CategoryShowcase.css
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.css
@@ -1,0 +1,258 @@
+.lt-showcase {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 32px;
+  min-height: 380px;
+  border: 1px solid var(--pd-border);
+  background: var(--pd-surface);
+}
+
+/* ── Corner brackets ─────────────────────────────────────── */
+.lt-showcase__bracket {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+  z-index: 2;
+}
+.lt-showcase__bracket--tl {
+  top: -1px;
+  left: -1px;
+  border-top: 2px solid var(--pd-fg-strong);
+  border-left: 2px solid var(--pd-fg-strong);
+}
+.lt-showcase__bracket--tr {
+  top: -1px;
+  right: -1px;
+  border-top: 2px solid var(--pd-fg-strong);
+  border-right: 2px solid var(--pd-fg-strong);
+}
+.lt-showcase__bracket--bl {
+  bottom: -1px;
+  left: -1px;
+  border-bottom: 2px solid var(--pd-fg-strong);
+  border-left: 2px solid var(--pd-fg-strong);
+}
+.lt-showcase__bracket--br {
+  bottom: -1px;
+  right: -1px;
+  border-bottom: 2px solid var(--pd-fg-strong);
+  border-right: 2px solid var(--pd-fg-strong);
+}
+
+/* ── Image side ──────────────────────────────────────────── */
+.lt-showcase__img-col {
+  position: relative;
+  background-image:
+    linear-gradient(var(--pd-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--pd-rule) 1px, transparent 1px);
+  background-size: 20px 20px;
+  background-position: -1px -1px;
+  border-right: 1px solid var(--pd-border);
+}
+
+.lt-showcase__slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.55s ease;
+  pointer-events: none;
+}
+.lt-showcase__slide[data-active="true"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.lt-showcase__img {
+  object-fit: contain;
+  object-position: center;
+  padding: 36px;
+}
+
+.lt-showcase__fig {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.12em;
+  color: var(--pd-muted);
+  z-index: 1;
+}
+
+/* ── Data sheet side ─────────────────────────────────────── */
+.lt-showcase__data {
+  padding: 32px 36px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+}
+
+.lt-showcase__section-label {
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pd-muted);
+  margin-bottom: 18px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--pd-border);
+}
+
+:lang(ko) .lt-showcase__section-label,
+:lang(zh) .lt-showcase__section-label {
+  font-family: var(--lt-sans);
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+.lt-showcase__entry {
+  position: absolute;
+  left: 36px;
+  right: 36px;
+  opacity: 0;
+  transition: opacity 0.55s ease;
+  pointer-events: none;
+}
+.lt-showcase__entry[data-active="true"] {
+  position: relative;
+  left: auto;
+  right: auto;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── Data rows ───────────────────────────────────────────── */
+.lt-showcase__row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 12px;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px dashed var(--pd-border);
+  align-items: baseline;
+}
+
+.lt-showcase__row-label {
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pd-muted);
+}
+
+:lang(ko) .lt-showcase__row-label,
+:lang(zh) .lt-showcase__row-label {
+  font-family: var(--lt-sans);
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+.lt-showcase__row-value {
+  font: 400 14px var(--lt-sans);
+  color: var(--pd-fg-strong);
+}
+
+.lt-showcase__row-value[data-mono="true"] {
+  font: 600 18px var(--lt-mono);
+  letter-spacing: -0.005em;
+}
+
+/* ── CTA button ──────────────────────────────────────────── */
+.lt-showcase__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 500 12px / 1 var(--lt-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  text-decoration: none;
+  padding: 10px 14px;
+  border: 1px solid var(--pd-primary);
+  margin-top: 12px;
+  align-self: flex-start;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.lt-showcase__link:hover {
+  background: var(--pd-primary);
+  color: var(--pd-on-primary);
+}
+
+:lang(ko) .lt-showcase__link,
+:lang(zh) .lt-showcase__link {
+  font-family: var(--lt-sans);
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+/* ── Tick mark navigation ───────────────────────────────── */
+.lt-showcase__nav {
+  margin-top: 28px;
+  padding-top: 16px;
+  border-top: 1px solid var(--pd-border);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font: 500 11px var(--lt-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pd-muted);
+}
+
+:lang(ko) .lt-showcase__nav,
+:lang(zh) .lt-showcase__nav {
+  font-family: var(--lt-sans);
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+.lt-showcase__nav-spacer {
+  flex: 1;
+}
+
+.lt-showcase__tick {
+  display: inline-block;
+  width: 2px;
+  height: 8px;
+  border: none;
+  padding: 0;
+  background: var(--pd-border-strong);
+  cursor: pointer;
+  transition: all 0.25s ease;
+  margin-left: 4px;
+}
+
+.lt-showcase__tick[data-active="true"] {
+  height: 16px;
+  background: var(--pd-primary);
+}
+
+/* ── Mobile ─────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .lt-showcase {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .lt-showcase__img-col {
+    height: 240px;
+    border-right: none;
+    border-bottom: 1px solid var(--pd-border);
+  }
+
+  .lt-showcase__img {
+    padding: 24px;
+  }
+
+  .lt-showcase__data {
+    padding: 24px;
+  }
+
+  .lt-showcase__entry {
+    left: 24px;
+    right: 24px;
+  }
+}

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import "./CategoryShowcase.css";
+
+export type ShowcaseProduct = {
+  slug: string;
+  model: string;
+  caption: string | null;
+  function: "MFC" | "MFM" | null;
+  flowRange: string | null;
+  accuracy: string | null;
+  image: string;
+  href: string;
+};
+
+type Props = {
+  products: ShowcaseProduct[];
+  viewLabel: string;
+  sectionLabel: string;
+  modelLabel: string;
+  functionLabel: string;
+  flowRangeLabel: string;
+  accuracyLabel: string;
+  highlightLabel: string;
+  slidesLabel: string;
+};
+
+const INTERVAL_MS = 4500;
+
+export function CategoryShowcase({
+  products,
+  viewLabel,
+  sectionLabel,
+  modelLabel,
+  functionLabel,
+  flowRangeLabel,
+  accuracyLabel,
+  highlightLabel,
+  slidesLabel,
+}: Props) {
+  const [active, setActive] = useState(0);
+  const isPaused = useRef(false);
+  const len = products.length;
+
+  useEffect(() => {
+    if (len < 2) return;
+    const id = setInterval(() => {
+      if (!isPaused.current) setActive((n) => (n + 1) % len);
+    }, INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [len]);
+
+  const selectSlide = useCallback((i: number) => setActive(i), []);
+
+  return (
+    <div
+      className="lt-showcase"
+      onMouseEnter={() => (isPaused.current = true)}
+      onMouseLeave={() => (isPaused.current = false)}
+    >
+      <span
+        className="lt-showcase__bracket lt-showcase__bracket--tl"
+        aria-hidden
+      />
+      <span
+        className="lt-showcase__bracket lt-showcase__bracket--tr"
+        aria-hidden
+      />
+      <span
+        className="lt-showcase__bracket lt-showcase__bracket--bl"
+        aria-hidden
+      />
+      <span
+        className="lt-showcase__bracket lt-showcase__bracket--br"
+        aria-hidden
+      />
+
+      {/* image side */}
+      <div className="lt-showcase__img-col">
+        {products.map((p, i) => (
+          <div
+            key={p.slug}
+            className="lt-showcase__slide"
+            data-active={String(i === active)}
+            aria-hidden={i !== active}
+          >
+            <Image
+              src={p.image}
+              alt={p.model}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="lt-showcase__img"
+              priority={i === 0}
+            />
+          </div>
+        ))}
+        <div className="lt-showcase__fig">
+          FIG. {String(active + 1).padStart(2, "0")}
+        </div>
+      </div>
+
+      {/* data sheet side */}
+      <div className="lt-showcase__data">
+        <div className="lt-showcase__section-label">─── {sectionLabel}</div>
+
+        {products.map((p, i) => (
+          <div
+            key={p.slug}
+            className="lt-showcase__entry"
+            data-active={String(i === active)}
+            aria-hidden={i !== active}
+          >
+            <DataRow label={modelLabel} value={p.model} mono />
+            {p.function && (
+              <DataRow label={functionLabel} value={p.function} mono />
+            )}
+            {p.flowRange && (
+              <DataRow label={flowRangeLabel} value={p.flowRange} />
+            )}
+            {p.accuracy && <DataRow label={accuracyLabel} value={p.accuracy} />}
+            {p.caption && <DataRow label={highlightLabel} value={p.caption} />}
+
+            <Link href={p.href} className="lt-showcase__link">
+              {viewLabel} →
+            </Link>
+          </div>
+        ))}
+
+        <div
+          className="lt-showcase__nav"
+          role="tablist"
+          aria-label="Featured product slides"
+        >
+          <span className="lt-showcase__nav-label">{slidesLabel}</span>
+          <span className="lt-showcase__nav-spacer" />
+          {Array.from({ length: len }, (_, i) => (
+            <button
+              key={i}
+              role="tab"
+              aria-selected={i === active}
+              aria-label={`Slide ${i + 1}`}
+              className="lt-showcase__tick"
+              data-active={String(i === active)}
+              onClick={() => selectSlide(i)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="lt-showcase__row">
+      <span className="lt-showcase__row-label">{label}</span>
+      <span
+        className="lt-showcase__row-value"
+        data-mono={mono ? "true" : "false"}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -26,6 +26,8 @@ type Props = {
   accuracyLabel: string;
   highlightLabel: string;
   slidesLabel: string;
+  slidesAriaLabel: string;
+  slideAriaLabels: string[];
 };
 
 const INTERVAL_MS = 4500;
@@ -40,6 +42,8 @@ export function CategoryShowcase({
   accuracyLabel,
   highlightLabel,
   slidesLabel,
+  slidesAriaLabel,
+  slideAriaLabels,
 }: Props) {
   const [active, setActive] = useState(0);
   const isPaused = useRef(false);
@@ -58,6 +62,9 @@ export function CategoryShowcase({
   return (
     <div
       className="lt-showcase"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={slidesAriaLabel}
       onMouseEnter={() => (isPaused.current = true)}
       onMouseLeave={() => (isPaused.current = false)}
     >
@@ -129,19 +136,15 @@ export function CategoryShowcase({
           </div>
         ))}
 
-        <div
-          className="lt-showcase__nav"
-          role="tablist"
-          aria-label="Featured product slides"
-        >
+        <div className="lt-showcase__nav">
           <span className="lt-showcase__nav-label">{slidesLabel}</span>
           <span className="lt-showcase__nav-spacer" />
           {Array.from({ length: len }, (_, i) => (
             <button
               key={i}
-              role="tab"
-              aria-selected={i === active}
-              aria-label={`Slide ${i + 1}`}
+              type="button"
+              aria-current={i === active ? "true" : undefined}
+              aria-label={slideAriaLabels[i]}
               className="lt-showcase__tick"
               data-active={String(i === active)}
               onClick={() => selectSlide(i)}

--- a/src/components/products/CategoryShowcase/index.ts
+++ b/src/components/products/CategoryShowcase/index.ts
@@ -1,0 +1,2 @@
+export { CategoryShowcase } from "./CategoryShowcase";
+export type { ShowcaseProduct } from "./CategoryShowcase";

--- a/src/lib/productImages.ts
+++ b/src/lib/productImages.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+type ManifestImage = { path: string; kind: "product" | "editor" };
+type ManifestProduct = { slug: string; images: ManifestImage[] };
+type Manifest = { products: ManifestProduct[] };
+
+const PLACEHOLDER = "/products/lti/placeholder.svg";
+
+let cache: Map<string, string> | null = null;
+
+function load(): Map<string, string> {
+  if (cache) return cache;
+  const file = path.join(process.cwd(), "public/products/_manifest.json");
+  const manifest = JSON.parse(readFileSync(file, "utf-8")) as Manifest;
+  cache = new Map();
+  for (const p of manifest.products) {
+    const primary = p.images.find((i) => i.kind === "product") ?? p.images[0];
+    if (primary) cache.set(p.slug.toLowerCase(), primary.path);
+  }
+  return cache;
+}
+
+export function resolveProductImage(slug: string): string {
+  return load().get(slug.toLowerCase()) ?? PLACEHOLDER;
+}

--- a/src/lib/types/showcase.ts
+++ b/src/lib/types/showcase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const ShowcaseEntrySchema = z.object({
+  model: z.string(),
+  slug: z.string(),
+  caption: z.string().nullable(),
+  function: z.enum(["MFC", "MFM"]).nullable(),
+  flowRange: z.string().nullable(),
+  accuracy: z.string().nullable(),
+});
+
+export const CategoryShowcaseSchema = z.object({
+  analogue: z.array(ShowcaseEntrySchema).nullable(),
+  digital: z.array(ShowcaseEntrySchema).nullable(),
+  specialized: z.array(ShowcaseEntrySchema).nullable(),
+});
+
+export type ShowcaseEntry = z.infer<typeof ShowcaseEntrySchema>;
+export type CategoryShowcaseData = z.infer<typeof CategoryShowcaseSchema>;

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -36,6 +36,35 @@ export const productByModelQuery = defineQuery(`
   }
 `);
 
+export const categoryShowcaseQuery = defineQuery(`
+  *[_type == "categoryShowcase" && _id == "category-showcases"][0]{
+    "analogue": analogue[]{
+      caption,
+      "model": product->model,
+      "slug": product->slug.current,
+      "function": product->function,
+      "flowRange": product->massFlowSpecs.flowRange.display,
+      "accuracy": product->massFlowSpecs.accuracy.display,
+    },
+    "digital": digital[]{
+      caption,
+      "model": product->model,
+      "slug": product->slug.current,
+      "function": product->function,
+      "flowRange": product->massFlowSpecs.flowRange.display,
+      "accuracy": product->massFlowSpecs.accuracy.display,
+    },
+    "specialized": specialized[]{
+      caption,
+      "model": product->model,
+      "slug": product->slug.current,
+      "function": product->function,
+      "flowRange": product->massFlowSpecs.flowRange.display,
+      "accuracy": product->massFlowSpecs.accuracy.display,
+    },
+  }
+`);
+
 export const allProductsQuery = defineQuery(`
   *[_type == "product"]
   | order(


### PR DESCRIPTION
## Summary
- New `CategoryShowcase` component (technical / data-sheet aesthetic) displays a curated, auto-cycling spotlight of featured products below the existing `CategoryHero` on `/products/[category]` pages
- Editor-curated via a new Sanity singleton (`categoryShowcase`) — references existing product docs + per-entry caption; falls back to text-only hero when a category has no featured entries
- Right panel pulls live spec data (function, flow range, accuracy) from the referenced product, plus the editor-written highlight caption
- Translations added across en/ko/zh for the new labels (`Featured products` / `대표 제품` / `精选产品`)
- Seed script (`scripts/seed-showcase.ts`) populates the singleton with demo entries across the three categories

## Test plan
- [ ] `/en/products/analogue` — showcase cycles every 4.5s, pauses on hover, tick-mark nav works
- [ ] `/en/products/digital` and `/specialized` — same behavior
- [ ] Sanity Studio at `/studio` → "Category Showcases" — singleton edits + drag-reorder
- [ ] Empty a category's array → text hero shows instead
- [ ] Verify ko/zh — mono labels switch to sans, no letter-spacing
- [ ] Mobile (<768px) — image and data sheet stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)