### PR TITLE
feat(ux): clickable product rows + spec table font balance

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,8 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const SANITY_CDN = "https://cdn.sanity.io";
 
-const isDev = process.env.NODE_ENV === "development";
+// Evaluated at Next.js config load time (build time on Vercel), not per request.
+const isDevBuild = process.env.NODE_ENV === "development";
 
 const cspDirectives = [
   "default-src 'self'",
@@ -13,7 +14,7 @@ const cspDirectives = [
   // 'unsafe-inline' on script-src is required for Next's inline runtime in
   // dev. Tighten with a nonce-based CSP later if SSR-only inlines remain.
   // 'unsafe-eval' is required by React dev tools (callstack reconstruction) but must never ship to prod.
-  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://challenges.cloudflare.com`,
+  `script-src 'self' 'unsafe-inline'${isDevBuild ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://challenges.cloudflare.com`,
   "style-src 'self' 'unsafe-inline'",
   `img-src 'self' data: blob: ${SANITY_CDN}`,
   "font-src 'self' data:",

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,12 +5,15 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const SANITY_CDN = "https://cdn.sanity.io";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const cspDirectives = [
   "default-src 'self'",
   // Next inlines small bootstrap scripts; allow only in production via 'self'.
   // 'unsafe-inline' on script-src is required for Next's inline runtime in
   // dev. Tighten with a nonce-based CSP later if SSR-only inlines remain.
-  `script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://challenges.cloudflare.com`,
+  // 'unsafe-eval' is required by React dev tools (callstack reconstruction) but must never ship to prod.
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://challenges.cloudflare.com`,
   "style-src 'self' 'unsafe-inline'",
   `img-src 'self' data: blob: ${SANITY_CDN}`,
   "font-src 'self' data:",

--- a/src/components/products/ProductRow/ProductRow.css
+++ b/src/components/products/ProductRow/ProductRow.css
@@ -14,6 +14,9 @@
   font-weight: inherit;
   text-align: left;
 }
+.lt-prod-row {
+  cursor: pointer;
+}
 .lt-prod-row:has(.lt-prod-row__cell:hover) .lt-prod-row__cell,
 .lt-prod-row:has(.lt-prod-row__cell :focus-visible) .lt-prod-row__cell {
   background: var(--pd-surface-2);

--- a/src/components/products/ProductRow/ProductRow.tsx
+++ b/src/components/products/ProductRow/ProductRow.tsx
@@ -1,4 +1,6 @@
-import { Link } from "@/i18n/navigation";
+"use client";
+
+import { Link, useRouter } from "@/i18n/navigation";
 import { ProductThumb } from "../ProductThumb";
 import type { Product } from "@/lib/types/product";
 import type { CategorySlug } from "@/lib/categories";
@@ -26,9 +28,16 @@ export function ProductRow({ product, category, locale }: Props) {
   const accuracy = product.massFlowSpecs.accuracy.display;
   const response = product.massFlowSpecs.responseTime?.display ?? "—";
   const fitting = fittingSummary(product.connections);
+  const router = useRouter();
 
   return (
-    <tr className="lt-prod-row">
+    <tr
+      className="lt-prod-row"
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("a")) return;
+        router.push(href);
+      }}
+    >
       <td
         className="lt-prod-row__cell lt-prod-row__cell--thumb"
         aria-hidden="true"

--- a/src/components/products/ProductRow/ProductRow.tsx
+++ b/src/components/products/ProductRow/ProductRow.tsx
@@ -33,9 +33,14 @@ export function ProductRow({ product, category, locale }: Props) {
   return (
     <tr
       className="lt-prod-row"
+      tabIndex={0}
       onClick={(e) => {
         if ((e.target as HTMLElement).closest("a")) return;
+        if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
         router.push(href);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") router.push(href);
       }}
     >
       <td

--- a/src/components/products/SpecTable/SpecTable.css
+++ b/src/components/products/SpecTable/SpecTable.css
@@ -37,7 +37,7 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
-  font: 500 var(--lt-fs-xs) var(--lt-sans);
+  font: 500 var(--lt-fs-sm) var(--lt-sans);
   color: var(--pd-fg-strong);
   height: fit-content;
   margin: 0;
@@ -69,7 +69,7 @@
   background: var(--lt-neutral-100);
 }
 .lt-pdp-spec__lbl {
-  font: 400 var(--lt-fs-sm) / 1.3 var(--lt-sans);
+  font: 400 14px / 1.3 var(--lt-sans);
   color: var(--pd-fg);
   margin: 0;
 }

--- a/src/components/products/SpecTable/SpecTable.css
+++ b/src/components/products/SpecTable/SpecTable.css
@@ -69,7 +69,7 @@
   background: var(--lt-neutral-100);
 }
 .lt-pdp-spec__lbl {
-  font: 400 14px / 1.3 var(--lt-sans);
+  font: 400 var(--lt-fs-xs) / 1.3 var(--lt-sans);
   color: var(--pd-fg);
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- Make entire product table row clickable — `onClick` + `useRouter` navigates to the product page; bails early if click lands on the existing `<a>` link to avoid double-navigation
- Add `cursor: pointer` to `.lt-prod-row` so the row looks interactive
- Spec table font hierarchy fix: group heading bumped 13px → 15px, row label 15px → 14px so section headings are visually above their content
- Add `unsafe-eval` to CSP `script-src` in dev mode only (React dev tools require it for callstack reconstruction; never ships to prod)

## Test plan
- Visit `/ko/products/analogue` — click any cell outside the model code link, should navigate to the product detail page
- Click the model code link directly — should still navigate correctly without double-firing
- Check `/ko/products/analogue/m3030va` spec table — group headings ("성능", "신호 · 전원", "환경") should read larger than row labels
- Verify no `eval()` CSP error in browser console in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)