### PR TITLE
fix(products): generateStaticParams reads from Sanity, not fixtures

### DIFF
--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -16,7 +16,7 @@ import {
   DownloadsList,
   type DownloadItem,
 } from "@/components/products/DownloadsList";
-import { sanityClient } from "@/sanity/client";
+import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
 import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import {
@@ -80,7 +80,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityClient.fetch<Array<{ slug: string; series: Product["series"] }>>(productSlugsQuery),
+    () => sanityBuildClient.fetch<Array<{ slug: string; series: Product["series"] }>>(productSlugsQuery),
     { name: "productSlugsForStaticParams" },
   );
   return routing.locales.flatMap((locale) =>

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -18,8 +18,7 @@ import {
 } from "@/components/products/DownloadsList";
 import { sanityClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { productBySlugQuery } from "@/sanity/queries";
-import { ALL_PRODUCTS } from "@/lib/fixtures/products";
+import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import {
   CATEGORIES,
   categoryForSeries,
@@ -79,12 +78,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildProductMetadata(locale, product, category);
 }
 
-export function generateStaticParams() {
+export async function generateStaticParams() {
+  const products = await fetchSanity(
+    () => sanityClient.fetch<Array<{ slug: string; series: Product["series"] }>>(productSlugsQuery),
+    { name: "productSlugsForStaticParams" },
+  );
   return routing.locales.flatMap((locale) =>
-    ALL_PRODUCTS.flatMap((p) => {
+    products.flatMap((p) => {
       const category = categoryForSeries(p.series);
       if (!category) return [];
-      return [{ locale, category, product: p.slug.current }];
+      return [{ locale, category, product: p.slug }];
     }),
   );
 }

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -80,7 +80,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityBuildClient.fetch<Array<{ slug: string; series: Product["series"] }>>(productSlugsQuery),
+    () =>
+      sanityBuildClient.fetch<
+        Array<{ slug: string; series: Product["series"] }>
+      >(productSlugsQuery),
     { name: "productSlugsForStaticParams" },
   );
   return routing.locales.flatMap((locale) =>

--- a/src/app/products/[slug]/spec.json/route.ts
+++ b/src/app/products/[slug]/spec.json/route.ts
@@ -1,4 +1,4 @@
-import { sanityClient } from "@/sanity/client";
+import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
 import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import { SanityProductSchema } from "@/lib/types/product";
@@ -11,7 +11,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    () => sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
     { name: "productSlugsForSpecJson" },
   );
   return products.map((p) => ({ slug: p.slug }));

--- a/src/app/products/[slug]/spec.json/route.ts
+++ b/src/app/products/[slug]/spec.json/route.ts
@@ -1,8 +1,7 @@
 import { sanityClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { productBySlugQuery } from "@/sanity/queries";
+import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import { SanityProductSchema } from "@/lib/types/product";
-import { ALL_PRODUCTS } from "@/lib/fixtures/products";
 import { buildSpecJson } from "@/lib/seo/specSheet";
 
 export const dynamic = "force-static";
@@ -10,8 +9,12 @@ export const revalidate = false;
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
-export function generateStaticParams() {
-  return ALL_PRODUCTS.map((p) => ({ slug: p.slug.current }));
+export async function generateStaticParams() {
+  const products = await fetchSanity(
+    () => sanityClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    { name: "productSlugsForSpecJson" },
+  );
+  return products.map((p) => ({ slug: p.slug }));
 }
 
 export async function GET(

--- a/src/app/products/[slug]/spec.json/route.ts
+++ b/src/app/products/[slug]/spec.json/route.ts
@@ -11,7 +11,10 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    () =>
+      sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(
+        productSlugsQuery,
+      ),
     { name: "productSlugsForSpecJson" },
   );
   return products.map((p) => ({ slug: p.slug }));

--- a/src/app/products/[slug]/spec.md/route.ts
+++ b/src/app/products/[slug]/spec.md/route.ts
@@ -1,4 +1,4 @@
-import { sanityClient } from "@/sanity/client";
+import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
 import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import { SanityProductSchema } from "@/lib/types/product";
@@ -11,7 +11,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    () => sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
     { name: "productSlugsForSpecMd" },
   );
   return products.map((p) => ({ slug: p.slug }));

--- a/src/app/products/[slug]/spec.md/route.ts
+++ b/src/app/products/[slug]/spec.md/route.ts
@@ -1,8 +1,7 @@
 import { sanityClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { productBySlugQuery } from "@/sanity/queries";
+import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
 import { SanityProductSchema } from "@/lib/types/product";
-import { ALL_PRODUCTS } from "@/lib/fixtures/products";
 import { buildSpecMarkdown } from "@/lib/seo/specSheet";
 
 export const dynamic = "force-static";
@@ -10,8 +9,12 @@ export const revalidate = false;
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
-export function generateStaticParams() {
-  return ALL_PRODUCTS.map((p) => ({ slug: p.slug.current }));
+export async function generateStaticParams() {
+  const products = await fetchSanity(
+    () => sanityClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    { name: "productSlugsForSpecMd" },
+  );
+  return products.map((p) => ({ slug: p.slug }));
 }
 
 export async function GET(

--- a/src/app/products/[slug]/spec.md/route.ts
+++ b/src/app/products/[slug]/spec.md/route.ts
@@ -11,7 +11,10 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://line-tech.co";
 
 export async function generateStaticParams() {
   const products = await fetchSanity(
-    () => sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(productSlugsQuery),
+    () =>
+      sanityBuildClient.fetch<Array<{ slug: string; series: string }>>(
+        productSlugsQuery,
+      ),
     { name: "productSlugsForSpecMd" },
   );
   return products.map((p) => ({ slug: p.slug }));

--- a/src/sanity/client.ts
+++ b/src/sanity/client.ts
@@ -7,3 +7,10 @@ export const sanityClient = createClient({
   apiVersion,
   useCdn: true,
 });
+
+export const sanityBuildClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  useCdn: false,
+});

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -37,6 +37,13 @@ export const productByModelQuery = defineQuery(`
   }
 `);
 
+export const productSlugsQuery = defineQuery(`
+  *[_type == "product" && defined(slug.current)]{
+    "slug": slug.current,
+    series
+  }
+`);
+
 export const categoryShowcaseQuery = defineQuery(`
   *[_type == "categoryShowcase" && _id == "category-showcases"][0]{
     "analogue": analogue[]{


### PR DESCRIPTION
## Summary
- Adds `productSlugsQuery` (minimal GROQ projection — slug + series) to avoid fetching full product data just for path enumeration
- Updates `generateStaticParams` in 3 routes (PDP, spec.json, spec.md) to query Sanity at build time instead of reading from the fixture file
- New products added in Sanity Studio now get static routes on the next deploy without a developer touching `products.json`

## Test plan
- `npm run build` succeeds and pre-renders known product routes (e.g. `/en/products/analogue/m3030va`)
- `/products/m3030va/spec.json` and `/products/m3030va/spec.md` return 200
- Unknown slug returns 404

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)