### PR TITLE
chore(products): seed canonical tag taxonomy and per-product references (closes #97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "seed:products": "tsx scripts/seed-products.ts",
+    "seed:tags": "tsx scripts/seed-tags.ts",
     "sanity:extract": "sanity schema extract",
     "sanity:typegen": "sanity typegen generate",
     "prepare": "husky"

--- a/scripts/seed-tags.ts
+++ b/scripts/seed-tags.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+import { ALL_PRODUCTS } from "../src/lib/fixtures/products";
+import type { Product } from "../src/lib/types/product";
+
+function loadEnv(path: string) {
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) process.env[m[1]] ??= m[2].trimEnd();
+  }
+}
+
+loadEnv(".env.local");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error(
+    "Missing env vars. Need NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET, SANITY_WRITE_TOKEN in .env.local",
+  );
+  process.exit(1);
+}
+
+const force = process.argv.includes("--force");
+const dryRun = process.argv.includes("--dry-run");
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+type TagKind = "capability" | "application" | "gas";
+
+type TagDef = {
+  slug: string;
+  kind: TagKind;
+  label: { ko: string; en: string; zh: string };
+};
+
+const TAGS: TagDef[] = [
+  {
+    slug: "ultra-low-flow",
+    kind: "capability",
+    label: { ko: "초저유량", en: "Ultra-low flow", zh: "超低流量" },
+  },
+  {
+    slug: "high-flow",
+    kind: "capability",
+    label: { ko: "고유량", en: "High flow", zh: "高流量" },
+  },
+  {
+    slug: "meter-only",
+    kind: "capability",
+    label: { ko: "측정전용", en: "Meter only", zh: "仅测量" },
+  },
+  {
+    slug: "digital",
+    kind: "capability",
+    label: { ko: "디지털", en: "Digital", zh: "数字" },
+  },
+  {
+    slug: "mems",
+    kind: "capability",
+    label: { ko: "MEMS", en: "MEMS", zh: "MEMS" },
+  },
+  {
+    slug: "explosion-proof",
+    kind: "capability",
+    label: { ko: "방폭", en: "Explosion-proof", zh: "防爆" },
+  },
+  {
+    slug: "integrated-display",
+    kind: "capability",
+    label: {
+      ko: "디스플레이 일체형",
+      en: "Integrated display",
+      zh: "显示一体",
+    },
+  },
+  {
+    slug: "hazardous-environment",
+    kind: "application",
+    label: {
+      ko: "위험환경",
+      en: "Hazardous environment",
+      zh: "危险环境",
+    },
+  },
+];
+
+function tagsForProduct(p: Product): string[] {
+  const tags: string[] = [];
+  if (p.series === "digital") tags.push("digital");
+  if (p.model.startsWith("LM")) tags.push("mems");
+  if (p.model.startsWith("EX")) {
+    tags.push("explosion-proof");
+    tags.push("hazardous-environment");
+  }
+  if (p.model.startsWith("LD")) tags.push("integrated-display");
+  const { min, max } = p.massFlowSpecs.flowRange;
+  if (min !== undefined && max !== undefined) {
+    if (min <= 0.01 && max <= 30) tags.push("ultra-low-flow");
+    if (max >= 1000) tags.push("high-flow");
+  }
+  if (p.function === "MFM") tags.push("meter-only");
+  return tags;
+}
+
+function tagDocFields(t: TagDef) {
+  return {
+    slug: { _type: "slug", current: t.slug },
+    kind: t.kind,
+    label: [
+      { _key: "ko", language: "ko", value: t.label.ko },
+      { _key: "en", language: "en", value: t.label.en },
+      { _key: "zh", language: "zh", value: t.label.zh },
+    ],
+  };
+}
+
+async function main() {
+  console.log(
+    `Seeding ${TAGS.length} tags + patching ${ALL_PRODUCTS.length} products → ${projectId}/${dataset} (force=${force}, dryRun=${dryRun})`,
+  );
+
+  for (const tag of TAGS) {
+    const _id = `tag-${tag.slug}`;
+    const fields = tagDocFields(tag);
+    if (dryRun) {
+      console.log(`  [dry] tag    ${_id} (${tag.kind})`);
+      continue;
+    }
+    try {
+      await client.createIfNotExists({
+        _id,
+        _type: "tag",
+        ...fields,
+      } as Parameters<typeof client.createIfNotExists>[0]);
+      if (force) {
+        await client.patch(_id).set(fields).commit();
+        console.log(`  patched  ${_id}`);
+      } else {
+        console.log(`  ensured  ${_id}`);
+      }
+    } catch (err) {
+      console.error(`  FAILED   ${_id}:`, err);
+      process.exit(1);
+    }
+  }
+
+  let patchedCount = 0;
+  let skippedCount = 0;
+
+  for (const product of ALL_PRODUCTS) {
+    const _id = `product-${product.slug.current}`;
+    const slugs = tagsForProduct(product);
+    if (slugs.length === 0) {
+      console.log(`  skipped  ${product.model} (no tags derived)`);
+      skippedCount++;
+      continue;
+    }
+    const refs = slugs.map((s) => ({
+      _key: s,
+      _type: "reference" as const,
+      _ref: `tag-${s}`,
+    }));
+    if (dryRun) {
+      console.log(`  [dry] patch  ${_id} ← [${slugs.join(", ")}]`);
+      patchedCount++;
+      continue;
+    }
+    try {
+      await client.patch(_id).set({ tags: refs }).commit();
+      console.log(`  patched  ${product.model} ← [${slugs.join(", ")}]`);
+      patchedCount++;
+    } catch (err) {
+      console.error(`  FAILED   ${product.model}:`, err);
+      process.exit(1);
+    }
+  }
+
+  console.log(
+    `Done. Tags=${TAGS.length}, products patched=${patchedCount}, skipped=${skippedCount}.`,
+  );
+  console.log(
+    "Note: zh strings are machine-drafted from English. Native review pending — file follow-up issue.",
+  );
+}
+
+main();

--- a/scripts/seed-tags.ts
+++ b/scripts/seed-tags.ts
@@ -104,6 +104,7 @@ function tagsForProduct(p: Product): string[] {
   if (p.model.startsWith("LD")) tags.push("integrated-display");
   const { min, max } = p.massFlowSpecs.flowRange;
   if (min !== undefined && max !== undefined) {
+    // Catalog tops out at 30 slpm for ultra-low models; >=1000 marks the high-flow band.
     if (min <= 0.01 && max <= 30) tags.push("ultra-low-flow");
     if (max >= 1000) tags.push("high-flow");
   }
@@ -155,6 +156,7 @@ async function main() {
 
   let patchedCount = 0;
   let skippedCount = 0;
+  let preservedCount = 0;
 
   for (const product of ALL_PRODUCTS) {
     const _id = `product-${product.slug.current}`;
@@ -175,6 +177,19 @@ async function main() {
       continue;
     }
     try {
+      // Preserve existing tag arrays (e.g. Studio-curated gas/application
+      // tags) unless --force is set. Mirrors the tag-document --force gate.
+      if (!force) {
+        const existing = await client.getDocument<{ tags?: unknown[] }>(_id);
+        const existingCount = existing?.tags?.length ?? 0;
+        if (existingCount > 0) {
+          console.log(
+            `  preserved  ${product.model} (has ${existingCount} existing tags; --force to overwrite)`,
+          );
+          preservedCount++;
+          continue;
+        }
+      }
       await client.patch(_id).set({ tags: refs }).commit();
       console.log(`  patched  ${product.model} ← [${slugs.join(", ")}]`);
       patchedCount++;
@@ -185,7 +200,7 @@ async function main() {
   }
 
   console.log(
-    `Done. Tags=${TAGS.length}, products patched=${patchedCount}, skipped=${skippedCount}.`,
+    `Done. Tags=${TAGS.length}, products patched=${patchedCount}, preserved=${preservedCount}, skipped=${skippedCount}.`,
   );
   console.log(
     "Note: zh strings are machine-drafted from English. Native review pending — file follow-up issue.",


### PR DESCRIPTION
## Summary

- Adds `scripts/seed-tags.ts` — idempotent migration that creates 8 canonical tag documents (7 capability + 1 application) and patches 36 products with derived tag references
- Adds `pnpm seed:tags` to `package.json`
- Already executed against the production dataset; tags + references are live in Sanity

Targets `desc` (#98) since this depends on the schema/UI work landing first. Will retarget to `main` once #98 merges.

## Tag taxonomy (live in Sanity)

| Slug | kind | en | ko | zh |
|---|---|---|---|---|
| `ultra-low-flow` | capability | Ultra-low flow | 초저유량 | 超低流量 |
| `high-flow` | capability | High flow | 고유량 | 高流量 |
| `meter-only` | capability | Meter only | 측정전용 | 仅测量 |
| `digital` | capability | Digital | 디지털 | 数字 |
| `mems` | capability | MEMS | MEMS | MEMS |
| `explosion-proof` | capability | Explosion-proof | 방폭 | 防爆 |
| `integrated-display` | capability | Integrated display | 디스플레이 일체형 | 显示一体 |
| `hazardous-environment` | application | Hazardous environment | 위험환경 | 危险环境 |

Korean strings approved inline by the user. Chinese strings machine-drafted from English — flagged in script output for native-speaker review (separate follow-up).

## Coverage

- 36 / 40 products tagged
- 4 mid-range analogue MFCs (M3100VA, M3200VA, MS3150VA, MS3400VA) intentionally untagged — they continue rendering the `productLabel` prose fallback until gas/application tags are authored

Reference counts after run:
- meter-only: 20 · high-flow: 18 · digital: 14 · ultra-low-flow: 7
- explosion-proof: 4 · hazardous-environment: 4 · integrated-display: 2 · mems: 2

## Out of scope (follow-ups)

- **Gas tags** — catalogue has no per-product gas data; needs domain-expert mapping
- **Other application tags** (반도체, R&D, 분석, 산업용, 의료) — catalogue's 12-industry list applies company-wide, not differentiating
- **Chinese translation review** — machine-drafted, needs native review
- **The 4 untagged products** — will get coverage from gas/application authoring

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm seed:tags --dry-run` — prints planned writes
- [x] `pnpm seed:tags` — real run completed (8 tags ensured, 36 products patched, 4 skipped)
- [x] `pnpm seed:tags` second run — idempotent (no errors, same output)
- [x] `pnpm seed:tags --force` — re-patches without errors
- [x] Sanity GROQ query — 8 tag docs present, EX1000M correctly references all 4 expected tags
- [ ] Studio inspect — open Tags list, eyeball-check chips
- [ ] Frontend — `pnpm dev`, open `/products`, confirm chips render and the 4 untagged rows still show prose fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)