### PR TITLE
feat(resources): Data Room hub + 4 sub-pages (closes #101)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3,7 +3,8 @@
     "products": "Products",
     "company": "Company",
     "applications": "Applications",
-    "faq": "Frequently asked questions"
+    "faq": "Frequently asked questions",
+    "dataRoom": "Data Room"
   },
   "common": {
     "home": "Home"
@@ -158,6 +159,64 @@
         "tbd": "TBD"
       }
     }
+  },
+  "resources": {
+    "hub": {
+      "title": "Data Room",
+      "intro": "Download Line Tech catalogues, CAD drawings, user manuals, and certification documents."
+    },
+    "cards": {
+      "catalogues": {
+        "title": "Catalogues",
+        "desc": "Series-level PDF brochures"
+      },
+      "drawings": {
+        "title": "CAD Drawings",
+        "desc": "AutoCAD (.dwg) and STEP (.stp) files"
+      },
+      "manuals": { "title": "Manuals", "desc": "Per-model user guides" },
+      "certifications": {
+        "title": "Certifications",
+        "desc": "Quality and conformity documents"
+      }
+    },
+    "catalogues": {
+      "title": "Catalogues",
+      "intro": "Series-level product brochures in PDF format."
+    },
+    "drawings": {
+      "title": "CAD Drawings",
+      "intro": "Outline drawings for each model in AutoCAD (.dwg) and STEP (.stp) formats."
+    },
+    "manuals": {
+      "title": "Manuals",
+      "intro": "User guides and installation manuals for each product model."
+    },
+    "certifications": {
+      "title": "Certifications",
+      "intro": "Quality management and product conformity certificates held by Line Tech."
+    },
+    "download": "Download",
+    "done": "Done",
+    "comingSoon": "File coming soon",
+    "seriesLabel": {
+      "all": "All series",
+      "analogue": "Analogue",
+      "digital": "Digital",
+      "specialized": "Specialized"
+    },
+    "drawingsTable": {
+      "model": "Model",
+      "series": "Series",
+      "files": "Files"
+    },
+    "certCard": {
+      "issuer": "Issuing body",
+      "scope": "Scope",
+      "validThrough": "Valid through",
+      "ongoing": "Ongoing"
+    },
+    "empty": "No files available yet. Check back soon."
   },
   "skipLink": {
     "main": "Skip to main content"

--- a/messages/en.json
+++ b/messages/en.json
@@ -168,16 +168,23 @@
     "cards": {
       "catalogues": {
         "title": "Catalogues",
-        "desc": "Series-level PDF brochures"
+        "desc": "Series-level PDF brochures",
+        "count": "{count} documents"
       },
       "drawings": {
         "title": "CAD Drawings",
-        "desc": "AutoCAD (.dwg) and STEP (.stp) files"
+        "desc": "AutoCAD (.dwg) and STEP (.stp) files",
+        "count": "{count} models"
       },
-      "manuals": { "title": "Manuals", "desc": "Per-model user guides" },
+      "manuals": {
+        "title": "Manuals",
+        "desc": "Per-model user guides",
+        "count": "{count} documents"
+      },
       "certifications": {
         "title": "Certifications",
-        "desc": "Quality and conformity documents"
+        "desc": "Quality and conformity documents",
+        "count": "{count} documents"
       }
     },
     "catalogues": {
@@ -197,7 +204,6 @@
       "intro": "Quality management and product conformity certificates held by Line Tech."
     },
     "download": "Download",
-    "done": "Done",
     "comingSoon": "File coming soon",
     "seriesLabel": {
       "all": "All series",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3,7 +3,8 @@
     "products": "제품",
     "company": "회사소개",
     "applications": "응용 분야",
-    "faq": "자주 묻는 질문"
+    "faq": "자주 묻는 질문",
+    "dataRoom": "자료실"
   },
   "common": {
     "home": "홈"
@@ -158,6 +159,64 @@
         "tbd": "준비 중"
       }
     }
+  },
+  "resources": {
+    "hub": {
+      "title": "자료실",
+      "intro": "라인테크의 카탈로그, 도면, 매뉴얼 및 인증 서류를 다운로드하실 수 있습니다."
+    },
+    "cards": {
+      "catalogues": {
+        "title": "카탈로그",
+        "desc": "시리즈별 제품 브로슈어 (PDF)"
+      },
+      "drawings": {
+        "title": "CAD 도면",
+        "desc": "AutoCAD (.dwg) 및 STEP (.stp) 파일"
+      },
+      "manuals": { "title": "매뉴얼", "desc": "모델별 사용자 가이드" },
+      "certifications": {
+        "title": "인증서",
+        "desc": "품질 및 적합성 인증 문서"
+      }
+    },
+    "catalogues": {
+      "title": "카탈로그",
+      "intro": "시리즈별 제품 브로슈어를 PDF로 제공합니다."
+    },
+    "drawings": {
+      "title": "CAD 도면",
+      "intro": "모델별 외형 도면을 AutoCAD (.dwg) 및 STEP (.stp) 형식으로 제공합니다."
+    },
+    "manuals": {
+      "title": "매뉴얼",
+      "intro": "각 제품 모델의 사용자 가이드 및 설치 매뉴얼입니다."
+    },
+    "certifications": {
+      "title": "인증서",
+      "intro": "라인테크가 보유한 품질경영 및 제품 적합성 인증서입니다."
+    },
+    "download": "다운로드",
+    "done": "완료",
+    "comingSoon": "파일 준비 중",
+    "seriesLabel": {
+      "all": "전 시리즈",
+      "analogue": "아날로그",
+      "digital": "디지털",
+      "specialized": "특수"
+    },
+    "drawingsTable": {
+      "model": "모델",
+      "series": "시리즈",
+      "files": "파일"
+    },
+    "certCard": {
+      "issuer": "발급 기관",
+      "scope": "인증 범위",
+      "validThrough": "유효 기간",
+      "ongoing": "계속 유효"
+    },
+    "empty": "아직 등록된 파일이 없습니다. 곧 업데이트될 예정입니다."
   },
   "skipLink": {
     "main": "본문으로 건너뛰기"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -168,16 +168,23 @@
     "cards": {
       "catalogues": {
         "title": "카탈로그",
-        "desc": "시리즈별 제품 브로슈어 (PDF)"
+        "desc": "시리즈별 제품 브로슈어 (PDF)",
+        "count": "{count}개 문서"
       },
       "drawings": {
         "title": "CAD 도면",
-        "desc": "AutoCAD (.dwg) 및 STEP (.stp) 파일"
+        "desc": "AutoCAD (.dwg) 및 STEP (.stp) 파일",
+        "count": "{count}개 도면"
       },
-      "manuals": { "title": "매뉴얼", "desc": "모델별 사용자 가이드" },
+      "manuals": {
+        "title": "매뉴얼",
+        "desc": "모델별 사용자 가이드",
+        "count": "{count}개 문서"
+      },
       "certifications": {
         "title": "인증서",
-        "desc": "품질 및 적합성 인증 문서"
+        "desc": "품질 및 적합성 인증 문서",
+        "count": "{count}개 인증서"
       }
     },
     "catalogues": {
@@ -197,7 +204,6 @@
       "intro": "라인테크가 보유한 품질경영 및 제품 적합성 인증서입니다."
     },
     "download": "다운로드",
-    "done": "완료",
     "comingSoon": "파일 준비 중",
     "seriesLabel": {
       "all": "전 시리즈",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -166,13 +166,26 @@
       "intro": "下载莱因技术的产品样册、CAD 图纸、使用手册及认证文件。"
     },
     "cards": {
-      "catalogues": { "title": "产品样册", "desc": "各系列产品 PDF 宣传册" },
+      "catalogues": {
+        "title": "产品样册",
+        "desc": "各系列产品 PDF 宣传册",
+        "count": "{count}个文件"
+      },
       "drawings": {
         "title": "CAD 图纸",
-        "desc": "AutoCAD (.dwg) 及 STEP (.stp) 文件"
+        "desc": "AutoCAD (.dwg) 及 STEP (.stp) 文件",
+        "count": "{count}个图纸"
       },
-      "manuals": { "title": "使用手册", "desc": "各型号用户指南" },
-      "certifications": { "title": "认证文件", "desc": "质量与合规认证文件" }
+      "manuals": {
+        "title": "使用手册",
+        "desc": "各型号用户指南",
+        "count": "{count}个文件"
+      },
+      "certifications": {
+        "title": "认证文件",
+        "desc": "质量与合规认证文件",
+        "count": "{count}个证书"
+      }
     },
     "catalogues": {
       "title": "产品样册",
@@ -191,7 +204,6 @@
       "intro": "莱因技术持有的质量管理及产品合规认证证书。"
     },
     "download": "下载",
-    "done": "完成",
     "comingSoon": "文件准备中",
     "seriesLabel": {
       "all": "全系列",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -3,7 +3,8 @@
     "products": "产品",
     "company": "公司介绍",
     "applications": "应用领域",
-    "faq": "常见问题"
+    "faq": "常见问题",
+    "dataRoom": "资料室"
   },
   "common": {
     "home": "首页"
@@ -158,6 +159,58 @@
         "tbd": "待发布"
       }
     }
+  },
+  "resources": {
+    "hub": {
+      "title": "资料室",
+      "intro": "下载莱因技术的产品样册、CAD 图纸、使用手册及认证文件。"
+    },
+    "cards": {
+      "catalogues": { "title": "产品样册", "desc": "各系列产品 PDF 宣传册" },
+      "drawings": {
+        "title": "CAD 图纸",
+        "desc": "AutoCAD (.dwg) 及 STEP (.stp) 文件"
+      },
+      "manuals": { "title": "使用手册", "desc": "各型号用户指南" },
+      "certifications": { "title": "认证文件", "desc": "质量与合规认证文件" }
+    },
+    "catalogues": {
+      "title": "产品样册",
+      "intro": "提供各系列产品的 PDF 格式宣传册。"
+    },
+    "drawings": {
+      "title": "CAD 图纸",
+      "intro": "提供各型号外形图，支持 AutoCAD (.dwg) 和 STEP (.stp) 格式下载。"
+    },
+    "manuals": {
+      "title": "使用手册",
+      "intro": "各产品型号的用户指南与安装手册。"
+    },
+    "certifications": {
+      "title": "认证文件",
+      "intro": "莱因技术持有的质量管理及产品合规认证证书。"
+    },
+    "download": "下载",
+    "done": "完成",
+    "comingSoon": "文件准备中",
+    "seriesLabel": {
+      "all": "全系列",
+      "analogue": "模拟",
+      "digital": "数字",
+      "specialized": "特殊"
+    },
+    "drawingsTable": {
+      "model": "型号",
+      "series": "系列",
+      "files": "文件"
+    },
+    "certCard": {
+      "issuer": "颁发机构",
+      "scope": "认证范围",
+      "validThrough": "有效期至",
+      "ongoing": "持续有效"
+    },
+    "empty": "暂无可用文件，敬请期待。"
   },
   "skipLink": {
     "main": "跳到主要内容"

--- a/sanity/schemaTypes/catalogue.ts
+++ b/sanity/schemaTypes/catalogue.ts
@@ -1,0 +1,48 @@
+import { defineType, defineField } from "sanity";
+
+export const catalogue = defineType({
+  name: "catalogue",
+  title: "Catalogue",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "series",
+      title: "Series",
+      type: "string",
+      options: {
+        list: [
+          { title: "All series", value: "all" },
+          { title: "Analogue", value: "analogue" },
+          { title: "Digital", value: "digital" },
+          { title: "Specialized", value: "specialized" },
+        ],
+        layout: "radio",
+      },
+      initialValue: "all",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "file",
+      title: "PDF file",
+      type: "file",
+      options: { accept: ".pdf" },
+    }),
+    defineField({
+      name: "publishedAt",
+      title: "Published",
+      type: "date",
+    }),
+  ],
+  preview: {
+    select: { title: "title", series: "series" },
+    prepare({ title, series }) {
+      return { title: title ?? "(untitled)", subtitle: series };
+    },
+  },
+});

--- a/sanity/schemaTypes/certification.ts
+++ b/sanity/schemaTypes/certification.ts
@@ -1,0 +1,55 @@
+import { defineType, defineField } from "sanity";
+
+export const certification = defineType({
+  name: "certification",
+  title: "Certification",
+  type: "document",
+  fields: [
+    defineField({
+      name: "name",
+      title: "Certificate name",
+      type: "string",
+      description: "Short name, same across languages (e.g. ISO 9001, CE)",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "issuer",
+      title: "Issuing body",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      name: "scope",
+      title: "Scope / description",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      name: "validThrough",
+      title: "Valid through",
+      type: "string",
+      description: 'e.g. "2026.08" — leave blank if ongoing',
+    }),
+    defineField({
+      name: "file",
+      title: "Certificate PDF",
+      type: "file",
+      options: { accept: ".pdf" },
+    }),
+    defineField({
+      name: "order",
+      title: "Display order",
+      type: "number",
+      description: "Lower numbers appear first",
+      initialValue: 99,
+    }),
+  ],
+  preview: {
+    select: { name: "name", issuer: "issuer" },
+    prepare({ name, issuer }) {
+      const arr = issuer as
+        | { _key: string; value?: string; language?: string }[]
+        | undefined;
+      const en = arr?.find((e) => e.language === "en")?.value;
+      return { title: name ?? "(untitled)", subtitle: en };
+    },
+  },
+});

--- a/sanity/schemaTypes/drawing.ts
+++ b/sanity/schemaTypes/drawing.ts
@@ -1,0 +1,53 @@
+import { defineType, defineField } from "sanity";
+
+export const drawing = defineType({
+  name: "drawing",
+  title: "CAD Drawing",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "model",
+      title: "Model",
+      type: "string",
+      description: "Product model code (e.g. M3030VA)",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "series",
+      title: "Series",
+      type: "string",
+      options: {
+        list: [
+          { title: "Analogue", value: "analogue" },
+          { title: "Digital", value: "digital" },
+          { title: "Specialized", value: "specialized" },
+        ],
+        layout: "radio",
+      },
+    }),
+    defineField({
+      name: "dwgFile",
+      title: "AutoCAD file (.dwg)",
+      type: "file",
+      options: { accept: ".dwg" },
+    }),
+    defineField({
+      name: "stpFile",
+      title: "STEP file (.stp)",
+      type: "file",
+      options: { accept: ".stp,.step" },
+    }),
+  ],
+  preview: {
+    select: { title: "title", model: "model" },
+    prepare({ title, model }) {
+      return { title: title ?? "(untitled)", subtitle: model };
+    },
+  },
+});

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,5 +2,18 @@ import { product } from "./product";
 import { tag } from "./tag";
 import { categoryShowcase } from "./categoryShowcase";
 import { contactSubmission } from "./contactSubmission";
+import { catalogue } from "./catalogue";
+import { manual } from "./manual";
+import { drawing } from "./drawing";
+import { certification } from "./certification";
 
-export const schemaTypes = [product, tag, categoryShowcase, contactSubmission];
+export const schemaTypes = [
+  product,
+  tag,
+  categoryShowcase,
+  contactSubmission,
+  catalogue,
+  manual,
+  drawing,
+  certification,
+];

--- a/sanity/schemaTypes/manual.ts
+++ b/sanity/schemaTypes/manual.ts
@@ -1,0 +1,60 @@
+import { defineType, defineField } from "sanity";
+
+export const manual = defineType({
+  name: "manual",
+  title: "Manual",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "model",
+      title: "Model",
+      type: "string",
+      description: "Product model code (e.g. M3030VA)",
+    }),
+    defineField({
+      name: "series",
+      title: "Series",
+      type: "string",
+      options: {
+        list: [
+          { title: "Analogue", value: "analogue" },
+          { title: "Digital", value: "digital" },
+          { title: "Specialized", value: "specialized" },
+        ],
+        layout: "radio",
+      },
+    }),
+    defineField({
+      name: "rev",
+      title: "Revision",
+      type: "string",
+      description: 'e.g. "Rev. A"',
+    }),
+    defineField({
+      name: "file",
+      title: "PDF file",
+      type: "file",
+      options: { accept: ".pdf" },
+    }),
+    defineField({
+      name: "publishedAt",
+      title: "Published",
+      type: "date",
+    }),
+  ],
+  preview: {
+    select: { title: "title", model: "model", series: "series" },
+    prepare({ title, model, series }) {
+      return {
+        title: title ?? "(untitled)",
+        subtitle: [model, series].filter(Boolean).join(" · "),
+      };
+    },
+  },
+});

--- a/src/app/[locale]/resources/catalogues/page.tsx
+++ b/src/app/[locale]/resources/catalogues/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import { allCataloguesQuery } from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import "../resources-subpage.css";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("catalogues.title")} — Line Tech`,
+    description: t("catalogues.intro"),
+  };
+}
+
+export default async function CataloguesPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, catalogues] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("resources"),
+    sanityClient.fetch(allCataloguesQuery),
+  ]);
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom"), href: "/resources" },
+    { label: tRes("catalogues.title") },
+  ];
+
+  return (
+    <main className="lt-wrap dr-sub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-sub__hero">
+        <h1 className="dr-sub__title">{tRes("catalogues.title")}</h1>
+        <p className="dr-sub__intro">{tRes("catalogues.intro")}</p>
+      </header>
+
+      {catalogues.length === 0 ? (
+        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+      ) : (
+        <ul className="dr-list" role="list">
+          {catalogues.map((item) => (
+            <li key={item._id} className="dr-list__row">
+              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
+              <div>
+                <div className="dr-list__label">{item.title}</div>
+                {(item.series || item.publishedAt) && (
+                  <div className="dr-list__meta">
+                    {item.series && (
+                      <span>
+                        {tRes(
+                          `seriesLabel.${item.series as "all" | "analogue" | "digital" | "specialized"}`,
+                        )}
+                      </span>
+                    )}
+                    {item.series && item.publishedAt && (
+                      <span className="dr-list__sep">·</span>
+                    )}
+                    {item.publishedAt && <span>{item.publishedAt}</span>}
+                  </div>
+                )}
+              </div>
+              {item.fileUrl ? (
+                <a href={item.fileUrl} download className="dr-list__btn">
+                  {tRes("download")}
+                </a>
+              ) : (
+                <span className="dr-list__btn dr-list__btn--disabled">
+                  {tRes("comingSoon")}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/catalogues/page.tsx
+++ b/src/app/[locale]/resources/catalogues/page.tsx
@@ -8,6 +8,14 @@ import "../resources-subpage.css";
 
 type Props = { params: Promise<{ locale: string }> };
 
+type CatalogueItem = {
+  _id: string;
+  title: string;
+  series?: string | null;
+  publishedAt?: string | null;
+  fileUrl?: string | null;
+};
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -29,7 +37,7 @@ export default async function CataloguesPage({ params }: Props) {
     getTranslations("common"),
     getTranslations("nav"),
     getTranslations("resources"),
-    sanityClient.fetch(allCataloguesQuery),
+    sanityClient.fetch<CatalogueItem[]>(allCataloguesQuery),
   ]);
 
   const breadcrumbs = [

--- a/src/app/[locale]/resources/certifications/page.tsx
+++ b/src/app/[locale]/resources/certifications/page.tsx
@@ -4,8 +4,22 @@ import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { sanityClient } from "@/sanity/client";
 import { allCertificationsQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
-import type { Locale } from "@/lib/content/home";
 import "../resources-subpage.css";
+
+type Locale = "ko" | "en" | "zh";
+
+type CertItem = {
+  _id: string;
+  name: string;
+  issuer?: {
+    ko?: string | null;
+    en?: string | null;
+    zh?: string | null;
+  } | null;
+  scope?: { ko?: string | null; en?: string | null; zh?: string | null } | null;
+  validThrough?: string | null;
+  fileUrl?: string | null;
+};
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -30,7 +44,7 @@ export default async function CertificationsPage({ params }: Props) {
     getTranslations("common"),
     getTranslations("nav"),
     getTranslations("resources"),
-    sanityClient.fetch(allCertificationsQuery),
+    sanityClient.fetch<CertItem[]>(allCertificationsQuery),
   ]);
 
   const lang = locale as Locale;

--- a/src/app/[locale]/resources/certifications/page.tsx
+++ b/src/app/[locale]/resources/certifications/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import { allCertificationsQuery } from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import type { Locale } from "@/lib/content/home";
+import "../resources-subpage.css";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("certifications.title")} — Line Tech`,
+    description: t("certifications.intro"),
+  };
+}
+
+export default async function CertificationsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, certs] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("resources"),
+    sanityClient.fetch(allCertificationsQuery),
+  ]);
+
+  const lang = locale as Locale;
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom"), href: "/resources" },
+    { label: tRes("certifications.title") },
+  ];
+
+  return (
+    <main className="lt-wrap dr-sub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-sub__hero">
+        <h1 className="dr-sub__title">{tRes("certifications.title")}</h1>
+        <p className="dr-sub__intro">{tRes("certifications.intro")}</p>
+      </header>
+
+      {certs.length === 0 ? (
+        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+      ) : (
+        <ul className="dr-certs" role="list">
+          {certs.map((cert) => {
+            const issuer = cert.issuer?.[lang] ?? cert.issuer?.en ?? null;
+            const scope = cert.scope?.[lang] ?? cert.scope?.en ?? null;
+            return (
+              <li key={cert._id} className="dr-cert">
+                <h2 className="dr-cert__name">{cert.name}</h2>
+                <dl className="dr-cert__dl">
+                  {issuer && (
+                    <>
+                      <dt className="dr-cert__dt">{tRes("certCard.issuer")}</dt>
+                      <dd className="dr-cert__dd">{issuer}</dd>
+                    </>
+                  )}
+                  {scope && (
+                    <>
+                      <dt className="dr-cert__dt">{tRes("certCard.scope")}</dt>
+                      <dd className="dr-cert__dd">{scope}</dd>
+                    </>
+                  )}
+                  {cert.validThrough && (
+                    <>
+                      <dt className="dr-cert__dt">
+                        {tRes("certCard.validThrough")}
+                      </dt>
+                      <dd className="dr-cert__dd">{cert.validThrough}</dd>
+                    </>
+                  )}
+                </dl>
+                <div className="dr-cert__footer">
+                  {cert.fileUrl ? (
+                    <a href={cert.fileUrl} download className="dr-list__btn">
+                      {tRes("download")}
+                    </a>
+                  ) : (
+                    <span className="dr-list__btn dr-list__btn--disabled">
+                      {tRes("comingSoon")}
+                    </span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/drawings/page.tsx
+++ b/src/app/[locale]/resources/drawings/page.tsx
@@ -8,6 +8,15 @@ import "../resources-subpage.css";
 
 type Props = { params: Promise<{ locale: string }> };
 
+type DrawingItem = {
+  _id: string;
+  title: string;
+  model: string;
+  series?: string | null;
+  dwgUrl?: string | null;
+  stpUrl?: string | null;
+};
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -29,7 +38,7 @@ export default async function DrawingsPage({ params }: Props) {
     getTranslations("common"),
     getTranslations("nav"),
     getTranslations("resources"),
-    sanityClient.fetch(allDrawingsQuery),
+    sanityClient.fetch<DrawingItem[]>(allDrawingsQuery),
   ]);
 
   const breadcrumbs = [

--- a/src/app/[locale]/resources/drawings/page.tsx
+++ b/src/app/[locale]/resources/drawings/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import { allDrawingsQuery } from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import "../resources-subpage.css";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("drawings.title")} — Line Tech`,
+    description: t("drawings.intro"),
+  };
+}
+
+export default async function DrawingsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, drawings] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("resources"),
+    sanityClient.fetch(allDrawingsQuery),
+  ]);
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom"), href: "/resources" },
+    { label: tRes("drawings.title") },
+  ];
+
+  return (
+    <main className="lt-wrap dr-sub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-sub__hero">
+        <h1 className="dr-sub__title">{tRes("drawings.title")}</h1>
+        <p className="dr-sub__intro">{tRes("drawings.intro")}</p>
+      </header>
+
+      {drawings.length === 0 ? (
+        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+      ) : (
+        <table className="dr-drawings">
+          <thead>
+            <tr>
+              <th>{tRes("drawingsTable.model")}</th>
+              <th>{tRes("drawingsTable.series")}</th>
+              <th>{tRes("drawingsTable.files")}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {drawings.map((item) => (
+              <tr key={item._id}>
+                <td>
+                  <div className="dr-drawings__model">{item.model}</div>
+                  <div className="dr-drawings__series">{item.title}</div>
+                </td>
+                <td>
+                  {item.series && (
+                    <span className="dr-drawings__series">
+                      {tRes(
+                        `seriesLabel.${item.series as "analogue" | "digital" | "specialized"}`,
+                      )}
+                    </span>
+                  )}
+                </td>
+                <td>
+                  <div className="dr-drawings__files">
+                    {item.dwgUrl && (
+                      <span className="dr-list__badge dr-list__badge--dwg">
+                        DWG
+                      </span>
+                    )}
+                    {item.stpUrl && (
+                      <span className="dr-list__badge dr-list__badge--stp">
+                        STP
+                      </span>
+                    )}
+                    {!item.dwgUrl && !item.stpUrl && (
+                      <span className="dr-list__badge">—</span>
+                    )}
+                  </div>
+                </td>
+                <td>
+                  <div className="dr-drawings__actions">
+                    {item.dwgUrl ? (
+                      <a href={item.dwgUrl} download className="dr-list__btn">
+                        DWG
+                      </a>
+                    ) : (
+                      <span className="dr-list__btn dr-list__btn--disabled">
+                        {tRes("comingSoon")}
+                      </span>
+                    )}
+                    {item.stpUrl && (
+                      <a href={item.stpUrl} download className="dr-list__btn">
+                        STP
+                      </a>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/drawings/page.tsx
+++ b/src/app/[locale]/resources/drawings/page.tsx
@@ -94,19 +94,20 @@ export default async function DrawingsPage({ params }: Props) {
                 </td>
                 <td>
                   <div className="dr-drawings__actions">
-                    {item.dwgUrl ? (
+                    {item.dwgUrl && (
                       <a href={item.dwgUrl} download className="dr-list__btn">
                         DWG
                       </a>
-                    ) : (
-                      <span className="dr-list__btn dr-list__btn--disabled">
-                        {tRes("comingSoon")}
-                      </span>
                     )}
                     {item.stpUrl && (
                       <a href={item.stpUrl} download className="dr-list__btn">
                         STP
                       </a>
+                    )}
+                    {!item.dwgUrl && !item.stpUrl && (
+                      <span className="dr-list__btn dr-list__btn--disabled">
+                        {tRes("comingSoon")}
+                      </span>
                     )}
                   </div>
                 </td>

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -122,13 +122,17 @@ export default async function ManualsPage({ params }: Props) {
               <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
               <div>
                 <div className="dr-list__label">{item.title}</div>
-                {(item.model || item.rev) && (
+                {(item.model || item.rev || item.publishedAt) && (
                   <div className="dr-list__meta">
                     {item.model && <span>{item.model}</span>}
-                    {item.model && item.rev && (
+                    {item.model && (item.rev || item.publishedAt) && (
                       <span className="dr-list__sep">·</span>
                     )}
                     {item.rev && <span>{item.rev}</span>}
+                    {item.rev && item.publishedAt && (
+                      <span className="dr-list__sep">·</span>
+                    )}
+                    {item.publishedAt && <span>{item.publishedAt}</span>}
                   </div>
                 )}
               </div>

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -12,6 +12,16 @@ type Props = { params: Promise<{ locale: string }> };
 type Series = "analogue" | "digital" | "specialized";
 const SERIES_ORDER: Series[] = ["analogue", "digital", "specialized"];
 
+type ManualItem = {
+  _id: string;
+  title: string;
+  model?: string | null;
+  series?: string | null;
+  rev?: string | null;
+  publishedAt?: string | null;
+  fileUrl?: string | null;
+};
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -33,7 +43,7 @@ export default async function ManualsPage({ params }: Props) {
     getTranslations("common"),
     getTranslations("nav"),
     getTranslations("resources"),
-    sanityClient.fetch(allManualsQuery),
+    sanityClient.fetch<ManualItem[]>(allManualsQuery),
   ]);
 
   const breadcrumbs = [

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -1,0 +1,140 @@
+import { Fragment } from "react";
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import { allManualsQuery } from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import "../resources-subpage.css";
+
+type Props = { params: Promise<{ locale: string }> };
+
+type Series = "analogue" | "digital" | "specialized";
+const SERIES_ORDER: Series[] = ["analogue", "digital", "specialized"];
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("manuals.title")} — Line Tech`,
+    description: t("manuals.intro"),
+  };
+}
+
+export default async function ManualsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, manuals] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("resources"),
+    sanityClient.fetch(allManualsQuery),
+  ]);
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom"), href: "/resources" },
+    { label: tRes("manuals.title") },
+  ];
+
+  const grouped = SERIES_ORDER.reduce<Record<string, typeof manuals>>(
+    (acc, s) => {
+      const items = manuals.filter((m) => m.series === s);
+      if (items.length) acc[s] = items;
+      return acc;
+    },
+    {},
+  );
+
+  const ungrouped = manuals.filter((m) => !m.series);
+
+  return (
+    <main className="lt-wrap dr-sub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-sub__hero">
+        <h1 className="dr-sub__title">{tRes("manuals.title")}</h1>
+        <p className="dr-sub__intro">{tRes("manuals.intro")}</p>
+      </header>
+
+      {manuals.length === 0 ? (
+        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+      ) : (
+        <ul className="dr-list" role="list">
+          {SERIES_ORDER.filter((s) => grouped[s]).map((s) => (
+            <Fragment key={s}>
+              <li>
+                <h2 className="dr-list__group-heading">
+                  {tRes(`seriesLabel.${s}`)}
+                </h2>
+              </li>
+              {grouped[s].map((item) => (
+                <li key={item._id} className="dr-list__row">
+                  <span className="dr-list__badge dr-list__badge--pdf">
+                    PDF
+                  </span>
+                  <div>
+                    <div className="dr-list__label">{item.title}</div>
+                    {(item.model || item.rev || item.publishedAt) && (
+                      <div className="dr-list__meta">
+                        {item.model && <span>{item.model}</span>}
+                        {item.model && (item.rev || item.publishedAt) && (
+                          <span className="dr-list__sep">·</span>
+                        )}
+                        {item.rev && <span>{item.rev}</span>}
+                        {item.rev && item.publishedAt && (
+                          <span className="dr-list__sep">·</span>
+                        )}
+                        {item.publishedAt && <span>{item.publishedAt}</span>}
+                      </div>
+                    )}
+                  </div>
+                  {item.fileUrl ? (
+                    <a href={item.fileUrl} download className="dr-list__btn">
+                      {tRes("download")}
+                    </a>
+                  ) : (
+                    <span className="dr-list__btn dr-list__btn--disabled">
+                      {tRes("comingSoon")}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </Fragment>
+          ))}
+          {ungrouped.map((item) => (
+            <li key={item._id} className="dr-list__row">
+              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
+              <div>
+                <div className="dr-list__label">{item.title}</div>
+                {(item.model || item.rev) && (
+                  <div className="dr-list__meta">
+                    {item.model && <span>{item.model}</span>}
+                    {item.model && item.rev && (
+                      <span className="dr-list__sep">·</span>
+                    )}
+                    {item.rev && <span>{item.rev}</span>}
+                  </div>
+                )}
+              </div>
+              {item.fileUrl ? (
+                <a href={item.fileUrl} download className="dr-list__btn">
+                  {tRes("download")}
+                </a>
+              ) : (
+                <span className="dr-list__btn dr-list__btn--disabled">
+                  {tRes("comingSoon")}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -10,7 +10,6 @@ import {
   allCertificationsQuery,
 } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
-import type { Locale } from "@/lib/content/home";
 import "./resources-hub.css";
 
 type Props = { params: Promise<{ locale: string }> };

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import {
+  allCataloguesQuery,
+  allManualsQuery,
+  allDrawingsQuery,
+  allCertificationsQuery,
+} from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import type { Locale } from "@/lib/content/home";
+import "./resources-hub.css";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("hub.title")} — Line Tech`,
+    description: t("hub.intro"),
+  };
+}
+
+const CARDS = [
+  { key: "catalogues", href: "/resources/catalogues" },
+  { key: "drawings", href: "/resources/drawings" },
+  { key: "manuals", href: "/resources/manuals" },
+  { key: "certifications", href: "/resources/certifications" },
+] as const;
+
+export default async function ResourcesHubPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, catalogues, manuals, drawings, certifications] =
+    await Promise.all([
+      getTranslations("common"),
+      getTranslations("nav"),
+      getTranslations("resources"),
+      sanityClient.fetch(allCataloguesQuery),
+      sanityClient.fetch(allManualsQuery),
+      sanityClient.fetch(allDrawingsQuery),
+      sanityClient.fetch(allCertificationsQuery),
+    ]);
+
+  const counts: Record<string, number> = {
+    catalogues: catalogues.length,
+    drawings: drawings.length,
+    manuals: manuals.length,
+    certifications: certifications.length,
+  };
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom") },
+  ];
+
+  return (
+    <main className="lt-wrap dr-hub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-hub__hero">
+        <h1 className="dr-hub__title">{tRes("hub.title")}</h1>
+        <p className="dr-hub__intro">{tRes("hub.intro")}</p>
+      </header>
+
+      <ul className="dr-hub__grid" role="list">
+        {CARDS.map(({ key, href }) => (
+          <li key={key}>
+            <Link
+              href={href as `/resources/${string}`}
+              className="dr-hub__card"
+            >
+              <span className="dr-hub__card-title">
+                {tRes(`cards.${key}.title`)}
+              </span>
+              <span className="dr-hub__card-desc">
+                {tRes(`cards.${key}.desc`)}
+              </span>
+              {counts[key] > 0 && (
+                <span className="dr-hub__card-count">
+                  {counts[key]} {key === "drawings" ? "models" : "documents"}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -85,7 +85,7 @@ export default async function ResourcesHubPage({ params }: Props) {
               </span>
               {counts[key] > 0 && (
                 <span className="dr-hub__card-count">
-                  {counts[key]} {key === "drawings" ? "models" : "documents"}
+                  {tRes(`cards.${key}.count`, { count: counts[key] })}
                 </span>
               )}
             </Link>

--- a/src/app/[locale]/resources/resources-hub.css
+++ b/src/app/[locale]/resources/resources-hub.css
@@ -1,0 +1,91 @@
+/* Line Tech — /resources hub (.dr-* namespace = Data Room) */
+
+.dr-hub {
+  padding-block: 1.5rem 4rem;
+}
+
+.dr-hub__hero {
+  padding: 2rem 0 2.5rem;
+  border-bottom: 1px solid var(--pd-rule);
+  margin-bottom: 2.5rem;
+}
+
+.dr-hub__title {
+  margin: 0 0 0.75rem;
+  font: 500 var(--lt-fs-h2-dense) / 1.1 var(--lt-sans);
+  letter-spacing: -0.02em;
+  color: var(--pd-fg-strong);
+}
+
+.dr-hub__intro {
+  margin: 0;
+  max-width: 60ch;
+  font-size: var(--lt-fs-md);
+  color: var(--pd-muted);
+  line-height: 1.55;
+}
+
+.dr-hub__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dr-hub__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.5rem 1.75rem;
+  height: 100%;
+  border: 1px solid var(--pd-rule);
+  border-radius: 4px;
+  background: var(--pd-surface);
+  text-decoration: none;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.dr-hub__card:hover {
+  border-color: var(--pd-primary);
+  background: var(--pd-surface-2);
+}
+
+.dr-hub__card:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+
+.dr-hub__card-title {
+  font: 600 var(--lt-fs-md) / 1.25 var(--lt-sans);
+  color: var(--pd-fg-strong);
+  letter-spacing: -0.01em;
+}
+
+.dr-hub__card-desc {
+  font: 400 var(--lt-fs-sm) / 1.55 var(--lt-sans);
+  color: var(--pd-muted);
+  flex: 1;
+}
+
+.dr-hub__card-count {
+  margin-top: 0.25rem;
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
+  color: var(--pd-primary);
+  letter-spacing: 0.04em;
+}
+
+:lang(ko) .dr-hub__card-count,
+:lang(zh) .dr-hub__card-count {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+}
+
+@media (max-width: 560px) {
+  .dr-hub__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/[locale]/resources/resources-subpage.css
+++ b/src/app/[locale]/resources/resources-subpage.css
@@ -1,0 +1,300 @@
+/* Line Tech — /resources sub-pages (.dr-* namespace) */
+
+.dr-sub {
+  padding-block: 1.5rem 4rem;
+}
+
+/* ── Hero ──────────────────────────────────────────────────────────────── */
+
+.dr-sub__hero {
+  padding: 2rem 0 2.5rem;
+  border-bottom: 1px solid var(--pd-rule);
+  margin-bottom: 2.5rem;
+}
+
+.dr-sub__title {
+  margin: 0 0 0.75rem;
+  font: 500 var(--lt-fs-h2-dense) / 1.1 var(--lt-sans);
+  letter-spacing: -0.02em;
+  color: var(--pd-fg-strong);
+}
+
+.dr-sub__intro {
+  margin: 0;
+  max-width: 60ch;
+  font-size: var(--lt-fs-md);
+  color: var(--pd-muted);
+  line-height: 1.55;
+}
+
+/* ── Download list (catalogues & manuals) ─────────────────────────────── */
+
+.dr-list {
+  list-style: none;
+  margin: 0 0 2.5rem;
+  padding: 0;
+  border-top: 1px solid var(--pd-border-strong);
+}
+
+.dr-list__group-heading {
+  margin: 2rem 0 0;
+  padding: 0.5rem 0;
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  border-bottom: 1px solid var(--pd-rule);
+}
+
+:lang(ko) .dr-list__group-heading,
+:lang(zh) .dr-list__group-heading {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.dr-list__row {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.125rem 0.5rem;
+  border-bottom: 1px solid var(--pd-rule);
+}
+
+.dr-list__row:hover {
+  background: var(--lt-neutral-50);
+}
+
+.dr-list__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  height: 22px;
+  padding: 0 6px;
+  font: 500 var(--lt-fs-micro) / 1 var(--lt-mono);
+  letter-spacing: 0.04em;
+  border: 1px solid var(--pd-border-strong);
+  border-radius: 3px;
+  background: var(--pd-surface);
+  color: var(--pd-fg);
+  text-transform: uppercase;
+}
+
+.dr-list__badge--pdf {
+  color: var(--lt-danger);
+  border-color: rgba(161, 43, 43, 0.3);
+}
+
+.dr-list__badge--dwg {
+  color: var(--lt-info);
+  border-color: rgba(27, 108, 173, 0.3);
+}
+
+.dr-list__badge--stp {
+  color: var(--pd-muted);
+}
+
+.dr-list__label {
+  font: 500 var(--lt-fs-md) var(--lt-sans);
+  color: var(--pd-fg-strong);
+  margin-bottom: 3px;
+}
+
+.dr-list__meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font: 400 var(--lt-fs-xs) var(--lt-mono);
+  color: var(--pd-muted);
+  letter-spacing: 0.02em;
+}
+
+.dr-list__sep {
+  opacity: 0.5;
+}
+
+.dr-list__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font: 500 var(--lt-fs-sm) var(--lt-sans);
+  border: 1px solid var(--pd-border-strong);
+  border-radius: 4px;
+  background: var(--pd-surface);
+  color: var(--pd-fg-strong);
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.dr-list__btn:hover {
+  border-color: var(--pd-primary);
+  color: var(--pd-primary);
+  background: var(--pd-surface-2);
+}
+
+.dr-list__btn--disabled {
+  color: var(--pd-muted);
+  cursor: default;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* ── Drawings table ───────────────────────────────────────────────────── */
+
+.dr-drawings {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2.5rem;
+  font-size: var(--lt-fs-sm);
+}
+
+.dr-drawings thead th {
+  padding: 0.75rem 0.75rem 0.75rem 0;
+  font: 600 var(--lt-fs-xs) var(--lt-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  text-align: left;
+  border-bottom: 2px solid var(--pd-border-strong);
+}
+
+:lang(ko) .dr-drawings thead th,
+:lang(zh) .dr-drawings thead th {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.dr-drawings tbody tr {
+  border-bottom: 1px solid var(--pd-rule);
+  transition: background 120ms ease;
+}
+
+.dr-drawings tbody tr:hover {
+  background: var(--lt-neutral-50);
+}
+
+.dr-drawings td {
+  padding: 0.875rem 0.75rem 0.875rem 0;
+  color: var(--pd-fg-strong);
+  vertical-align: middle;
+}
+
+.dr-drawings__model {
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
+  letter-spacing: 0.02em;
+}
+
+.dr-drawings__series {
+  font-size: var(--lt-fs-xs);
+  color: var(--pd-muted);
+}
+
+.dr-drawings__files {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.dr-drawings__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .dr-drawings {
+    display: block;
+  }
+  .dr-drawings thead {
+    display: none;
+  }
+  .dr-drawings tbody,
+  .dr-drawings tr,
+  .dr-drawings td {
+    display: block;
+  }
+  .dr-drawings tr {
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--pd-rule);
+  }
+  .dr-drawings td {
+    padding: 0.25rem 0;
+  }
+}
+
+/* ── Certifications grid ──────────────────────────────────────────────── */
+
+.dr-certs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  margin: 0 0 2.5rem;
+  padding: 0;
+}
+
+.dr-cert {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid var(--pd-rule);
+  border-top: 3px solid var(--pd-primary);
+  border-radius: 4px;
+  background: var(--pd-surface);
+}
+
+.dr-cert__name {
+  margin: 0;
+  font: 700 var(--lt-fs-md) / 1.2 var(--lt-sans);
+  letter-spacing: -0.01em;
+  color: var(--pd-fg-strong);
+}
+
+.dr-cert__dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+  font-size: var(--lt-fs-sm);
+}
+
+.dr-cert__dt {
+  font: 600 var(--lt-fs-xs) var(--lt-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pd-muted);
+  padding-top: 1px;
+}
+
+:lang(ko) .dr-cert__dt,
+:lang(zh) .dr-cert__dt {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.dr-cert__dd {
+  margin: 0;
+  color: var(--pd-fg-strong);
+  line-height: 1.5;
+}
+
+.dr-cert__footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--pd-rule);
+}
+
+@media (max-width: 560px) {
+  .dr-certs {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/[locale]/resources/resources-subpage.css
+++ b/src/app/[locale]/resources/resources-subpage.css
@@ -111,6 +111,12 @@
   letter-spacing: 0.02em;
 }
 
+:lang(ko) .dr-list__meta,
+:lang(zh) .dr-list__meta {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+}
+
 .dr-list__sep {
   opacity: 0.5;
 }

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -92,3 +92,63 @@ export const allProductsQuery = defineQuery(`
     ${PRODUCT_PROJECTION}
   }
 `);
+
+export const allCataloguesQuery = defineQuery(`
+  *[_type == "catalogue"] | order(publishedAt desc) {
+    _id,
+    title,
+    series,
+    publishedAt,
+    "fileUrl": file.asset->url
+  }
+`);
+
+export const allManualsQuery = defineQuery(`
+  *[_type == "manual"]
+  | order(
+    select(series == "analogue" => 0, series == "digital" => 1, 2),
+    model asc
+  ) {
+    _id,
+    title,
+    model,
+    series,
+    rev,
+    publishedAt,
+    "fileUrl": file.asset->url
+  }
+`);
+
+export const allDrawingsQuery = defineQuery(`
+  *[_type == "drawing"]
+  | order(
+    select(series == "analogue" => 0, series == "digital" => 1, 2),
+    model asc
+  ) {
+    _id,
+    title,
+    model,
+    series,
+    "dwgUrl": dwgFile.asset->url,
+    "stpUrl": stpFile.asset->url
+  }
+`);
+
+export const allCertificationsQuery = defineQuery(`
+  *[_type == "certification"] | order(coalesce(order, 99) asc) {
+    _id,
+    name,
+    "issuer": {
+      "ko": coalesce(issuer[language == "ko"][0].value, issuer[language == "en"][0].value),
+      "en": coalesce(issuer[language == "en"][0].value, issuer[language == "ko"][0].value),
+      "zh": coalesce(issuer[language == "zh"][0].value, issuer[language == "en"][0].value)
+    },
+    "scope": {
+      "ko": coalesce(scope[language == "ko"][0].value, scope[language == "en"][0].value),
+      "en": coalesce(scope[language == "en"][0].value, scope[language == "ko"][0].value),
+      "zh": coalesce(scope[language == "zh"][0].value, scope[language == "en"][0].value)
+    },
+    validThrough,
+    "fileUrl": file.asset->url
+  }
+`);


### PR DESCRIPTION
## Summary

- Builds all 5 missing `/resources` routes, fixing the live 404s advertised in the nav mega menu
- 4 new Sanity document types: `catalogue`, `manual`, `drawing`, `certification` — staff can upload files and manage metadata in Studio without code deploys
- 4 new GROQ queries; pages fetch from Sanity at build time, all 3 locales
- Download buttons show "File coming soon" until actual PDFs/DWGs are uploaded in Studio

## What's in this PR

| | |
|---|---|
| Sanity schemas | `catalogue`, `manual`, `drawing`, `certification` |
| Pages | `/resources` hub + `/resources/catalogues`, `/drawings`, `/manuals`, `/certifications` |
| CSS | `resources-hub.css`, `resources-subpage.css` (.dr-* namespace) |
| i18n | `resources.*` namespace in en/ko/zh, `nav.dataRoom` key |

## Test plan

- [ ] Visit `/en/resources`, `/ko/resources`, `/zh/resources` — hub renders, no 404
- [ ] All 4 sub-pages load in all 3 locales (12 routes total)
- [ ] Nav mega menu Data Room links resolve correctly
- [ ] Breadcrumbs present on all sub-pages
- [ ] Sanity Studio: 4 new document types appear under Content
- [ ] Upload a test PDF to a `catalogue` doc → Download button activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)