### PR TITLE
chore(ci): disable Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,16 +3,9 @@ name: Claude PR Review
 on:
   workflow_dispatch:
 
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     name: Review
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,7 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Switches `.github/workflows/claude-review.yml` trigger from `pull_request` to `workflow_dispatch` only.
- File stays on disk so it's easy to flip back on later.

## Test plan
- [ ] Confirm Claude review does not run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)