### PR TITLE
chore(ci): add i18n message parity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: i18n parity
+        run: pnpm i18n:check
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
+    "i18n:check": "tsx scripts/check-i18n-parity.ts",
     "seed:products": "tsx scripts/seed-products.ts",
     "sanity:extract": "sanity schema extract",
     "sanity:typegen": "sanity typegen generate",

--- a/scripts/check-i18n-parity.ts
+++ b/scripts/check-i18n-parity.ts
@@ -23,22 +23,27 @@ const keysByLocale = Object.fromEntries(
   }),
 ) as Record<(typeof LOCALES)[number], Set<string>>;
 
-const union = new Set(LOCALES.flatMap((l) => [...keysByLocale[l]]));
+const union = [...new Set(LOCALES.flatMap((l) => [...keysByLocale[l]]))].sort();
 
-const missing: Record<string, string[]> = {};
-for (const locale of LOCALES) {
-  const gaps = [...union].filter((k) => !keysByLocale[locale].has(k)).sort();
-  if (gaps.length > 0) missing[locale] = gaps;
-}
+const drift = union
+  .map((key) => ({
+    key,
+    presentIn: LOCALES.filter((l) => keysByLocale[l].has(key)),
+    missingFrom: LOCALES.filter((l) => !keysByLocale[l].has(key)),
+  }))
+  .filter((row) => row.missingFrom.length > 0);
 
-if (Object.keys(missing).length > 0) {
-  console.error("i18n parity check failed — missing keys:\n");
-  for (const [locale, keys] of Object.entries(missing)) {
-    console.error(`  ${locale}.json is missing ${keys.length} key(s):`);
-    for (const k of keys) console.error(`    - ${k}`);
-    console.error("");
+if (drift.length > 0) {
+  console.error(`i18n parity check failed — ${drift.length} key(s) drifted:\n`);
+  for (const { key, presentIn, missingFrom } of drift) {
+    console.error(
+      `  ${key} — missing from ${missingFrom.join(", ")} (present in ${presentIn.join(", ")})`,
+    );
   }
+  console.error("");
   process.exit(1);
 }
 
-console.log(`i18n parity OK — ${union.size} keys across ${LOCALES.join(", ")}`);
+console.log(
+  `i18n parity OK — ${union.length} keys across ${LOCALES.join(", ")}`,
+);

--- a/scripts/check-i18n-parity.ts
+++ b/scripts/check-i18n-parity.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LOCALES = ["en", "ko", "zh"] as const;
+const MESSAGES_DIR = join(process.cwd(), "messages");
+
+type Json = string | number | boolean | null | { [k: string]: Json } | Json[];
+
+function flatten(value: Json, prefix = ""): string[] {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return [prefix];
+  }
+  return Object.entries(value).flatMap(([k, v]) =>
+    flatten(v, prefix ? `${prefix}.${k}` : k),
+  );
+}
+
+const keysByLocale = Object.fromEntries(
+  LOCALES.map((locale) => {
+    const file = join(MESSAGES_DIR, `${locale}.json`);
+    const data = JSON.parse(readFileSync(file, "utf-8")) as Json;
+    return [locale, new Set(flatten(data))];
+  }),
+) as Record<(typeof LOCALES)[number], Set<string>>;
+
+const union = new Set(LOCALES.flatMap((l) => [...keysByLocale[l]]));
+
+const missing: Record<string, string[]> = {};
+for (const locale of LOCALES) {
+  const gaps = [...union].filter((k) => !keysByLocale[locale].has(k)).sort();
+  if (gaps.length > 0) missing[locale] = gaps;
+}
+
+if (Object.keys(missing).length > 0) {
+  console.error("i18n parity check failed — missing keys:\n");
+  for (const [locale, keys] of Object.entries(missing)) {
+    console.error(`  ${locale}.json is missing ${keys.length} key(s):`);
+    for (const k of keys) console.error(`    - ${k}`);
+    console.error("");
+  }
+  process.exit(1);
+}
+
+console.log(`i18n parity OK — ${union.size} keys across ${LOCALES.join(", ")}`);


### PR DESCRIPTION
## Summary
- Adds `scripts/check-i18n-parity.ts` — flattens `messages/{en,ko,zh}.json` keys and exits non-zero if any locale is missing keys another has.
- Exposes it as `pnpm i18n:check`.
- Adds an `i18n parity` step in `ci.yml` between Lint and Typecheck.

Currently passes (103 keys aligned across en/ko/zh).

## Test plan
- [ ] CI's new `i18n parity` step is green on this PR.
- [ ] (Sanity check, optional) Temporarily delete a key from one locale and confirm CI fails with a useful message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)