### PR TITLE
fix(applications): link certifications stat to /resources/certifications

### DIFF
--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -32,7 +32,7 @@ function buildStats(locale: Locale, industryCount: number): StatItem[] {
   return [
     { value: String(industryCount), label: industries, href: "#industries" },
     { value: "40+", label: models, href: "/products" },
-    { value: "13", label: certs },
+    { value: "13", label: certs, href: "/resources/certifications" },
   ];
 }
 


### PR DESCRIPTION
## Summary
- Converts the "13 Certifications" stat on `/applications` from a plain `<div>` to a `<Link>` pointing to `/resources/certifications`
- Matches the existing pattern used for the "Industries" and "Models" stats

## Test plan
- [ ] Visit `/applications` — certifications stat is clickable and navigates to `/resources/certifications`
- [ ] Verify other two stats (Industries, Models) still work

Closes #105
🤖 Generated with [Claude Code](https://claude.com/claude-code)