### PR TITLE
fix(footer): replace logomark + tagline with full logo lockup

### DIFF
--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -27,19 +27,6 @@
   color: var(--pd-primary);
 }
 
-.pd-foot__mark {
-  display: inline-flex;
-  align-items: center;
-}
-
-.pd-foot__sig {
-  margin: 0;
-  font-weight: 600;
-  font-size: var(--lt-fs-xs);
-  color: var(--pd-fg-strong);
-  max-width: 36ch;
-}
-
 .pd-foot__col {
   flex: 1 1 200px;
   min-width: 0;

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { LT_SHELL } from "@/lib/content/shell";
 import type { Locale } from "@/lib/content/home";
-import { Logomark } from "../Logomark";
+import { LogoLockup } from "../LogoLockup";
 import "./Footer.css";
 
 type Props = {
@@ -14,18 +14,14 @@ function telHref(phone: string) {
 }
 
 export async function Footer({ locale }: Props) {
-  const { signoff, contact, legal, subsidiary, links, rights } =
-    LT_SHELL[locale].footer;
+  const { contact, legal, subsidiary, links, rights } = LT_SHELL[locale].footer;
   const t = await getTranslations({ locale, namespace: "footer" });
 
   return (
     <footer className="pd-foot">
       <div className="pd-foot__cols">
         <div className="pd-foot__brand">
-          <span className="pd-foot__mark" aria-hidden="true">
-            <Logomark size={20} />
-          </span>
-          <p className="pd-foot__sig">{signoff}</p>
+          <LogoLockup height={28} />
         </div>
 
         <div className="pd-foot__col">

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -22,6 +22,7 @@ export async function Footer({ locale }: Props) {
       <div className="pd-foot__cols">
         <div className="pd-foot__brand">
           <LogoLockup height={28} />
+          <span className="sr-only">Line Tech</span>
         </div>
 
         <div className="pd-foot__col">

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -56,7 +56,6 @@ export type ShellFeaturedCard = {
 };
 
 export type ShellFooter = {
-  signoff: string;
   contact: {
     heading: string;
     address: string;
@@ -340,7 +339,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "사이트 메뉴",
     },
     footer: {
-      signoff: "정밀 질량유량 솔루션",
       contact: {
         heading: "문의",
         address: "대전광역시 유성구 대덕대로 806 (34055)",
@@ -571,7 +569,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "Site menu",
     },
     footer: {
-      signoff: "Mass Flow Solutions",
       contact: {
         heading: "Contact",
         address: "806 Daedeok-daero, Yuseong-gu, Daejeon 34055, Korea",
@@ -790,7 +787,6 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
       heading: "站点菜单",
     },
     footer: {
-      signoff: "精密质量流量解决方案",
       contact: {
         heading: "联系方式",
         address: "韩国大田广域市儒城区大德大路 806 号 (34055)",


### PR DESCRIPTION
## Summary
- Swaps the small `<Logomark>` + "Mass Flow Solutions" tagline in the footer brand column for the full `<LogoLockup>` SVG component (mark + "Line Tech" wordmark)
- Removes now-unused `signoff` destructure from `LT_SHELL[locale].footer`

## Test plan
- Verify footer renders the full logo lockup (mark + "Line Tech" text) across all three locales (/en, /ko, /zh)
- Check mobile (≤640px) — logo should wrap cleanly within the brand column

🤖 Generated with [Claude Code](https://claude.com/claude-code)