### PR TITLE
chore(seo): block training-only AI crawlers, keep assistant bots open

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,9 +1,25 @@
 import type { MetadataRoute } from "next";
 import { siteUrl } from "@/lib/seo";
 
+// Training-only harvesters — no user-facing AI assistant answers, so no discoverability return.
+// User-facing assistant bots (GPTBot, PerplexityBot, Claude-User, etc.) are left unrestricted.
+const TRAINING_ONLY_BOTS = [
+  "CCBot",
+  "Google-Extended",
+  "Bytespider",
+  "ClaudeBot",
+  "Diffbot",
+  "meta-externalagent",
+  "OmgiliBot",
+  "Timpibot",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/", disallow: ["/studio"] }],
+    rules: [
+      { userAgent: "*", allow: "/", disallow: ["/studio"] },
+      ...TRAINING_ONLY_BOTS.map((bot) => ({ userAgent: bot, disallow: "/" })),
+    ],
     sitemap: `${siteUrl}/sitemap.xml`,
   };
 }


### PR DESCRIPTION
Closes #88

## Summary

- Blocks 8 training-only AI harvesters (CCBot, Google-Extended, Bytespider, ClaudeBot, Diffbot, meta-externalagent, OmgiliBot, Timpibot) with `Disallow: /`
- Leaves user-facing assistant crawlers unrestricted (GPTBot, PerplexityBot, ChatGPT-User, Claude-User, Applebot-Extended, YouBot) — these surface Line Tech in live AI answers
- One file changed: `src/app/robots.ts`

## Policy rationale

Bots are split on whether they produce user-facing discoverability:
- **Allow** = bot surfaces specific pages in live assistant answers (ChatGPT, Perplexity, Apple Intelligence, etc.)
- **Block** = bot harvests data only for model training; no return in user-facing answers

`Google-Extended` blocks Gemini/Bard training without affecting Google Search ranking or citations.
`FacebookBot` (link previews) is left unrestricted; only `meta-externalagent` (Meta AI training) is blocked.

## Test plan

- [ ] `GET /robots.txt` — confirm one `Disallow: /` block per blocked bot
- [ ] Confirm `User-agent: *` with `Disallow: /studio` still present
- [ ] Confirm `Sitemap:` line present

🤖 Generated with [Claude Code](https://claude.com/claude-code)