### PR TITLE
fix(products): pin flagships for digital and specialized rotator slots

### DIFF
--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -31,7 +31,12 @@ const FLAGSHIP_IMAGE_PLACEHOLDER = "/products/lti/placeholder.svg";
 
 function flagshipImageUrl(flagship: Product): string {
   const image = flagship.images?.[0];
-  if (!image?.asset) return FLAGSHIP_IMAGE_PLACEHOLDER;
+  if (!image?.asset) {
+    console.warn(
+      `[products rotator] No image for flagship ${flagship.model} — showing placeholder`,
+    );
+    return FLAGSHIP_IMAGE_PLACEHOLDER;
+  }
   return urlFor(image).width(720).url();
 }
 
@@ -56,6 +61,8 @@ const SERIES_COUNT = 4;
 
 const FLAGSHIP_MODEL: Partial<Record<CategorySlug, string>> = {
   analogue: "M3030VA",
+  digital: "MD800C",
+  specialized: "LD030C",
 };
 
 function pickFlagship(

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -22,10 +22,7 @@ import {
   type RotatingSlide,
   type SlideAccent,
 } from "./RotatingFeatured";
-import {
-  flagshipImageUrl,
-  pickFlagship,
-} from "@/lib/products/flagship";
+import { flagshipImageUrl, pickFlagship } from "@/lib/products/flagship";
 import "./products-list.css";
 
 export const revalidate = 3600;

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -11,34 +11,24 @@ import {
   categoryForSeries,
   type CategorySlug,
 } from "@/lib/categories";
-import { SanityProductSchema, type Product } from "@/lib/types/product";
+import { SanityProductSchema } from "@/lib/types/product";
 import { z } from "zod";
 import { buildProductsMetadata } from "@/lib/seo";
 import { getProductsCategories } from "@/lib/content/shell";
 import { LT_HOME, type Locale } from "@/lib/content/home";
 import { LT_APPLICATIONS } from "@/lib/content/applications";
-import { urlFor } from "@/sanity/imageUrl";
 import {
   RotatingFeatured,
   type RotatingSlide,
   type SlideAccent,
 } from "./RotatingFeatured";
+import {
+  flagshipImageUrl,
+  pickFlagship,
+} from "@/lib/products/flagship";
 import "./products-list.css";
 
 export const revalidate = 3600;
-
-const FLAGSHIP_IMAGE_PLACEHOLDER = "/products/lti/placeholder.svg";
-
-function flagshipImageUrl(flagship: Product): string {
-  const image = flagship.images?.[0];
-  if (!image?.asset) {
-    console.warn(
-      `[products rotator] No image for flagship ${flagship.model} — showing placeholder`,
-    );
-    return FLAGSHIP_IMAGE_PLACEHOLDER;
-  }
-  return urlFor(image).width(720).url();
-}
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -58,28 +48,6 @@ const APPLICATION_STRIP_SLUGS = [
 ] as const;
 
 const SERIES_COUNT = 4;
-
-const FLAGSHIP_MODEL: Partial<Record<CategorySlug, string>> = {
-  analogue: "M3030VA",
-  digital: "MD800C",
-  specialized: "LD030C",
-};
-
-function pickFlagship(
-  products: Product[],
-  slug: CategorySlug,
-): Product | undefined {
-  const preferred = FLAGSHIP_MODEL[slug];
-  if (preferred) {
-    const match = products.find(
-      (p) =>
-        categoryForSeries(p.series) === slug &&
-        p.model.toLowerCase() === preferred.toLowerCase(),
-    );
-    if (match) return match;
-  }
-  return products.find((p) => categoryForSeries(p.series) === slug);
-}
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;

--- a/src/lib/products/flagship.test.ts
+++ b/src/lib/products/flagship.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  FLAGSHIP_MODEL,
+  FLAGSHIP_IMAGE_PLACEHOLDER,
+  pickFlagship,
+  flagshipImageUrl,
+} from "./flagship";
+import { CATEGORY_SLUGS, type CategorySlug } from "@/lib/categories";
+import type { Product } from "@/lib/types/product";
+
+vi.mock("@/sanity/imageUrl", () => ({
+  urlFor: () => ({ width: () => ({ url: () => "https://cdn.sanity.io/mock.jpg" }) }),
+}));
+
+function makeProduct(overrides: Partial<Product> & Pick<Product, "model" | "series">): Product {
+  return {
+    slug: { current: overrides.model.toLowerCase() },
+    function: "MFC",
+    productLabel: { ko: "", en: "", zh: "" },
+    tags: [],
+    features: [],
+    connections: [],
+    massFlowSpecs: [],
+    images: null,
+    ...overrides,
+  } as unknown as Product;
+}
+
+function makeProductWithImage(model: string, series: Product["series"]): Product {
+  return makeProduct({
+    model,
+    series,
+    images: [
+      {
+        _type: "image",
+        _key: "img1",
+        asset: { _type: "reference", _ref: "image-abc123-jpg" },
+      } as NonNullable<Product["images"]>[0],
+    ],
+  });
+}
+
+const ANALOGUE_FLAGSHIP = makeProductWithImage("M3030VA", "analogue");
+const DIGITAL_FLAGSHIP = makeProductWithImage("MD800C", "digital");
+const SPECIALIZED_FLAGSHIP = makeProductWithImage("LD030C", "specialized");
+
+const ALL_PRODUCTS: Product[] = [
+  makeProduct({ model: "M3010VA", series: "analogue" }),
+  ANALOGUE_FLAGSHIP,
+  makeProduct({ model: "MD100C", series: "digital" }),
+  DIGITAL_FLAGSHIP,
+  makeProduct({ model: "LD010C", series: "specialized" }),
+  SPECIALIZED_FLAGSHIP,
+];
+
+describe("FLAGSHIP_MODEL", () => {
+  it("pins a model for every category slug", () => {
+    for (const slug of CATEGORY_SLUGS) {
+      expect(FLAGSHIP_MODEL[slug]).toBeDefined();
+    }
+  });
+});
+
+describe("pickFlagship", () => {
+  it("returns the pinned model when present", () => {
+    expect(pickFlagship(ALL_PRODUCTS, "analogue")?.model).toBe("M3030VA");
+    expect(pickFlagship(ALL_PRODUCTS, "digital")?.model).toBe("MD800C");
+    expect(pickFlagship(ALL_PRODUCTS, "specialized")?.model).toBe("LD030C");
+  });
+
+  it("falls back to any product in the category when the pin is absent", () => {
+    const products = ALL_PRODUCTS.filter((p) => p.model !== "M3030VA");
+    const result = pickFlagship(products, "analogue");
+    expect(result?.series).toBe("analogue");
+  });
+
+  it("returns undefined when the category has no products", () => {
+    const products = ALL_PRODUCTS.filter((p) => p.series !== "specialized");
+    expect(pickFlagship(products, "specialized")).toBeUndefined();
+  });
+});
+
+describe("flagshipImageUrl", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the Sanity CDN URL when the product has an image", () => {
+    const url = flagshipImageUrl(ANALOGUE_FLAGSHIP);
+    expect(url).toBe("https://cdn.sanity.io/mock.jpg");
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns the placeholder and warns when the product has no image", () => {
+    const noImage = makeProduct({ model: "M3030VA", series: "analogue" });
+    const url = flagshipImageUrl(noImage);
+    expect(url).toBe(FLAGSHIP_IMAGE_PLACEHOLDER);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("M3030VA"),
+    );
+  });
+
+  it("placeholder cannot silently reach the rotator — warn fires for every imageless flagship", () => {
+    const imagelessFlagships = CATEGORY_SLUGS.map((slug) =>
+      makeProduct({ model: FLAGSHIP_MODEL[slug]!, series: slug === "analogue" ? "analogue" : slug === "digital" ? "digital" : "specialized" }),
+    );
+    for (const p of imagelessFlagships) {
+      vi.mocked(console.warn).mockClear();
+      flagshipImageUrl(p);
+      expect(console.warn).toHaveBeenCalled();
+    }
+  });
+});

--- a/src/lib/products/flagship.test.ts
+++ b/src/lib/products/flagship.test.ts
@@ -9,10 +9,14 @@ import { CATEGORY_SLUGS, type CategorySlug } from "@/lib/categories";
 import type { Product } from "@/lib/types/product";
 
 vi.mock("@/sanity/imageUrl", () => ({
-  urlFor: () => ({ width: () => ({ url: () => "https://cdn.sanity.io/mock.jpg" }) }),
+  urlFor: () => ({
+    width: () => ({ url: () => "https://cdn.sanity.io/mock.jpg" }),
+  }),
 }));
 
-function makeProduct(overrides: Partial<Product> & Pick<Product, "model" | "series">): Product {
+function makeProduct(
+  overrides: Partial<Product> & Pick<Product, "model" | "series">,
+): Product {
   return {
     slug: { current: overrides.model.toLowerCase() },
     function: "MFC",
@@ -26,7 +30,10 @@ function makeProduct(overrides: Partial<Product> & Pick<Product, "model" | "seri
   } as unknown as Product;
 }
 
-function makeProductWithImage(model: string, series: Product["series"]): Product {
+function makeProductWithImage(
+  model: string,
+  series: Product["series"],
+): Product {
   return makeProduct({
     model,
     series,
@@ -119,7 +126,10 @@ describe("flagshipImageUrl", () => {
 
   it("placeholder cannot silently reach the rotator — warn fires for every imageless flagship", () => {
     const imagelessFlagships = CATEGORY_SLUGS.map((slug) =>
-      makeProduct({ model: FLAGSHIP_MODEL[slug]!, series: slug as Product["series"] }),
+      makeProduct({
+        model: FLAGSHIP_MODEL[slug]!,
+        series: slug as Product["series"],
+      }),
     );
     for (const p of imagelessFlagships) {
       vi.mocked(console.warn).mockClear();

--- a/src/lib/products/flagship.test.ts
+++ b/src/lib/products/flagship.test.ts
@@ -68,10 +68,23 @@ describe("pickFlagship", () => {
     expect(pickFlagship(ALL_PRODUCTS, "specialized")?.model).toBe("LD030C");
   });
 
-  it("falls back to any product in the category when the pin is absent", () => {
+  it("falls back when the pinned model is not in the product list", () => {
     const products = ALL_PRODUCTS.filter((p) => p.model !== "M3030VA");
     const result = pickFlagship(products, "analogue");
     expect(result?.series).toBe("analogue");
+    expect(result?.model).not.toBe("M3030VA");
+  });
+
+  it("falls back when the slug has no entry in FLAGSHIP_MODEL", () => {
+    const saved = FLAGSHIP_MODEL.analogue;
+    try {
+      delete (FLAGSHIP_MODEL as Partial<Record<string, string>>).analogue;
+      const products = ALL_PRODUCTS.filter((p) => p.series === "analogue");
+      const result = pickFlagship(products, "analogue");
+      expect(result?.series).toBe("analogue");
+    } finally {
+      FLAGSHIP_MODEL.analogue = saved;
+    }
   });
 
   it("returns undefined when the category has no products", () => {
@@ -106,7 +119,7 @@ describe("flagshipImageUrl", () => {
 
   it("placeholder cannot silently reach the rotator — warn fires for every imageless flagship", () => {
     const imagelessFlagships = CATEGORY_SLUGS.map((slug) =>
-      makeProduct({ model: FLAGSHIP_MODEL[slug]!, series: slug === "analogue" ? "analogue" : slug === "digital" ? "digital" : "specialized" }),
+      makeProduct({ model: FLAGSHIP_MODEL[slug]!, series: slug as Product["series"] }),
     );
     for (const p of imagelessFlagships) {
       vi.mocked(console.warn).mockClear();

--- a/src/lib/products/flagship.ts
+++ b/src/lib/products/flagship.ts
@@ -1,0 +1,38 @@
+import { urlFor } from "@/sanity/imageUrl";
+import { categoryForSeries, type CategorySlug } from "@/lib/categories";
+import type { Product } from "@/lib/types/product";
+
+export const FLAGSHIP_IMAGE_PLACEHOLDER = "/products/lti/placeholder.svg";
+
+export const FLAGSHIP_MODEL: Partial<Record<CategorySlug, string>> = {
+  analogue: "M3030VA",
+  digital: "MD800C",
+  specialized: "LD030C",
+};
+
+export function pickFlagship(
+  products: Product[],
+  slug: CategorySlug,
+): Product | undefined {
+  const preferred = FLAGSHIP_MODEL[slug];
+  if (preferred) {
+    const match = products.find(
+      (p) =>
+        categoryForSeries(p.series) === slug &&
+        p.model.toLowerCase() === preferred.toLowerCase(),
+    );
+    if (match) return match;
+  }
+  return products.find((p) => categoryForSeries(p.series) === slug);
+}
+
+export function flagshipImageUrl(flagship: Product): string {
+  const image = flagship.images?.[0];
+  if (!image?.asset) {
+    console.warn(
+      `[products rotator] No image for flagship ${flagship.model} — showing placeholder`,
+    );
+    return FLAGSHIP_IMAGE_PLACEHOLDER;
+  }
+  return urlFor(image).width(720).url();
+}


### PR DESCRIPTION
## Summary
- Extends \`FLAGSHIP_MODEL\` with \`digital: "MD800C"\` and \`specialized: "LD030C"\` so the rotator shows a deliberate product per series instead of alphabetical fallback
- Adds \`console.warn\` in \`flagshipImageUrl\` when no Sanity image is present, making silent broken slides visible in build/server logs
- Extracts flagship logic (\`FLAGSHIP_MODEL\`, \`pickFlagship\`, \`flagshipImageUrl\`) into \`src/lib/products/flagship.ts\` for testability
- Adds 8 unit tests covering correct model selection, category fallback (missing product, missing pin), and the warn-on-placeholder invariant

## Test plan
- [ ] \`/products\` rotator shows MD800C for digital slot and LD030C for specialized slot
- [ ] Removing a model's Sanity image triggers a server-side warning in the build log

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)