### PR TITLE
fix(products): replace hardcoded certification count with Sanity query

### DIFF
--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -50,7 +50,6 @@ const APPLICATION_STRIP_SLUGS = [
   "research-development",
 ] as const;
 
-const CERTIFICATION_COUNT = 13;
 const SERIES_COUNT = 4;
 
 const FLAGSHIP_MODEL: Partial<Record<CategorySlug, string>> = {
@@ -88,9 +87,12 @@ export default async function ProductsListPage({ params }: Props) {
     getTranslations("products"),
   ]);
 
-  const products = z
-    .array(SanityProductSchema)
-    .parse(await sanityClient.fetch(allProductsQuery));
+  const [products, certificationCount] = await Promise.all([
+    sanityClient
+      .fetch(allProductsQuery)
+      .then((data) => z.array(SanityProductSchema).parse(data)),
+    sanityClient.fetch<number>('count(*[_type == "certification"])'),
+  ]);
 
   const counts = new Map<CategorySlug, number>(
     CATEGORY_SLUGS.map((slug) => [slug, 0]),
@@ -186,7 +188,7 @@ export default async function ProductsListPage({ params }: Props) {
         <li className="lt-products-list__stat">
           <div className="lt-products-list__stat-cell">
             <div className="lt-products-list__stat-num">
-              {CERTIFICATION_COUNT}
+              {certificationCount}
             </div>
             <div className="lt-products-list__stat-label">
               {tProducts("list.stats.certificationsLabel")}

--- a/src/components/layout/MegaMenu/MegaMenu.test.tsx
+++ b/src/components/layout/MegaMenu/MegaMenu.test.tsx
@@ -113,8 +113,11 @@ describe("MegaMenu", () => {
     expect(panel).toHaveAttribute("aria-hidden", "false");
     expect(panel).toHaveClass("is-open");
 
+    const linkList = panel!.querySelector(".pd-mega__list");
     ["Greeting", "History", "Certifications", "Location"].forEach((label) => {
-      expect(within(panel as HTMLElement).getByText(label)).toBeInTheDocument();
+      expect(
+        within(linkList as HTMLElement).getByText(label),
+      ).toBeInTheDocument();
     });
     expect(
       within(panel as HTMLElement).getByText("View all certifications"),

--- a/src/components/layout/MegaMenu/MegaMenu.test.tsx
+++ b/src/components/layout/MegaMenu/MegaMenu.test.tsx
@@ -106,7 +106,7 @@ describe("MegaMenu", () => {
     expect(resources).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("renders 4 company links + 13-certifications featured card when company is open", () => {
+  it("renders 4 company links + certifications featured card when company is open", () => {
     const { container } = renderMega(stubCtx({ openId: "company" }));
 
     const panel = container.querySelector('[data-id="company"]');
@@ -117,7 +117,7 @@ describe("MegaMenu", () => {
       expect(within(panel as HTMLElement).getByText(label)).toBeInTheDocument();
     });
     expect(
-      within(panel as HTMLElement).getByText(/certifications/i),
+      within(panel as HTMLElement).getByText("View all certifications"),
     ).toBeInTheDocument();
   });
 

--- a/src/components/layout/MegaMenu/MegaMenu.test.tsx
+++ b/src/components/layout/MegaMenu/MegaMenu.test.tsx
@@ -117,7 +117,7 @@ describe("MegaMenu", () => {
       expect(within(panel as HTMLElement).getByText(label)).toBeInTheDocument();
     });
     expect(
-      within(panel as HTMLElement).getByText(/13 certifications/i),
+      within(panel as HTMLElement).getByText(/certifications/i),
     ).toBeInTheDocument();
   });
 

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -169,7 +169,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           ],
           featured: {
             eyebrow: "신뢰",
-            title: "13종 인증",
+            title: "인증서",
             blurb: "ISO 9001 · CE · INNOBIZ · RoHS / REACH 외 9종.",
             href: "/company#certifications",
             cta: "전체 인증 보기",
@@ -269,7 +269,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             {
               href: "/resources/certifications",
               label: "인증서",
-              desc: "13종 인증 문서",
+              desc: "인증 문서",
             },
             {
               href: "/faq",
@@ -396,7 +396,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           ],
           featured: {
             eyebrow: "Trust",
-            title: "13 certifications",
+            title: "Certifications",
             blurb:
               "ISO 9001, CE, INNOBIZ, RoHS / REACH and 9 more — the full set procurement teams ask for.",
             href: "/company#certifications",
@@ -498,7 +498,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             {
               href: "/resources/certifications",
               label: "Certifications",
-              desc: "13 certification documents",
+              desc: "Certification documents",
             },
             {
               href: "/faq",
@@ -617,8 +617,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
           ],
           featured: {
             eyebrow: "信赖",
-            title: "13 项资质认证",
-            blurb: "ISO 9001 · CE · INNOBIZ · RoHS / REACH 等 13 项认证文件。",
+            title: "资质认证",
+            blurb: "ISO 9001 · CE · INNOBIZ · RoHS / REACH 等认证文件。",
             href: "/company#certifications",
             cta: "查看全部认证",
           },
@@ -717,7 +717,7 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
             {
               href: "/resources/certifications",
               label: "认证文件",
-              desc: "13 份认证文件",
+              desc: "认证文件",
             },
             {
               href: "/faq",


### PR DESCRIPTION
## Summary
- Fetches `count(*[_type == "certification"])` in parallel with the products query; stats band now reflects live Sanity data on each revalidation
- Removes hardcoded `13` from all six nav strings across en/ko/zh in `shell.ts`
- Updates MegaMenu test to match new string

## Test plan
- [ ] `/products` stats band shows live cert count from Sanity
- [ ] Nav featured card and resources dropdown no longer show "13"
- [ ] MegaMenu tests pass

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)