### PR TITLE
fix(showcase): stop cropping product images on category pages

### DIFF
--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -62,7 +62,7 @@ export default async function CategoryPage({ params }: Props) {
     flowRange: e.flowRange,
     accuracy: e.accuracy,
     image: e.image?.asset
-      ? urlFor(e.image).width(960).fit("max").url()
+      ? urlFor(e.image).width(960).url()
       : "/products/lti/placeholder.svg",
     href: `/${locale}/products/${category}/${e.slug}`,
   }));

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -62,7 +62,7 @@ export default async function CategoryPage({ params }: Props) {
     flowRange: e.flowRange,
     accuracy: e.accuracy,
     image: e.image?.asset
-      ? urlFor(e.image).width(960).height(640).fit("crop").url()
+      ? urlFor(e.image).width(960).fit("max").url()
       : "/products/lti/placeholder.svg",
     href: `/${locale}/products/${category}/${e.slug}`,
   }));


### PR DESCRIPTION
## Summary
- Product photos in the CategoryShowcase were being hard-cropped to 960×640 via Sanity's fit("crop") transform
- The showcase container already uses object-fit: contain, so the browser handles fitting — only a max-width scale is needed
- Fixes incorrectly cropped images on /products/analogue, /products/digital, and /products/specialized

## Test plan
- Visit /ko/products/analogue, /digital, /specialized and confirm product images show full, uncropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)