### PR TITLE
fix(footer): replace flex-wrap with CSS Grid

### DIFF
--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -14,7 +14,7 @@
   margin: 0 auto;
   padding: 40px 32px 28px;
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 1fr);
   gap: 48px;
   align-items: flex-start;
 }

--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -13,14 +13,13 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: 40px 32px 28px;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
   gap: 48px;
   align-items: flex-start;
 }
 
 .pd-foot__brand {
-  flex: 2 1 280px;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -28,7 +27,6 @@
 }
 
 .pd-foot__col {
-  flex: 1 1 200px;
   min-width: 0;
 }
 
@@ -97,9 +95,20 @@
   font-size: var(--lt-fs-xs);
 }
 
+@media (max-width: 1023px) {
+  .pd-foot__cols {
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 32px;
+  }
+
+  .pd-foot__brand {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 640px) {
   .pd-foot__cols {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 28px;
     padding: 28px 16px 20px;
   }


### PR DESCRIPTION
## Summary
- Footer used `flex-wrap: wrap`, causing the last column (빠른 링크) to drop alone onto a second row at medium viewport widths (~750–1050px)
- Replaced flexbox layout with CSS Grid: 4-col on wide (≥1024px), brand full-width + 3-col info columns on tablet (641–1023px), single column on mobile (≤640px)

## Test plan
- Resize viewport from ~600px to 1400px and verify no column wraps mid-row
- Wide (≥1024px): all 4 columns on one row, brand ~2× wider
- Tablet (~900px): logo spans full width on top, 3 info columns below
- Mobile (~375px): single stacked column

🤖 Generated with [Claude Code](https://claude.com/claude-code)