### PR TITLE
fix(products): remove force-crop from showcase images

### DIFF
--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -62,7 +62,7 @@ export default async function CategoryPage({ params }: Props) {
     flowRange: e.flowRange,
     accuracy: e.accuracy,
     image: e.image?.asset
-      ? urlFor(e.image).width(960).height(640).fit("crop").url()
+      ? urlFor(e.image).width(960).url()
       : "/products/lti/placeholder.svg",
     href: `/${locale}/products/${category}/${e.slug}`,
   }));

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -99,6 +99,7 @@ export function CategoryShowcase({
               alt={p.model}
               fill
               sizes="(max-width: 768px) 100vw, 50vw"
+              quality={85}
               className="lt-showcase__img"
               priority={i === 0}
             />


### PR DESCRIPTION
## Summary
- Category showcase carousel was building image URLs with `.width(960).height(640).fit("crop")` — the same force-crop that was fixed for table thumbnails in #117 but missed for the showcase.
- Product photos are roughly square; the 3:2 crop cuts ~16% from top and bottom. For slides 2+ (MS3700VA, M2030VA) the connector / top of the device is near the top edge, so the crop visibly slices the product.
- Fix: drop the height + fit args → `.width(960).url()`. The showcase already uses `object-fit: contain` in CSS, which letterboxes correctly — no layout changes needed.

## Test plan
- Visit `/en/products/analogue` (and digital / specialized)
- Cycle through all showcase slides — each product photo should display without cropping, with letterbox padding as needed
- Confirm table thumbnails are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)