### PR TITLE
fix(launch-blockers): home CTAs, real product downloads, email + studio hardening

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -165,13 +165,14 @@
       "sub": "Latest revisions only. Request historical files via the contact form.",
       "download": "Download",
       "done": "Done",
-      "placeholders": {
-        "datasheet": "{model} datasheet",
-        "manual": "{model} user manual",
-        "cad": "{model} outline drawing",
-        "rev": "Rev. —",
-        "tbd": "TBD"
-      }
+      "datasheetFor": "{model} datasheet",
+      "manualFor": "{model} user manual"
+    },
+    "requestDocs": {
+      "kicker": "Documentation",
+      "heading": "Need datasheets, manuals, or CAD drawings?",
+      "body": "Technical documents are sent on request. Tell us the model and your application — we'll respond within one business day.",
+      "cta": "Request technical documents"
     }
   },
   "resources": {
@@ -189,6 +190,11 @@
         "title": "CAD Drawings",
         "desc": "AutoCAD (.dwg) and STEP (.stp) files",
         "count": "{count} models"
+      },
+      "datasheets": {
+        "title": "Datasheets",
+        "desc": "Per-model specification sheets",
+        "count": "{count} documents"
       },
       "manuals": {
         "title": "Manuals",
@@ -208,6 +214,10 @@
     "drawings": {
       "title": "CAD Drawings",
       "intro": "Outline drawings for each model in AutoCAD (.dwg) and STEP (.stp) formats."
+    },
+    "datasheets": {
+      "title": "Datasheets",
+      "intro": "Specification sheets for every model. Download the latest revision or request a specific configuration."
     },
     "manuals": {
       "title": "Manuals",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -165,13 +165,14 @@
       "sub": "최신본만 게시됩니다. 이력 자료는 문의 폼으로 요청해 주십시오.",
       "download": "다운로드",
       "done": "완료",
-      "placeholders": {
-        "datasheet": "{model} 데이터시트",
-        "manual": "{model} 사용자 매뉴얼",
-        "cad": "{model} 외형 도면",
-        "rev": "Rev. —",
-        "tbd": "준비 중"
-      }
+      "datasheetFor": "{model} 데이터시트",
+      "manualFor": "{model} 사용자 매뉴얼"
+    },
+    "requestDocs": {
+      "kicker": "자료",
+      "heading": "데이터시트, 매뉴얼, CAD 도면이 필요하신가요?",
+      "body": "기술 자료는 요청 시 발송해 드립니다. 모델명과 사용 분야를 알려주시면 영업일 1일 이내에 회신드립니다.",
+      "cta": "기술 자료 요청"
     }
   },
   "resources": {
@@ -189,6 +190,11 @@
         "title": "CAD 도면",
         "desc": "AutoCAD (.dwg) 및 STEP (.stp) 파일",
         "count": "{count}개 도면"
+      },
+      "datasheets": {
+        "title": "데이터시트",
+        "desc": "모델별 사양서",
+        "count": "{count}개 문서"
       },
       "manuals": {
         "title": "매뉴얼",
@@ -208,6 +214,10 @@
     "drawings": {
       "title": "CAD 도면",
       "intro": "모델별 외형 도면을 AutoCAD (.dwg) 및 STEP (.stp) 형식으로 제공합니다."
+    },
+    "datasheets": {
+      "title": "데이터시트",
+      "intro": "모델별 사양서를 내려받거나 필요한 구성을 문의해 주세요. 항상 최신 개정판을 제공해 드립니다."
     },
     "manuals": {
       "title": "매뉴얼",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -165,13 +165,14 @@
       "sub": "仅发布最新版。如需历史资料，请通过联系表单申请。",
       "download": "下载",
       "done": "完成",
-      "placeholders": {
-        "datasheet": "{model} 数据手册",
-        "manual": "{model} 使用手册",
-        "cad": "{model} 外形图",
-        "rev": "Rev. —",
-        "tbd": "待发布"
-      }
+      "datasheetFor": "{model} 数据手册",
+      "manualFor": "{model} 使用手册"
+    },
+    "requestDocs": {
+      "kicker": "技术资料",
+      "heading": "需要数据手册、说明书或CAD图纸？",
+      "body": "技术资料可应需求提供。请告知型号和应用场景，我们将在一个工作日内回复。",
+      "cta": "申请技术资料"
     }
   },
   "resources": {
@@ -189,6 +190,11 @@
         "title": "CAD 图纸",
         "desc": "AutoCAD (.dwg) 及 STEP (.stp) 文件",
         "count": "{count}个图纸"
+      },
+      "datasheets": {
+        "title": "数据手册",
+        "desc": "各型号规格说明书",
+        "count": "{count}份文件"
       },
       "manuals": {
         "title": "使用手册",
@@ -208,6 +214,10 @@
     "drawings": {
       "title": "CAD 图纸",
       "intro": "提供各型号外形图，支持 AutoCAD (.dwg) 和 STEP (.stp) 格式下载。"
+    },
+    "datasheets": {
+      "title": "数据手册",
+      "intro": "各型号产品的规格说明书。下载最新版本或申请特定配置。"
     },
     "manuals": {
       "title": "使用手册",

--- a/sanity/schemaTypes/datasheet.ts
+++ b/sanity/schemaTypes/datasheet.ts
@@ -1,0 +1,61 @@
+import { defineType, defineField } from "sanity";
+
+export const datasheet = defineType({
+  name: "datasheet",
+  title: "Datasheet",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "model",
+      title: "Model",
+      type: "string",
+      description: "Product model code (e.g. M3030VA)",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "series",
+      title: "Series",
+      type: "string",
+      options: {
+        list: [
+          { title: "Analogue", value: "analogue" },
+          { title: "Digital", value: "digital" },
+          { title: "Specialized", value: "specialized" },
+        ],
+        layout: "radio",
+      },
+    }),
+    defineField({
+      name: "rev",
+      title: "Revision",
+      type: "string",
+      description: 'e.g. "Rev. A"',
+    }),
+    defineField({
+      name: "file",
+      title: "PDF file",
+      type: "file",
+      options: { accept: ".pdf" },
+    }),
+    defineField({
+      name: "publishedAt",
+      title: "Published",
+      type: "date",
+    }),
+  ],
+  preview: {
+    select: { title: "title", model: "model", series: "series" },
+    prepare({ title, model, series }) {
+      return {
+        title: title ?? "(untitled)",
+        subtitle: [model, series].filter(Boolean).join(" · "),
+      };
+    },
+  },
+});

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -5,6 +5,7 @@ import { contactSubmission } from "./contactSubmission";
 import { catalogue } from "./catalogue";
 import { manual } from "./manual";
 import { drawing } from "./drawing";
+import { datasheet } from "./datasheet";
 import { certification } from "./certification";
 
 export const schemaTypes = [
@@ -15,5 +16,6 @@ export const schemaTypes = [
   catalogue,
   manual,
   drawing,
+  datasheet,
   certification,
 ];

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -687,6 +687,9 @@ function buildProduct(
     features: featuresFor(section.model).map(localize),
     connections,
     massFlowSpecs,
+    datasheets: [],
+    manuals: [],
+    drawings: [],
   };
   if (series === "digital") {
     product.digitalCommunication = STANDARD_DIGITAL_COMM;

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -33,7 +33,7 @@ export default async function HomePage({ params }: Props) {
         <Applications h={h} />
         <Feature h={h} />
         <Credentials h={h} />
-        <Contact h={h} locale={locale} />
+        <Contact h={h} />
       </div>
     </main>
   );

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -16,6 +16,8 @@ import {
   DownloadsList,
   type DownloadItem,
 } from "@/components/products/DownloadsList";
+import { RequestDocs } from "@/components/products/RequestDocs";
+import { formatBytes, formatDate } from "@/lib/format";
 import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
 import { productBySlugQuery, productSlugsQuery } from "@/sanity/queries";
@@ -188,27 +190,49 @@ export default async function ProductPage({ params }: Props) {
     : null;
 
   const downloadItems: DownloadItem[] = [
-    {
-      label: tPdp("downloads.placeholders.datasheet", { model: product.model }),
-      type: "PDF",
-      size: "—",
-      rev: tPdp("downloads.placeholders.rev"),
-      date: tPdp("downloads.placeholders.tbd"),
-    },
-    {
-      label: tPdp("downloads.placeholders.manual", { model: product.model }),
-      type: "PDF",
-      size: "—",
-      rev: tPdp("downloads.placeholders.rev"),
-      date: tPdp("downloads.placeholders.tbd"),
-    },
-    {
-      label: tPdp("downloads.placeholders.cad", { model: product.model }),
-      type: "DWG",
-      size: "—",
-      rev: tPdp("downloads.placeholders.rev"),
-      date: tPdp("downloads.placeholders.tbd"),
-    },
+    ...product.datasheets
+      .filter((d) => d.fileUrl)
+      .map<DownloadItem>((d) => ({
+        label:
+          d.title || tPdp("downloads.datasheetFor", { model: product.model }),
+        type: "PDF",
+        href: d.fileUrl ?? undefined,
+        size: formatBytes(d.size),
+        rev: d.rev ?? undefined,
+        date: formatDate(d.publishedAt ?? d.updatedAt, locale),
+      })),
+    ...product.manuals
+      .filter((m) => m.fileUrl)
+      .map<DownloadItem>((m) => ({
+        label: m.title || tPdp("downloads.manualFor", { model: product.model }),
+        type: "PDF",
+        href: m.fileUrl ?? undefined,
+        size: formatBytes(m.size),
+        rev: m.rev ?? undefined,
+        date: formatDate(m.publishedAt ?? m.updatedAt, locale),
+      })),
+    ...product.drawings.flatMap<DownloadItem>((d) => {
+      const items: DownloadItem[] = [];
+      if (d.dwgUrl) {
+        items.push({
+          label: `${d.title} (DWG)`,
+          type: "DWG",
+          href: d.dwgUrl,
+          size: formatBytes(d.dwgSize),
+          date: formatDate(d.updatedAt, locale),
+        });
+      }
+      if (d.stpUrl) {
+        items.push({
+          label: `${d.title} (STEP)`,
+          type: "STEP",
+          href: d.stpUrl,
+          size: formatBytes(d.stpSize),
+          date: formatDate(d.updatedAt, locale),
+        });
+      }
+      return items;
+    }),
   ];
 
   const productUrl = `${siteUrl}/${locale}/products/${category}/${product.slug.current}`;
@@ -340,14 +364,24 @@ export default async function ProductPage({ params }: Props) {
           />
         )}
 
-        <DownloadsList
-          kicker={`04 — ${tPdp("tabs.downloads")}`}
-          heading={tPdp("downloads.heading")}
-          sub={tPdp("downloads.sub")}
-          downloadLabel={tPdp("downloads.download")}
-          doneLabel={tPdp("downloads.done")}
-          items={downloadItems}
-        />
+        {downloadItems.length > 0 ? (
+          <DownloadsList
+            kicker={`04 — ${tPdp("tabs.downloads")}`}
+            heading={tPdp("downloads.heading")}
+            sub={tPdp("downloads.sub")}
+            downloadLabel={tPdp("downloads.download")}
+            doneLabel={tPdp("downloads.done")}
+            items={downloadItems}
+          />
+        ) : (
+          <RequestDocs
+            kicker={`04 — ${tPdp("requestDocs.kicker")}`}
+            heading={tPdp("requestDocs.heading")}
+            body={tPdp("requestDocs.body")}
+            ctaLabel={tPdp("requestDocs.cta")}
+            ctaHref={`/contact?product=${encodeURIComponent(product.model)}`}
+          />
+        )}
 
         {relatedApplications.length > 0 && (
           <section className="pd-related-apps">

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -145,13 +145,6 @@ export default async function ProductPage({ params }: Props) {
     { label: product.model },
   ];
 
-  const tabs = [
-    { id: "overview", num: "01", label: tPdp("tabs.overview") },
-    { id: "specs", num: "02", label: tPdp("tabs.specs") },
-    { id: "dimensions", num: "03", label: tPdp("tabs.dimensions") },
-    { id: "downloads", num: "04", label: tPdp("tabs.downloads") },
-  ];
-
   type SpecRow = { key: string; label: string; value: string };
   const specGroups = SPEC_GROUPS.map((g) => ({
     id: g.id,
@@ -233,6 +226,20 @@ export default async function ProductPage({ params }: Props) {
       }
       return items;
     }),
+  ];
+
+  const tabs = [
+    { id: "overview", num: "01", label: tPdp("tabs.overview") },
+    { id: "specs", num: "02", label: tPdp("tabs.specs") },
+    { id: "dimensions", num: "03", label: tPdp("tabs.dimensions") },
+    {
+      id: "downloads",
+      num: "04",
+      label:
+        downloadItems.length > 0
+          ? tPdp("tabs.downloads")
+          : tPdp("requestDocs.kicker"),
+    },
   ];
 
   const productUrl = `${siteUrl}/${locale}/products/${category}/${product.slug.current}`;

--- a/src/app/[locale]/resources/datasheets/page.tsx
+++ b/src/app/[locale]/resources/datasheets/page.tsx
@@ -1,0 +1,156 @@
+import { Fragment } from "react";
+import type { Metadata } from "next";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { sanityClient } from "@/sanity/client";
+import { allDatasheetsQuery } from "@/sanity/queries";
+import { routing } from "@/i18n/routing";
+import "../resources-subpage.css";
+
+export const revalidate = 3600;
+
+type Props = { params: Promise<{ locale: string }> };
+
+type Series = "analogue" | "digital" | "specialized";
+const SERIES_ORDER: Series[] = ["analogue", "digital", "specialized"];
+
+type DatasheetItem = {
+  _id: string;
+  title: string;
+  model?: string | null;
+  series?: string | null;
+  rev?: string | null;
+  publishedAt?: string | null;
+  fileUrl?: string | null;
+};
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "resources" });
+  return {
+    title: `${t("datasheets.title")} — Line Tech`,
+    description: t("datasheets.intro"),
+  };
+}
+
+export default async function DatasheetsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [tCommon, tNav, tRes, datasheets] = await Promise.all([
+    getTranslations("common"),
+    getTranslations("nav"),
+    getTranslations("resources"),
+    sanityClient.fetch<DatasheetItem[]>(allDatasheetsQuery),
+  ]);
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: tNav("dataRoom"), href: "/resources" },
+    { label: tRes("datasheets.title") },
+  ];
+
+  const grouped = SERIES_ORDER.reduce<Record<string, typeof datasheets>>(
+    (acc, s) => {
+      const items = datasheets.filter((d) => d.series === s);
+      if (items.length) acc[s] = items;
+      return acc;
+    },
+    {},
+  );
+
+  const ungrouped = datasheets.filter((d) => !d.series);
+
+  return (
+    <main className="lt-wrap dr-sub">
+      <Breadcrumbs items={breadcrumbs} />
+
+      <header className="dr-sub__hero">
+        <h1 className="dr-sub__title">{tRes("datasheets.title")}</h1>
+        <p className="dr-sub__intro">{tRes("datasheets.intro")}</p>
+      </header>
+
+      {datasheets.length === 0 ? (
+        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+      ) : (
+        <ul className="dr-list" role="list">
+          {SERIES_ORDER.filter((s) => grouped[s]).map((s) => (
+            <Fragment key={s}>
+              <li>
+                <h2 className="dr-list__group-heading">
+                  {tRes(`seriesLabel.${s}`)}
+                </h2>
+              </li>
+              {grouped[s].map((item) => (
+                <li key={item._id} className="dr-list__row">
+                  <span className="dr-list__badge dr-list__badge--pdf">
+                    PDF
+                  </span>
+                  <div>
+                    <div className="dr-list__label">{item.title}</div>
+                    {(item.model || item.rev || item.publishedAt) && (
+                      <div className="dr-list__meta">
+                        {item.model && <span>{item.model}</span>}
+                        {item.model && (item.rev || item.publishedAt) && (
+                          <span className="dr-list__sep">·</span>
+                        )}
+                        {item.rev && <span>{item.rev}</span>}
+                        {item.rev && item.publishedAt && (
+                          <span className="dr-list__sep">·</span>
+                        )}
+                        {item.publishedAt && <span>{item.publishedAt}</span>}
+                      </div>
+                    )}
+                  </div>
+                  {item.fileUrl ? (
+                    <a href={item.fileUrl} download className="dr-list__btn">
+                      {tRes("download")}
+                    </a>
+                  ) : (
+                    <span className="dr-list__btn dr-list__btn--disabled">
+                      {tRes("comingSoon")}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </Fragment>
+          ))}
+          {ungrouped.map((item) => (
+            <li key={item._id} className="dr-list__row">
+              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
+              <div>
+                <div className="dr-list__label">{item.title}</div>
+                {(item.model || item.rev || item.publishedAt) && (
+                  <div className="dr-list__meta">
+                    {item.model && <span>{item.model}</span>}
+                    {item.model && (item.rev || item.publishedAt) && (
+                      <span className="dr-list__sep">·</span>
+                    )}
+                    {item.rev && <span>{item.rev}</span>}
+                    {item.rev && item.publishedAt && (
+                      <span className="dr-list__sep">·</span>
+                    )}
+                    {item.publishedAt && <span>{item.publishedAt}</span>}
+                  </div>
+                )}
+              </div>
+              {item.fileUrl ? (
+                <a href={item.fileUrl} download className="dr-list__btn">
+                  {tRes("download")}
+                </a>
+              ) : (
+                <span className="dr-list__btn dr-list__btn--disabled">
+                  {tRes("comingSoon")}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -27,6 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 const CARDS = [
   { key: "catalogues", href: "/resources/catalogues" },
   { key: "drawings", href: "/resources/drawings" },
+  { key: "datasheets", href: "/resources/datasheets" },
   { key: "manuals", href: "/resources/manuals" },
   { key: "certifications", href: "/resources/certifications" },
 ] as const;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -21,6 +21,16 @@ const STATIC_ROUTES: StaticRoute[] = [
   { path: "contact", priority: 0.3, changeFrequency: "yearly" },
   { path: "products", priority: 0.7, changeFrequency: "monthly" },
   { path: "products/accessories", priority: 0.6, changeFrequency: "monthly" },
+  { path: "resources", priority: 0.5, changeFrequency: "monthly" },
+  { path: "resources/catalogues", priority: 0.4, changeFrequency: "monthly" },
+  { path: "resources/drawings", priority: 0.4, changeFrequency: "monthly" },
+  { path: "resources/datasheets", priority: 0.4, changeFrequency: "monthly" },
+  { path: "resources/manuals", priority: 0.4, changeFrequency: "monthly" },
+  {
+    path: "resources/certifications",
+    priority: 0.4,
+    changeFrequency: "monthly",
+  },
 ];
 
 function buildLocaleAlternates(path: string): Record<string, string> {

--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -1,9 +1,15 @@
 import { NextStudio } from "next-sanity/studio";
+import { metadata as studioMetadata, viewport } from "next-sanity/studio";
 import config from "../../../../sanity.config";
 
 export const dynamic = "force-static";
 
-export { metadata, viewport } from "next-sanity/studio";
+export const metadata = {
+  ...studioMetadata,
+  robots: { index: false, follow: false },
+};
+
+export { viewport };
 
 export default function StudioPage() {
   return <NextStudio config={config} />;

--- a/src/components/home/Contact/Contact.tsx
+++ b/src/components/home/Contact/Contact.tsx
@@ -1,14 +1,12 @@
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
-import { LT_SHELL } from "@/lib/content/shell";
-import type { HomeContent, Locale } from "@/lib/content/home";
+import type { HomeContent } from "@/lib/content/home";
 import "./Contact.css";
 
-type Props = { h: HomeContent; locale: Locale };
+type Props = { h: HomeContent };
 
-export function Contact({ h, locale }: Props) {
+export function Contact({ h }: Props) {
   const { contact } = h;
-  const email = LT_SHELL[locale].footer.contact.email;
   return (
     <section className="ho-contact">
       <div className="ho-contact__inner">
@@ -18,13 +16,12 @@ export function Contact({ h, locale }: Props) {
           <Button
             variant="primary"
             size="lg"
-            href={`mailto:${email}`}
-            plain
+            href="/contact"
             icon={<Glyph name="phone" size={14} />}
           >
             {contact.primary}
           </Button>
-          <Button variant="ghost" size="lg" href={`mailto:${email}`} plain>
+          <Button variant="ghost" size="lg" href="/contact">
             {contact.secondary}
           </Button>
         </div>

--- a/src/components/products/DownloadsList/DownloadsList.tsx
+++ b/src/components/products/DownloadsList/DownloadsList.tsx
@@ -87,6 +87,7 @@ export function DownloadsList({
                   size="sm"
                   href={it.href}
                   plain
+                  download
                   icon={<Glyph name="download" size={14} />}
                 >
                   {downloadLabel}

--- a/src/components/products/DownloadsList/DownloadsList.tsx
+++ b/src/components/products/DownloadsList/DownloadsList.tsx
@@ -7,10 +7,11 @@ import "./DownloadsList.css";
 
 export type DownloadItem = {
   label: string;
-  type: "PDF" | "DWG" | "ZIP";
+  type: "PDF" | "DWG" | "STEP" | "ZIP";
   size: string;
-  rev: string;
+  rev?: string;
   date: string;
+  href?: string;
 };
 
 type Props = {
@@ -25,6 +26,7 @@ type Props = {
 const TYPE_TONE: Record<DownloadItem["type"], string> = {
   PDF: "lt-pdp-dl__type--danger",
   DWG: "lt-pdp-dl__type--info",
+  STEP: "lt-pdp-dl__type--info",
   ZIP: "lt-pdp-dl__type--neutral",
 };
 
@@ -57,39 +59,57 @@ export function DownloadsList({
 
       <ul className="lt-pdp-dl__list" role="list">
         {items.map((it, i) => {
-          const s = state[i] || "idle";
+          const metaParts = [it.rev, it.size, it.date].filter(Boolean);
           return (
             <li
               key={`${it.label}-${i}`}
-              className={`lt-pdp-dl__row lt-pdp-dl__row--${s}`}
+              className={`lt-pdp-dl__row lt-pdp-dl__row--${state[i] || "idle"}`}
             >
               <span className={`lt-pdp-dl__type ${TYPE_TONE[it.type]}`}>
                 {it.type}
               </span>
               <div className="lt-pdp-dl__meta">
                 <div className="lt-pdp-dl__label">{it.label}</div>
-                <div className="lt-pdp-dl__sub">
-                  <span>{it.rev}</span>
-                  <span className="lt-pdp-dl__sep">·</span>
-                  <span>{it.size}</span>
-                  <span className="lt-pdp-dl__sep">·</span>
-                  <span>{it.date}</span>
-                </div>
+                {metaParts.length > 0 && (
+                  <div className="lt-pdp-dl__sub">
+                    {metaParts.map((part, idx) => (
+                      <span key={idx}>
+                        {idx > 0 && <span className="lt-pdp-dl__sep">·</span>}
+                        <span>{part}</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
-              <Button
-                variant={s === "done" ? "subtle" : "ghost"}
-                size="sm"
-                icon={
-                  <Glyph name={s === "done" ? "check" : "download"} size={14} />
-                }
-                onClick={() => start(i)}
-              >
-                {s === "loading"
-                  ? "…"
-                  : s === "done"
-                    ? doneLabel
-                    : downloadLabel}
-              </Button>
+              {it.href ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  href={it.href}
+                  plain
+                  icon={<Glyph name="download" size={14} />}
+                >
+                  {downloadLabel}
+                </Button>
+              ) : (
+                <Button
+                  variant={state[i] === "done" ? "subtle" : "ghost"}
+                  size="sm"
+                  icon={
+                    <Glyph
+                      name={state[i] === "done" ? "check" : "download"}
+                      size={14}
+                    />
+                  }
+                  onClick={() => start(i)}
+                >
+                  {state[i] === "loading"
+                    ? "…"
+                    : state[i] === "done"
+                      ? doneLabel
+                      : downloadLabel}
+                </Button>
+              )}
             </li>
           );
         })}

--- a/src/components/products/RequestDocs/RequestDocs.css
+++ b/src/components/products/RequestDocs/RequestDocs.css
@@ -1,0 +1,9 @@
+.lt-pdp-rd {
+  margin-bottom: 64px;
+  scroll-margin-top: 72px;
+}
+.lt-pdp-rd__cta {
+  display: flex;
+  justify-content: flex-start;
+  padding: 8px 16px 0;
+}

--- a/src/components/products/RequestDocs/RequestDocs.tsx
+++ b/src/components/products/RequestDocs/RequestDocs.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/Button";
+import { Glyph } from "@/components/ui/Glyph";
+import "./RequestDocs.css";
+
+type Props = {
+  kicker: string;
+  heading: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+};
+
+export function RequestDocs({
+  kicker,
+  heading,
+  body,
+  ctaLabel,
+  ctaHref,
+}: Props) {
+  return (
+    <section id="downloads" className="lt-pdp-rd">
+      <header className="lt-pdp-section-hd">
+        <div>
+          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
+          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
+          <p className="lt-pdp-section-hd__sub">{body}</p>
+        </div>
+      </header>
+      <div className="lt-pdp-rd__cta">
+        <Button
+          variant="primary"
+          size="lg"
+          href={ctaHref}
+          trailingGlyph={<Glyph name="arrow-right" size={14} />}
+        >
+          {ctaLabel}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/products/RequestDocs/index.ts
+++ b/src/components/products/RequestDocs/index.ts
@@ -1,0 +1,1 @@
+export { RequestDocs } from "./RequestDocs";

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -20,7 +20,7 @@ type Base = {
 // `plain: true` renders a bare <a> instead of the locale-aware <Link>.
 // Use for non-route URLs: mailto:, tel:, static files, external origins.
 type AsLocalLink = Base & { href: LinkHref; plain?: false };
-type AsPlainLink = Base & { href: string; plain: true };
+type AsPlainLink = Base & { href: string; plain: true; download?: boolean };
 type AsButton = Base & {
   onClick?: () => void;
   type?: "button" | "submit";
@@ -66,7 +66,7 @@ export function Button(props: Props) {
   if (isLink(props)) {
     if (props.plain) {
       return (
-        <a className={cls} href={props.href}>
+        <a className={cls} href={props.href} download={props.download}>
           {inner}
         </a>
       );

--- a/src/lib/contact/email.ts
+++ b/src/lib/contact/email.ts
@@ -7,6 +7,15 @@ const TO = "info@linetech.co.kr";
 const FROM =
   process.env.RESEND_FROM ?? "Line Tech Contact <onboarding@resend.dev>";
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function buildSubject(data: ContactFormPayload): string {
   const parts = [data.inquiryType];
   if (data.typeDetail) parts.push(`(${data.typeDetail})`);
@@ -18,14 +27,15 @@ function buildHtml(data: ContactFormPayload): string {
   const row = (label: string, value: string) =>
     `<tr><td style="padding:6px 12px 6px 0;font-weight:600;white-space:nowrap;vertical-align:top">${label}</td><td style="padding:6px 0">${value}</td></tr>`;
 
+  const safeEmail = escapeHtml(data.email);
   const rows = [
-    row("Inquiry type", data.inquiryType),
-    ...(data.typeDetail ? [row("Detail", data.typeDetail)] : []),
-    row("Name", data.name),
-    row("Email", `<a href="mailto:${data.email}">${data.email}</a>`),
-    ...(data.company ? [row("Company", data.company)] : []),
-    ...(data.phone ? [row("Phone", data.phone)] : []),
-    ...(data.subject ? [row("Subject", data.subject)] : []),
+    row("Inquiry type", escapeHtml(data.inquiryType)),
+    ...(data.typeDetail ? [row("Detail", escapeHtml(data.typeDetail))] : []),
+    row("Name", escapeHtml(data.name)),
+    row("Email", `<a href="mailto:${safeEmail}">${safeEmail}</a>`),
+    ...(data.company ? [row("Company", escapeHtml(data.company))] : []),
+    ...(data.phone ? [row("Phone", escapeHtml(data.phone))] : []),
+    ...(data.subject ? [row("Subject", escapeHtml(data.subject))] : []),
   ].join("");
 
   return `
@@ -34,7 +44,7 @@ function buildHtml(data: ContactFormPayload): string {
   <table style="border-collapse:collapse;width:100%">${rows}</table>
   <hr style="margin:24px 0">
   <h3 style="margin-bottom:8px">Message</h3>
-  <p style="white-space:pre-wrap;margin:0">${data.message}</p>
+  <p style="white-space:pre-wrap;margin:0">${escapeHtml(data.message)}</p>
 </div>`;
 }
 

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -262,6 +262,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
               desc: "AutoCAD (.dwg · .stp)",
             },
             {
+              href: "/resources/datasheets",
+              label: "데이터시트",
+              desc: "모델별 사양서",
+            },
+            {
               href: "/resources/manuals",
               label: "매뉴얼",
               desc: "모델별 사용 설명서",
@@ -491,6 +496,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
               desc: "AutoCAD (.dwg · .stp)",
             },
             {
+              href: "/resources/datasheets",
+              label: "Datasheets",
+              desc: "Per-model specification sheets",
+            },
+            {
               href: "/resources/manuals",
               label: "Manuals",
               desc: "Per-model user guides",
@@ -708,6 +718,11 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
               href: "/resources/drawings",
               label: "CAD 图纸",
               desc: "AutoCAD (.dwg · .stp)",
+            },
+            {
+              href: "/resources/datasheets",
+              label: "数据手册",
+              desc: "各型号规格说明书",
             },
             {
               href: "/resources/manuals",

--- a/src/lib/fixtures/products.ts
+++ b/src/lib/fixtures/products.ts
@@ -1,7 +1,14 @@
 import type { Product } from "../types/product";
 import data from "./products.json";
 
-export const ALL_PRODUCTS: Product[] = data as Product[];
+export const ALL_PRODUCTS: Product[] = (data as unknown as Product[]).map(
+  (p) => ({
+    ...p,
+    datasheets: p.datasheets ?? [],
+    manuals: p.manuals ?? [],
+    drawings: p.drawings ?? [],
+  }),
+);
 
 const bySlug = new Map(ALL_PRODUCTS.map((p) => [p.slug.current, p]));
 const byModel = new Map(ALL_PRODUCTS.map((p) => [p.model, p]));

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,27 @@
+import type { Locale } from "@/lib/content/home";
+
+export function formatBytes(bytes: number | null | undefined): string {
+  if (!bytes || bytes <= 0) return "—";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+  );
+  const value = bytes / Math.pow(1024, i);
+  const digits = i === 0 || value >= 100 ? 0 : 1;
+  return `${value.toFixed(digits)} ${units[i]}`;
+}
+
+export function formatDate(
+  iso: string | null | undefined,
+  locale: Locale,
+): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(d);
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -17,7 +17,7 @@ export function formatDate(
   locale: Locale,
 ): string {
   if (!iso) return "";
-  const d = new Date(iso);
+  const d = new Date(iso.includes("T") ? iso : iso + "T00:00:00");
   if (Number.isNaN(d.getTime())) return "";
   return new Intl.DateTimeFormat(locale, {
     year: "numeric",

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -134,6 +134,45 @@ export const SanityProductSchema = z.object({
     .nullable()
     .optional(),
   dimensionDrawing: SanityImageSchema.nullable().optional(),
+  datasheets: z
+    .array(
+      z.object({
+        _id: z.string(),
+        title: z.string(),
+        rev: z.string().nullable().optional(),
+        publishedAt: z.string().nullable().optional(),
+        fileUrl: z.string().nullable().optional(),
+        size: z.number().nullable().optional(),
+        updatedAt: z.string().nullable().optional(),
+      }),
+    )
+    .default([]),
+  manuals: z
+    .array(
+      z.object({
+        _id: z.string(),
+        title: z.string(),
+        rev: z.string().nullable().optional(),
+        publishedAt: z.string().nullable().optional(),
+        fileUrl: z.string().nullable().optional(),
+        size: z.number().nullable().optional(),
+        updatedAt: z.string().nullable().optional(),
+      }),
+    )
+    .default([]),
+  drawings: z
+    .array(
+      z.object({
+        _id: z.string(),
+        title: z.string(),
+        dwgUrl: z.string().nullable().optional(),
+        dwgSize: z.number().nullable().optional(),
+        stpUrl: z.string().nullable().optional(),
+        stpSize: z.number().nullable().optional(),
+        updatedAt: z.string().nullable().optional(),
+      }),
+    )
+    .default([]),
 });
 
 export type Product = z.infer<typeof SanityProductSchema>;

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -34,7 +34,37 @@ const PRODUCT_DETAIL_PROJECTION = `
   ${PRODUCT_BASE_PROJECTION},
   digitalCommunication,
   images,
-  dimensionDrawing
+  dimensionDrawing,
+  "datasheets": *[_type == "datasheet" && lower(model) == lower(^.model)]
+    | order(coalesce(publishedAt, _updatedAt) desc) {
+      _id,
+      title,
+      rev,
+      publishedAt,
+      "fileUrl": file.asset->url,
+      "size": file.asset->size,
+      "updatedAt": _updatedAt
+    },
+  "manuals": *[_type == "manual" && lower(model) == lower(^.model)]
+    | order(coalesce(publishedAt, _updatedAt) desc) {
+      _id,
+      title,
+      rev,
+      publishedAt,
+      "fileUrl": file.asset->url,
+      "size": file.asset->size,
+      "updatedAt": _updatedAt
+    },
+  "drawings": *[_type == "drawing" && lower(model) == lower(^.model)]
+    | order(_updatedAt desc) {
+      _id,
+      title,
+      "dwgUrl": dwgFile.asset->url,
+      "dwgSize": dwgFile.asset->size,
+      "stpUrl": stpFile.asset->url,
+      "stpSize": stpFile.asset->size,
+      "updatedAt": _updatedAt
+    }
 `;
 
 export const productBySlugQuery = defineQuery(`
@@ -131,6 +161,22 @@ export const allManualsQuery = defineQuery(`
   }
 `);
 
+export const allDatasheetsQuery = defineQuery(`
+  *[_type == "datasheet"]
+  | order(
+    select(series == "analogue" => 0, series == "digital" => 1, 2),
+    model asc
+  ) {
+    _id,
+    title,
+    model,
+    series,
+    rev,
+    publishedAt,
+    "fileUrl": file.asset->url
+  }
+`);
+
 export const allDrawingsQuery = defineQuery(`
   *[_type == "drawing"]
   | order(
@@ -149,6 +195,7 @@ export const allDrawingsQuery = defineQuery(`
 export const resourceCountsQuery = defineQuery(`
   {
     "catalogues": count(*[_type == "catalogue"]),
+    "datasheets": count(*[_type == "datasheet"]),
     "manuals": count(*[_type == "manual"]),
     "drawings": count(*[_type == "drawing"]),
     "certifications": count(*[_type == "certification"])

--- a/src/sanity/writeClient.ts
+++ b/src/sanity/writeClient.ts
@@ -1,6 +1,12 @@
 import { createClient } from "@sanity/client";
 import { apiVersion, dataset, projectId } from "./env";
 
+const writeToken = (() => {
+  const v = process.env.SANITY_WRITE_TOKEN;
+  if (!v) throw new Error("Missing env var: SANITY_WRITE_TOKEN");
+  return v;
+})();
+
 // Separate write-capable client — uses the server-only SANITY_WRITE_TOKEN.
 // Never import this in client components.
 export const sanityWriteClient = createClient({
@@ -8,5 +14,5 @@ export const sanityWriteClient = createClient({
   dataset,
   apiVersion,
   useCdn: false,
-  token: process.env.SANITY_WRITE_TOKEN,
+  token: writeToken,
 });

--- a/src/test/fixtures/products.ts
+++ b/src/test/fixtures/products.ts
@@ -27,6 +27,9 @@ export const productFixture: Product = {
     },
     controlRange: { display: "2–100% F.S.", min: 2, max: 100, unit: "% F.S." },
   },
+  datasheets: [],
+  manuals: [],
+  drawings: [],
 };
 
 export function makeProduct(overrides: Partial<Product> = {}): Product {


### PR DESCRIPTION
Closes #130.

## Summary

Four launch blockers from the pre-deploy repo review, packaged as one PR. The product-downloads fix grew when we agreed to wire real Sanity files (not just a stopgap CTA), so this also adds a `datasheet` doc type and a new `/resources/datasheets` Data Room page.

## What changes

**Homepage** — `Contact` section primary + secondary buttons now route to `/[locale]/contact` instead of opening a blank `mailto:` draft. Locale-aware via the existing `Button` + next-intl `Link` integration.

**Product detail downloads** — replaced placeholder rows with a Sanity-backed pipeline.
- New `datasheet` document type (mirrors the existing `manual` schema: title, model, series, rev, file, publishedAt).
- `productBySlugQuery` / `productByModelQuery` now project matching `datasheet`, `manual`, and `drawing` docs by case-insensitive `model` match — same convention the rest of the codebase already uses.
- The existing `DownloadsList` got an optional `href`; when present it renders an `<a download>` rather than the fake state machine. STEP file type added to the union.
- When at least one file is uploaded for a product, the list shows real rows with size + date + revision (locale-formatted via new `src/lib/format.ts`).
- When none exist yet, a new `RequestDocs` card renders instead — single CTA → `/contact?product=<MODEL>` (the form already prefills `inquiryType: "sales"` and the model field on arrival).

**Data Room** — `/resources/datasheets` page mirrors `/resources/manuals` structurally. New `allDatasheetsQuery`, `resourceCounts` extended, hub card, nav dropdown entry in all three locales, sitemap. The sitemap fix also picks up the existing `/resources/*` routes that weren't being emitted before.

**Email template** — added a 5-line `escapeHtml()` helper and ran every interpolated user field (`name`, `email`, `company`, `phone`, `subject`, `message`, `inquiryType`, `typeDetail`) through it. Closes the stored-XSS vector in the recipient inbox.

**Studio hardening**
- `/studio/[[...tool]]/page.tsx` exports `metadata.robots = { index: false, follow: false }` (merged with the upstream `next-sanity/studio` metadata) — belt-and-suspenders alongside `robots.ts`.
- `src/sanity/writeClient.ts` asserts `SANITY_WRITE_TOKEN` at module top-level. If the env var is missing, the first contact submission throws a clear `Missing env var` error rather than a silent Sanity 401. (Next.js loads server modules lazily, so this fires on first import — adding `instrumentation.ts` for true boot-time validation was over-engineering for the win.)

## i18n

New keys reviewed by the user before commit:
- `pdp.requestDocs.{kicker, heading, body, cta}` (new card on PDP)
- `pdp.downloads.{datasheetFor, manualFor}` (replace `placeholders.*`)
- `resources.datasheets.{title, intro}` (Data Room subpage)
- `resources.cards.datasheets.{title, desc, count}` (hub card)
- Datasheets nav-dropdown entries for ko/en/zh

`pnpm i18n:check` reports 156 keys × 3 locales, parity OK.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (1 pre-existing unrelated warning)
- [x] `pnpm test:run` — 38 / 38 passing
- [x] `pnpm i18n:check` — parity OK
- [x] `pnpm build` — all routes generate, including new `/[locale]/resources/datasheets` × 3
- [ ] Manual: homepage CTAs → `/contact` (no mailto)
- [ ] Manual: product detail with no Sanity files → request-docs CTA, click lands on `/contact?product=<model>` with sales type + model prefilled
- [ ] Manual: upload a Datasheet doc with `model: M3030VA` in Studio → reload `/ko/products/analogue/m3030va` → real download row appears, CTA hides
- [ ] Manual: `/studio` source — check `<meta name="robots" content="noindex,nofollow">`
- [ ] Manual: temporarily unset `SANITY_WRITE_TOKEN`, restart, submit form → server logs `Missing env var: SANITY_WRITE_TOKEN`
- [ ] Manual: submit form with `<img src=x onerror=alert(1)>Hello` in message — recipient inbox shows escaped text, no rendered tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)