### PR TITLE
fix(ux): empty states, privacy link, SLA hint, CJK dates, carousel swipe (#132)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -251,7 +251,7 @@
       "captcha": "Verification failed. Please complete the challenge again.",
       "server": "We could not send your message. Please email us directly."
     },
-    "success": "Thanks — your message has been sent. We will reply within one business day.",
+    "success": "Thanks — your message has been sent. We typically respond within 1 business day.",
     "submitting": "Sending…",
     "slaHint": "We typically respond within 1 business day."
   }

--- a/messages/en.json
+++ b/messages/en.json
@@ -18,7 +18,8 @@
   },
   "footer": {
     "tel": "TEL",
-    "fax": "FAX"
+    "fax": "FAX",
+    "privacy": "Privacy Policy"
   },
   "errors": {
     "notFound": {
@@ -236,7 +237,9 @@
       "validThrough": "Valid through",
       "ongoing": "Ongoing"
     },
-    "empty": "No files available yet. Check back soon."
+    "empty": "No files available yet. Check back soon.",
+    "emptyStateCta": "Contact us",
+    "requestFile": "Request file"
   },
   "skipLink": {
     "main": "Skip to main content"
@@ -249,6 +252,7 @@
       "server": "We could not send your message. Please email us directly."
     },
     "success": "Thanks — your message has been sent. We will reply within one business day.",
-    "submitting": "Sending…"
+    "submitting": "Sending…",
+    "slaHint": "We typically respond within 1 business day."
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -18,7 +18,8 @@
   },
   "footer": {
     "tel": "TEL",
-    "fax": "FAX"
+    "fax": "FAX",
+    "privacy": "개인정보처리방침"
   },
   "errors": {
     "notFound": {
@@ -236,7 +237,9 @@
       "validThrough": "유효 기간",
       "ongoing": "계속 유효"
     },
-    "empty": "아직 등록된 파일이 없습니다. 곧 업데이트될 예정입니다."
+    "empty": "아직 등록된 파일이 없습니다. 곧 업데이트될 예정입니다.",
+    "emptyStateCta": "문의하기",
+    "requestFile": "파일 요청"
   },
   "skipLink": {
     "main": "본문으로 건너뛰기"
@@ -249,6 +252,7 @@
       "server": "메시지를 보낼 수 없습니다. 이메일로 직접 연락해 주세요."
     },
     "success": "메시지가 전송되었습니다. 영업일 기준 1일 이내 답변드리겠습니다.",
-    "submitting": "전송 중…"
+    "submitting": "전송 중…",
+    "slaHint": "영업일 기준 1일 이내에 답변드립니다."
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -18,7 +18,8 @@
   },
   "footer": {
     "tel": "TEL",
-    "fax": "FAX"
+    "fax": "FAX",
+    "privacy": "隐私政策"
   },
   "errors": {
     "notFound": {
@@ -236,7 +237,9 @@
       "validThrough": "有效期至",
       "ongoing": "持续有效"
     },
-    "empty": "暂无可用文件，敬请期待。"
+    "empty": "暂无可用文件，敬请期待。",
+    "emptyStateCta": "联系我们",
+    "requestFile": "申请文件"
   },
   "skipLink": {
     "main": "跳到主要内容"
@@ -249,6 +252,7 @@
       "server": "无法发送您的消息。请直接通过邮件联系我们。"
     },
     "success": "感谢您的留言，我们将在 1 个工作日内回复。",
-    "submitting": "发送中…"
+    "submitting": "发送中…",
+    "slaHint": "我们通常在1个工作日内回复。"
   }
 }

--- a/src/app/[locale]/company/page.tsx
+++ b/src/app/[locale]/company/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/content/company";
 import type { Locale } from "@/lib/content/home";
 import { buildCompanyMetadata } from "@/lib/seo";
+import { formatYearMonth } from "@/lib/i18n/dates";
 
 function MapPinIcon() {
   return (
@@ -58,7 +59,7 @@ export default async function CompanyPage({ params }: Props) {
   return (
     <CompanyShell locale={locale} breadcrumbs={breadcrumbs}>
       <Greeting c={c} />
-      <History c={c} />
+      <History c={c} locale={locale} />
       <Certifications c={c} />
       <Location c={c} />
     </CompanyShell>
@@ -102,7 +103,7 @@ function Greeting({ c }: { c: CompanyContent }) {
   );
 }
 
-function History({ c }: { c: CompanyContent }) {
+function History({ c, locale }: { c: CompanyContent; locale: string }) {
   return (
     <section id="history" className="co-section">
       <header className="co-sechd">
@@ -125,7 +126,7 @@ function History({ c }: { c: CompanyContent }) {
                 className="co-timeline__date"
                 dateTime={row.date.replace(".", "-")}
               >
-                {row.date}
+                {formatYearMonth(row.date, locale)}
               </time>
               <span className="co-timeline__event">{row.event}</span>
             </li>

--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -240,6 +240,7 @@ export function ContactForm({ form, privacyNotice, defaults }: Props) {
           <p className="ct-form__help">{form.submitDisabledHelp}</p>
         )}
       </div>
+      <p className="ct-form__sla">{t("slaHint")}</p>
       <p className="ct-form__privacy">{privacyNotice}</p>
     </form>
   );

--- a/src/app/[locale]/contact/contact-page.css
+++ b/src/app/[locale]/contact/contact-page.css
@@ -198,6 +198,13 @@
   line-height: 1.45;
   flex: 1 1 240px;
 }
+.ct-form__sla {
+  margin: 10px 0 0;
+  font-size: var(--lt-fs-xs);
+  line-height: 1.45;
+  color: var(--pd-muted);
+}
+
 .ct-form__privacy {
   margin: 14px 0 0;
   padding-top: 14px;

--- a/src/app/[locale]/legal/privacy/page.tsx
+++ b/src/app/[locale]/legal/privacy/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import { setRequestLocale } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    robots: { index: false, follow: false },
+  };
+}
+
+const CONTENT = {
+  ko: {
+    title: "개인정보처리방침",
+    body: "개인정보처리방침은 준비 중입니다.",
+  },
+  en: {
+    title: "Privacy Policy",
+    body: "Our privacy policy is being prepared.",
+  },
+  zh: {
+    title: "隐私政策",
+    body: "隐私政策正在准备中。",
+  },
+} as const;
+
+export default async function PrivacyPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const { title, body } = CONTENT[locale as keyof typeof CONTENT] ?? CONTENT.en;
+
+  return (
+    <main className="lt-wrap" style={{ paddingTop: 48, paddingBottom: 64 }}>
+      <h1 style={{ marginBottom: 16 }}>{title}</h1>
+      <p style={{ color: "var(--pd-muted)" }}>{body}</p>
+    </main>
+  );
+}

--- a/src/app/[locale]/products/RotatingFeatured.tsx
+++ b/src/app/[locale]/products/RotatingFeatured.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { Link } from "@/i18n/navigation";
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
@@ -43,6 +43,7 @@ export function RotatingFeatured({
   const [active, setActive] = useState(0);
   const [mouseInside, setMouseInside] = useState(false);
   const [focusInside, setFocusInside] = useState(false);
+  const touchStartX = useRef<number | null>(null);
   const reducedMotion = useSyncExternalStore(
     subscribeReducedMotion,
     getReducedMotionSnapshot,
@@ -68,6 +69,20 @@ export function RotatingFeatured({
       onMouseLeave={() => setMouseInside(false)}
       onFocusCapture={() => setFocusInside(true)}
       onBlurCapture={() => setFocusInside(false)}
+      onTouchStart={(e) => {
+        touchStartX.current = e.touches[0].clientX;
+      }}
+      onTouchEnd={(e) => {
+        if (touchStartX.current === null) return;
+        const delta = e.changedTouches[0].clientX - touchStartX.current;
+        touchStartX.current = null;
+        if (Math.abs(delta) < 50) return;
+        setActive((prev) =>
+          delta < 0
+            ? (prev + 1) % slides.length
+            : (prev - 1 + slides.length) % slides.length,
+        );
+      }}
     >
       <div className="lt-products-side__rot-stack">
         {slides.map((s, i) => {

--- a/src/app/[locale]/products/products-list.css
+++ b/src/app/[locale]/products/products-list.css
@@ -409,7 +409,7 @@
 .lt-products-side__rot-dot::after {
   content: "";
   position: absolute;
-  inset: -18px;
+  inset: -19px;
 }
 
 .lt-products-side__rot-dot:hover {

--- a/src/app/[locale]/products/products-list.css
+++ b/src/app/[locale]/products/products-list.css
@@ -399,9 +399,17 @@
   border: none;
   padding: 0;
   cursor: pointer;
+  position: relative;
   transition:
     background 0.15s ease,
     transform 0.15s ease;
+}
+
+/* Invisible expanded tap target (WCAG 2.5.5 44×44px minimum) */
+.lt-products-side__rot-dot::after {
+  content: "";
+  position: absolute;
+  inset: -18px;
 }
 
 .lt-products-side__rot-dot:hover {

--- a/src/app/[locale]/resources/catalogues/page.tsx
+++ b/src/app/[locale]/resources/catalogues/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { formatISODate } from "@/lib/i18n/dates";
 import { sanityClient } from "@/sanity/client";
 import { allCataloguesQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
@@ -58,7 +61,11 @@ export default async function CataloguesPage({ params }: Props) {
       </header>
 
       {catalogues.length === 0 ? (
-        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+        <EmptyState
+          message={tRes("empty")}
+          ctaHref="/contact?topic=request"
+          ctaLabel={tRes("emptyStateCta")}
+        />
       ) : (
         <ul className="dr-list" role="list">
           {catalogues.map((item) => (
@@ -78,7 +85,9 @@ export default async function CataloguesPage({ params }: Props) {
                     {item.series && item.publishedAt && (
                       <span className="dr-list__sep">·</span>
                     )}
-                    {item.publishedAt && <span>{item.publishedAt}</span>}
+                    {item.publishedAt && (
+                      <span>{formatISODate(item.publishedAt, locale)}</span>
+                    )}
                   </div>
                 )}
               </div>
@@ -87,9 +96,12 @@ export default async function CataloguesPage({ params }: Props) {
                   {tRes("download")}
                 </a>
               ) : (
-                <span className="dr-list__btn dr-list__btn--disabled">
-                  {tRes("comingSoon")}
-                </span>
+                <Link
+                  href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                  className="dr-list__btn dr-list__btn--request"
+                >
+                  {tRes("requestFile")}
+                </Link>
               )}
             </li>
           ))}

--- a/src/app/[locale]/resources/certifications/page.tsx
+++ b/src/app/[locale]/resources/certifications/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { EmptyState } from "@/components/shared/EmptyState";
 import { sanityClient } from "@/sanity/client";
 import { allCertificationsQuery } from "@/sanity/queries";
 import { routing, type Locale } from "@/i18n/routing";
@@ -65,7 +67,11 @@ export default async function CertificationsPage({ params }: Props) {
       </header>
 
       {certs.length === 0 ? (
-        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+        <EmptyState
+          message={tRes("empty")}
+          ctaHref="/contact?topic=request"
+          ctaLabel={tRes("emptyStateCta")}
+        />
       ) : (
         <ul className="dr-certs" role="list">
           {certs.map((cert) => {
@@ -102,9 +108,12 @@ export default async function CertificationsPage({ params }: Props) {
                       {tRes("download")}
                     </a>
                   ) : (
-                    <span className="dr-list__btn dr-list__btn--disabled">
-                      {tRes("comingSoon")}
-                    </span>
+                    <Link
+                      href={`/contact?topic=request&file=${encodeURIComponent(cert.name)}`}
+                      className="dr-list__btn dr-list__btn--request"
+                    >
+                      {tRes("requestFile")}
+                    </Link>
                   )}
                 </div>
               </li>

--- a/src/app/[locale]/resources/drawings/page.tsx
+++ b/src/app/[locale]/resources/drawings/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { EmptyState } from "@/components/shared/EmptyState";
 import { sanityClient } from "@/sanity/client";
 import { allDrawingsQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
@@ -59,7 +61,11 @@ export default async function DrawingsPage({ params }: Props) {
       </header>
 
       {drawings.length === 0 ? (
-        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+        <EmptyState
+          message={tRes("empty")}
+          ctaHref="/contact?topic=request"
+          ctaLabel={tRes("emptyStateCta")}
+        />
       ) : (
         <table className="dr-drawings">
           <thead>
@@ -116,9 +122,12 @@ export default async function DrawingsPage({ params }: Props) {
                       </a>
                     )}
                     {!item.dwgUrl && !item.stpUrl && (
-                      <span className="dr-list__btn dr-list__btn--disabled">
-                        {tRes("comingSoon")}
-                      </span>
+                      <Link
+                        href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                        className="dr-list__btn dr-list__btn--request"
+                      >
+                        {tRes("requestFile")}
+                      </Link>
                     )}
                   </div>
                 </td>

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -146,7 +146,9 @@ export default async function ManualsPage({ params }: Props) {
                     {item.rev && item.publishedAt && (
                       <span className="dr-list__sep">·</span>
                     )}
-                    {item.publishedAt && <span>{item.publishedAt}</span>}
+                    {item.publishedAt && (
+                      <span>{formatISODate(item.publishedAt, locale)}</span>
+                    )}
                   </div>
                 )}
               </div>
@@ -155,9 +157,12 @@ export default async function ManualsPage({ params }: Props) {
                   {tRes("download")}
                 </a>
               ) : (
-                <span className="dr-list__btn dr-list__btn--disabled">
-                  {tRes("comingSoon")}
-                </span>
+                <Link
+                  href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                  className="dr-list__btn dr-list__btn--request"
+                >
+                  {tRes("requestFile")}
+                </Link>
               )}
             </li>
           ))}

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -1,7 +1,10 @@
 import { Fragment } from "react";
 import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { formatISODate } from "@/lib/i18n/dates";
 import { sanityClient } from "@/sanity/client";
 import { allManualsQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
@@ -75,7 +78,11 @@ export default async function ManualsPage({ params }: Props) {
       </header>
 
       {manuals.length === 0 ? (
-        <p style={{ color: "var(--pd-muted)" }}>{tRes("empty")}</p>
+        <EmptyState
+          message={tRes("empty")}
+          ctaHref="/contact?topic=request"
+          ctaLabel={tRes("emptyStateCta")}
+        />
       ) : (
         <ul className="dr-list" role="list">
           {SERIES_ORDER.filter((s) => grouped[s]).map((s) => (
@@ -102,7 +109,9 @@ export default async function ManualsPage({ params }: Props) {
                         {item.rev && item.publishedAt && (
                           <span className="dr-list__sep">·</span>
                         )}
-                        {item.publishedAt && <span>{item.publishedAt}</span>}
+                        {item.publishedAt && (
+                          <span>{formatISODate(item.publishedAt, locale)}</span>
+                        )}
                       </div>
                     )}
                   </div>
@@ -111,9 +120,12 @@ export default async function ManualsPage({ params }: Props) {
                       {tRes("download")}
                     </a>
                   ) : (
-                    <span className="dr-list__btn dr-list__btn--disabled">
-                      {tRes("comingSoon")}
-                    </span>
+                    <Link
+                      href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                      className="dr-list__btn dr-list__btn--request"
+                    >
+                      {tRes("requestFile")}
+                    </Link>
                   )}
                 </li>
               ))}

--- a/src/app/[locale]/resources/resources-subpage.css
+++ b/src/app/[locale]/resources/resources-subpage.css
@@ -151,6 +151,16 @@
   opacity: 0.6;
 }
 
+.dr-list__btn--request {
+  border-color: var(--pd-border);
+  color: var(--pd-primary);
+}
+
+.dr-list__btn--request:hover {
+  border-color: var(--pd-primary);
+  background: var(--pd-surface-2);
+}
+
 /* ── Drawings table ───────────────────────────────────────────────────── */
 
 .dr-drawings {

--- a/src/app/[locale]/resources/resources-subpage.css
+++ b/src/app/[locale]/resources/resources-subpage.css
@@ -144,13 +144,6 @@
   background: var(--pd-surface-2);
 }
 
-.dr-list__btn--disabled {
-  color: var(--pd-muted);
-  cursor: default;
-  pointer-events: none;
-  opacity: 0.6;
-}
-
 .dr-list__btn--request {
   border-color: var(--pd-border);
   color: var(--pd-primary);

--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -86,6 +86,17 @@
   color: var(--pd-fg-strong);
 }
 
+.pd-foot__addr-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  transition: color 120ms ease;
+}
+
+.pd-foot__addr-link:hover {
+  color: var(--pd-primary);
+}
+
 .pd-foot__base {
   border-top: 1px solid var(--pd-border);
   max-width: 1400px;
@@ -95,6 +106,16 @@
   align-items: baseline;
   gap: 18px;
   font-size: var(--lt-fs-xs);
+}
+
+.pd-foot__privacy-link {
+  color: var(--pd-muted);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.pd-foot__privacy-link:hover {
+  color: var(--pd-primary);
 }
 
 @media (max-width: 640px) {

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -27,7 +27,18 @@ export async function Footer({ locale }: Props) {
 
         <div className="pd-foot__col">
           <h2 className="pd-foot__heading">{contact.heading}</h2>
-          <address className="pd-foot__addr">{contact.address}</address>
+          <a
+            href={
+              locale === "ko"
+                ? "https://map.naver.com/search/806%20대덕대로%20유성구%20대전"
+                : "https://www.google.com/maps/search/806+Daedeok-daero,+Yuseong-gu,+Daejeon"
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+            className="pd-foot__addr-link"
+          >
+            <address className="pd-foot__addr">{contact.address}</address>
+          </a>
           <ul className="pd-foot__list">
             <li>
               <span className="pd-foot__label">{t("tel")}</span>
@@ -81,6 +92,9 @@ export async function Footer({ locale }: Props) {
 
       <div className="pd-foot__base">
         <span>{rights}</span>
+        <Link href="/legal/privacy" className="pd-foot__privacy-link">
+          {t("privacy")}
+        </Link>
       </div>
     </footer>
   );

--- a/src/components/layout/Header/HeaderShell.tsx
+++ b/src/components/layout/Header/HeaderShell.tsx
@@ -186,7 +186,17 @@ export function HeaderShell({
     <SearchStateCtx.Provider value={searchCtx}>
       <HeaderNavProvider value={navCtx}>
         <MobileNavProvider value={mobileNavCtx}>
-          <header className={cls}>
+          <header
+            className={cls}
+            onBlur={(e) => {
+              if (
+                openId &&
+                !e.currentTarget.contains(e.relatedTarget as Node)
+              ) {
+                setOpenId(null);
+              }
+            }}
+          >
             {children}
             <SearchPanel
               content={search}

--- a/src/components/layout/Header/HeaderShell.tsx
+++ b/src/components/layout/Header/HeaderShell.tsx
@@ -189,11 +189,8 @@ export function HeaderShell({
           <header
             className={cls}
             onBlur={(e) => {
-              if (
-                openId &&
-                !e.currentTarget.contains(e.relatedTarget as Node)
-              ) {
-                setOpenId(null);
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                navCtx.setOpenId(null);
               }
             }}
           >

--- a/src/components/products/ProductStack/ProductStack.css
+++ b/src/components/products/ProductStack/ProductStack.css
@@ -73,16 +73,6 @@
   text-align: left;
 }
 
-.lt-prod-stack__empty {
-  margin: 16px 0;
-  padding: 32px;
-  border: 1px dashed var(--pd-border);
-  border-radius: var(--pd-r-md);
-  text-align: center;
-  color: var(--pd-muted);
-  font-size: var(--lt-fs-sm);
-}
-
 :lang(ko) .lt-prod-stack__kicker,
 :lang(zh) .lt-prod-stack__kicker,
 :lang(ko) .lt-prod-stack__head-cell,

--- a/src/components/products/ProductStack/ProductStack.tsx
+++ b/src/components/products/ProductStack/ProductStack.tsx
@@ -3,6 +3,7 @@ import type { Product } from "@/lib/types/product";
 import type { CategorySlug } from "@/lib/categories";
 import type { Locale } from "@/i18n/routing";
 import { urlFor } from "@/sanity/imageUrl";
+import { EmptyState } from "@/components/shared/EmptyState";
 import "./ProductStack.css";
 
 type Props = {
@@ -42,7 +43,7 @@ export function ProductStack({
       </header>
 
       {products.length === 0 ? (
-        <p className="lt-prod-stack__empty">{emptyLabel}</p>
+        <EmptyState message={emptyLabel} />
       ) : (
         <table className="lt-prod-stack__table">
           <caption className="lt-prod-stack__sr-caption">{title}</caption>

--- a/src/components/shared/EmptyState/EmptyState.css
+++ b/src/components/shared/EmptyState/EmptyState.css
@@ -1,0 +1,28 @@
+.lt-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 24px 0;
+}
+
+.lt-empty-state__msg {
+  margin: 0;
+  color: var(--pd-muted);
+  font-size: var(--lt-fs-sm);
+  line-height: 1.5;
+}
+
+.lt-empty-state__cta {
+  font-size: var(--lt-fs-sm);
+  font-weight: 500;
+  color: var(--pd-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgba(24, 86, 134, 0.35);
+  transition: text-decoration-color 120ms ease;
+}
+
+.lt-empty-state__cta:hover {
+  text-decoration-color: var(--pd-primary);
+}

--- a/src/components/shared/EmptyState/EmptyState.tsx
+++ b/src/components/shared/EmptyState/EmptyState.tsx
@@ -1,0 +1,21 @@
+import { Link } from "@/i18n/navigation";
+import "./EmptyState.css";
+
+type Props = {
+  message: string;
+  ctaHref?: string;
+  ctaLabel?: string;
+};
+
+export function EmptyState({ message, ctaHref, ctaLabel }: Props) {
+  return (
+    <div className="lt-empty-state">
+      <p className="lt-empty-state__msg">{message}</p>
+      {ctaHref && ctaLabel && (
+        <Link href={ctaHref} className="lt-empty-state__cta">
+          {ctaLabel}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/EmptyState/index.ts
+++ b/src/components/shared/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export { EmptyState } from "./EmptyState";

--- a/src/lib/i18n/dates.ts
+++ b/src/lib/i18n/dates.ts
@@ -1,0 +1,20 @@
+export function formatYearMonth(value: string, locale: string): string {
+  const [year, month] = value.split(".");
+  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1);
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  }).format(date);
+}
+
+export function formatISODate(
+  value: string,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  },
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(new Date(value));
+}


### PR DESCRIPTION
## Summary

- **Empty states**: All 4 resource pages + ProductStack now use a shared `EmptyState` component with an optional CTA link instead of bare muted `<p>` tags
- **Coming-soon buttons**: Disabled spans replaced with `Request file` links pointing to `/contact?topic=request&file=<title>` so users can take action
- **Privacy link + stub page**: Footer now links to `/legal/privacy`; stub page with `robots: noindex` added for all 3 locales
- **SLA hint**: Contact form now shows "We typically respond within 1 business day" below the submit button
- **CJK date formatting**: Company timeline dates (`1997.03` → `"1997년 3월"` / `"1997年3月"` / `"Mar 1997"`) and resource `publishedAt` fields formatted via `Intl.DateTimeFormat`
- **Carousel swipe**: Touch swipe (≥50px delta) advances/retreats slides on mobile
- **Dot tap targets**: `::after` pseudo-element expands carousel dot hit area to ~43×43px without visual change
- **Mega-menu focus-out**: Header `onBlur` closes open dropdown when focus leaves the header
- **Footer address**: Wrapped in map link (Naver for `ko`, Google Maps for `en`/`zh`)
- **New i18n keys**: `footer.privacy`, `resources.emptyStateCta`, `resources.requestFile`, `contactForm.slaHint` added to all 3 locales

## Test plan

- [ ] `/en/resources/catalogues` with empty Sanity data → EmptyState with "Contact us" CTA renders
- [ ] Any resource page with items that have no file → "Request file" link navigates to contact page with query params
- [ ] `/ko/company` timeline → dates show `"1997년 3월"` not `"1997.03"`
- [ ] `/en/company` timeline → dates show `"Mar 1997"`
- [ ] Contact form → SLA hint appears below submit button
- [ ] Footer → privacy link visible, opens stub page
- [ ] Footer → address is tappable, opens Naver Maps (ko) / Google Maps (en/zh)
- [ ] Mobile: swipe carousel left/right → advances/retreats
- [ ] Tab through mega menu → focus leaving header closes the dropdown panel
- [ ] `pnpm build` → zero TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)