### PR TITLE
fix(header): stop locale pill from stretching in mobile nav

### DIFF
--- a/src/components/layout/LocaleSwitcher/LocaleSwitcher.css
+++ b/src/components/layout/LocaleSwitcher/LocaleSwitcher.css
@@ -2,6 +2,7 @@
 
 .lt-locale {
   display: inline-flex;
+  width: fit-content;
   flex-direction: row;
   align-items: stretch;
   gap: 0;


### PR DESCRIPTION
## Summary
- On mobile / narrow viewports, the KO/EN/ZH locale pill in the open mobile nav stretched to span the full panel width, leaving the segments awkwardly bunched on the left.
- Root cause: `.pd-mnav__footer` is a `flex-direction: column` container, which blockifies its children — `inline-flex` on `.lt-locale` was overridden and the pill expanded to fill the cross axis.
- Fix: add `width: fit-content` to `.lt-locale`. Restores shrink-to-content sizing in any flex parent (mobile column footer or desktop row), without touching markup or affecting the full-width primary CTA below it.

## Test plan
- [ ] Mobile viewport (≤480px): open hamburger menu — locale pill is a snug 3-segment pill, not a full-width bar
- [ ] Desktop header: locale pill looks unchanged
- [ ] Toggling KO / EN / ZH still routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)