### PR TITLE
feat(i18n): auto-detect locale from browser preference and geo

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { NextRequest } from "next/server";
+
+vi.mock("next-intl/middleware", () => ({ default: vi.fn() }));
+
 import { detectLocale } from "./middleware";
 
 function makeReq(

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { detectLocale } from "./middleware";
+
+function makeReq(
+  url = "http://localhost/",
+  opts: { headers?: Record<string, string>; cookie?: string } = {},
+) {
+  const headers: Record<string, string> = { ...opts.headers };
+  if (opts.cookie) headers["cookie"] = opts.cookie;
+  return new NextRequest(url, { headers });
+}
+
+describe("detectLocale", () => {
+  it("returns cookie value when valid", () => {
+    const req = makeReq("http://localhost/", { cookie: "NEXT_LOCALE=en" });
+    expect(detectLocale(req)).toBe("en");
+  });
+
+  it("ignores cookie with unknown locale", () => {
+    const req = makeReq("http://localhost/", {
+      cookie: "NEXT_LOCALE=fr",
+      headers: { "accept-language": "ko" },
+    });
+    expect(detectLocale(req)).toBe("ko");
+  });
+
+  it("prefers cookie over Accept-Language", () => {
+    const req = makeReq("http://localhost/", {
+      cookie: "NEXT_LOCALE=zh",
+      headers: { "accept-language": "en-US,en;q=0.9" },
+    });
+    expect(detectLocale(req)).toBe("zh");
+  });
+
+  it("detects Korean from Accept-Language", () => {
+    const req = makeReq("http://localhost/", {
+      headers: { "accept-language": "ko-KR,ko;q=0.9" },
+    });
+    expect(detectLocale(req)).toBe("ko");
+  });
+
+  it("detects English from Accept-Language", () => {
+    const req = makeReq("http://localhost/", {
+      headers: { "accept-language": "en-US,en;q=0.9,ko;q=0.8" },
+    });
+    expect(detectLocale(req)).toBe("en");
+  });
+
+  it("detects Chinese from Accept-Language", () => {
+    const req = makeReq("http://localhost/", {
+      headers: { "accept-language": "zh-CN,zh;q=0.9" },
+    });
+    expect(detectLocale(req)).toBe("zh");
+  });
+
+  it("prefers Accept-Language over geo", () => {
+    const req = makeReq("http://localhost/", {
+      headers: {
+        "accept-language": "en",
+        "x-vercel-ip-country": "KR",
+      },
+    });
+    expect(detectLocale(req)).toBe("en");
+  });
+
+  it("falls back to geo when Accept-Language has no match", () => {
+    const req = makeReq("http://localhost/", {
+      headers: {
+        "accept-language": "fr,de;q=0.9",
+        "x-vercel-ip-country": "KR",
+      },
+    });
+    expect(detectLocale(req)).toBe("ko");
+  });
+
+  it("maps CN to zh via geo", () => {
+    const req = makeReq("http://localhost/", {
+      headers: { "x-vercel-ip-country": "CN" },
+    });
+    expect(detectLocale(req)).toBe("zh");
+  });
+
+  it("falls back to ko when no signals match", () => {
+    const req = makeReq("http://localhost/", {
+      headers: { "accept-language": "fr,de;q=0.9" },
+    });
+    expect(detectLocale(req)).toBe("ko");
+  });
+
+  it("falls back to ko with no headers at all", () => {
+    expect(detectLocale(makeReq())).toBe("ko");
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,69 @@
 import createMiddleware from "next-intl/middleware";
+import { type NextRequest, NextResponse } from "next/server";
 import { routing } from "./i18n/routing";
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+const LOCALE_COOKIE = "NEXT_LOCALE";
+const COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
+
+const COUNTRY_LOCALE: Record<string, string> = {
+  KR: "ko",
+  CN: "zh",
+  TW: "zh",
+  HK: "zh",
+  MO: "zh",
+};
+
+function detectLocale(req: NextRequest): string {
+  const locales: readonly string[] = routing.locales;
+
+  const cookie = req.cookies.get(LOCALE_COOKIE)?.value;
+  if (cookie && locales.includes(cookie)) return cookie;
+
+  const acceptLang = req.headers.get("accept-language") ?? "";
+  for (const part of acceptLang.split(",")) {
+    const lang = part.trim().split(/[-;]/)[0].toLowerCase();
+    if (locales.includes(lang)) return lang;
+  }
+
+  const country = req.headers.get("x-vercel-ip-country")?.toUpperCase();
+  if (country && COUNTRY_LOCALE[country]) return COUNTRY_LOCALE[country];
+
+  return routing.defaultLocale;
+}
+
+export default function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const locales: readonly string[] = routing.locales;
+
+  const matchedLocale = locales.find(
+    (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+
+  if (matchedLocale) {
+    const response = intlMiddleware(req);
+    if (req.cookies.get(LOCALE_COOKIE)?.value !== matchedLocale) {
+      response.cookies.set(LOCALE_COOKIE, matchedLocale, {
+        path: "/",
+        maxAge: COOKIE_MAX_AGE,
+        sameSite: "lax",
+      });
+    }
+    return response;
+  }
+
+  const locale = detectLocale(req);
+  const url = req.nextUrl.clone();
+  url.pathname = `/${locale}${pathname}`;
+  const response = NextResponse.redirect(url);
+  response.cookies.set(LOCALE_COOKIE, locale, {
+    path: "/",
+    maxAge: COOKIE_MAX_AGE,
+    sameSite: "lax",
+  });
+  return response;
+}
 
 export const config = {
   matcher: "/((?!api|_next|_vercel|studio|icon|apple-icon|.*\\..*).*)",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,7 @@ const COUNTRY_LOCALE: Record<string, string> = {
   MO: "zh",
 };
 
-function detectLocale(req: NextRequest): string {
+export function detectLocale(req: NextRequest): string {
   const locales: readonly string[] = routing.locales;
 
   const cookie = req.cookies.get(LOCALE_COOKIE)?.value;
@@ -41,6 +41,8 @@ export default function middleware(req: NextRequest) {
     (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
   );
 
+  const secure = process.env.NODE_ENV === "production";
+
   if (matchedLocale) {
     const response = intlMiddleware(req);
     if (req.cookies.get(LOCALE_COOKIE)?.value !== matchedLocale) {
@@ -48,9 +50,15 @@ export default function middleware(req: NextRequest) {
         path: "/",
         maxAge: COOKIE_MAX_AGE,
         sameSite: "lax",
+        secure,
       });
     }
     return response;
+  }
+
+  // Unknown locale-like prefix (e.g. /xx/about) — let intlMiddleware normalize it
+  if (/^\/[a-z]{2}(\/|$)/.test(pathname)) {
+    return intlMiddleware(req);
   }
 
   const locale = detectLocale(req);
@@ -61,6 +69,7 @@ export default function middleware(req: NextRequest) {
     path: "/",
     maxAge: COOKIE_MAX_AGE,
     sameSite: "lax",
+    secure,
   });
   return response;
 }


### PR DESCRIPTION
## Summary
- Detects visitor locale on first visit using Accept-Language header (primary), Vercel geo header as fallback, defaulting to Korean
- Persists the detected locale in a NEXT_LOCALE cookie (1-year) so repeat visits skip re-detection
- Manual locale switcher clicks update the cookie, making the choice sticky

## Test plan
- Visit the site with no cookie — should redirect to `/ko/`
- Set browser language to English — should redirect to `/en/`
- Switch locale via the nav (KO/EN/ZH) — cookie should update, next visit stays on that locale
- Verify `NEXT_LOCALE` cookie in DevTools → Application → Cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)