### PR TITLE
fix(home): homepage UI polish — copy, fonts, and section headers

### DIFF
--- a/src/app/[locale]/applications/applications-page.css
+++ b/src/app/[locale]/applications/applications-page.css
@@ -229,7 +229,7 @@
   gap: 20px;
   padding: 56px 32px;
   margin-bottom: 64px;
-  background: var(--lt-primary-700);
+  background: var(--pd-primary-dark);
   border-radius: 12px;
   text-align: center;
 }

--- a/src/app/[locale]/applications/applications-page.css
+++ b/src/app/[locale]/applications/applications-page.css
@@ -229,7 +229,7 @@
   gap: 20px;
   padding: 56px 32px;
   margin-bottom: 64px;
-  background: var(--pd-primary);
+  background: var(--lt-primary-700);
   border-radius: 12px;
   text-align: center;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,6 +60,7 @@
 
   --pd-primary: var(--lt-primary-500);
   --pd-primary-hover: var(--lt-primary-600);
+  --pd-primary-dark: var(--lt-primary-700);
   --pd-on-primary: #ffffff;
   --pd-accent: var(--lt-accent-400);
 

--- a/src/components/home/Applications/Applications.css
+++ b/src/components/home/Applications/Applications.css
@@ -39,12 +39,12 @@
   margin-bottom: 18px;
 }
 .ho-applications__n {
-  font: 500 var(--lt-fs-md)/1.25 var(--lt-sans);
+  font: 500 var(--lt-fs-lg)/1.25 var(--lt-sans);
   color: var(--pd-fg-strong);
   letter-spacing: -0.005em;
 }
 .ho-applications__k {
-  font: 400 var(--lt-fs-xs) var(--lt-mono);
+  font: 400 var(--lt-fs-sm) var(--lt-mono);
   color: var(--pd-muted);
 }
 

--- a/src/components/home/Applications/Applications.tsx
+++ b/src/components/home/Applications/Applications.tsx
@@ -9,7 +9,11 @@ export function Applications({ h }: Props) {
   const { applications } = h;
   return (
     <section className="ho-sec">
-      <SectionHead kicker={applications.kicker} title={applications.title} />
+      <SectionHead
+        kicker={applications.kicker}
+        title={applications.title}
+        sub={applications.sub}
+      />
       <ul className="ho-applications">
         {applications.items.map((a, i) => (
           <li className="ho-applications__cell" key={a.n}>

--- a/src/components/home/Contact/Contact.css
+++ b/src/components/home/Contact/Contact.css
@@ -41,9 +41,11 @@
   line-height: 1.55;
   color: rgba(255, 255, 255, 0.72);
 }
-:lang(ko) .ho-contact__sub {
-  max-width: none;
-  white-space: nowrap;
+@media (min-width: 900px) {
+  :lang(ko) .ho-contact__sub {
+    max-width: none;
+    white-space: nowrap;
+  }
 }
 .ho-contact__btns {
   position: relative;

--- a/src/components/home/Contact/Contact.css
+++ b/src/components/home/Contact/Contact.css
@@ -41,6 +41,10 @@
   line-height: 1.55;
   color: rgba(255, 255, 255, 0.72);
 }
+:lang(ko) .ho-contact__sub {
+  max-width: none;
+  white-space: nowrap;
+}
 .ho-contact__btns {
   position: relative;
   display: inline-flex;

--- a/src/components/home/Credentials/Credentials.tsx
+++ b/src/components/home/Credentials/Credentials.tsx
@@ -8,7 +8,11 @@ export function Credentials({ h }: Props) {
   const { credentials } = h;
   return (
     <section className="ho-sec">
-      <SectionHead kicker={credentials.kicker} title={credentials.title} />
+      <SectionHead
+        kicker={credentials.kicker}
+        title={credentials.title}
+        sub={credentials.sub}
+      />
       <ul className="ho-credentials">
         {credentials.items.map((it) => (
           <li key={it} className="ho-credentials__item">

--- a/src/components/home/Series/Series.css
+++ b/src/components/home/Series/Series.css
@@ -28,14 +28,14 @@
   justify-content: space-between;
 }
 .ho-series__code {
-  font: 600 var(--lt-fs-xs) var(--lt-mono);
+  font: 600 var(--lt-fs-sm) var(--lt-mono);
   letter-spacing: 0.08em;
   color: var(--pd-primary);
   text-transform: uppercase;
   white-space: nowrap;
 }
 .ho-series__count {
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
+  font: 500 var(--lt-fs-sm) var(--lt-mono);
   color: var(--pd-muted);
   letter-spacing: 0.06em;
   white-space: nowrap;
@@ -48,7 +48,7 @@
 }
 .ho-series__desc {
   margin: 0;
-  font-size: var(--lt-fs-sm);
+  font-size: var(--lt-fs-md);
   color: var(--pd-muted);
   line-height: 1.55;
   flex: 1;
@@ -59,7 +59,7 @@
   justify-content: space-between;
   padding-top: 12px;
   border-top: 1px solid var(--pd-rule);
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
+  font: 500 var(--lt-fs-sm) var(--lt-mono);
 }
 .ho-series__range {
   color: var(--pd-fg);

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -29,7 +29,12 @@ export type HomeContent = {
   };
   stats: Stat[];
   series: { kicker: string; title: string; sub: string; items: SeriesItem[] };
-  applications: { kicker: string; title: string; items: ApplicationItem[] };
+  applications: {
+    kicker: string;
+    title: string;
+    sub: string;
+    items: ApplicationItem[];
+  };
   feature: {
     kicker: string;
     title: string;
@@ -37,7 +42,7 @@ export type HomeContent = {
     bullets: Bullet[];
     cta: string;
   };
-  credentials: { kicker: string; title: string; items: string[] };
+  credentials: { kicker: string; title: string; sub: string; items: string[] };
   contact: { title: string; sub: string; primary: string; secondary: string };
 };
 
@@ -101,7 +106,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     applications: {
       kicker: "02 — 적용 분야",
-      title: "정밀을 요구하는 모든 공정에",
+      title: "어디서나, 정확하게",
+      sub: "반도체부터 바이오까지, 정밀이 요구되는 모든 현장.",
       items: [
         { n: "반도체 · 디스플레이", k: "Semiconductor", slug: "semiconductor" },
         { n: "연료전지", k: "Fuel Cells", slug: "fuel-cells" },
@@ -131,7 +137,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     credentials: {
       kicker: "04 — 인증",
-      title: "국제 표준을 충족합니다",
+      title: "검증된 국제 인증",
+      sub: "ISO 9001, CE 인증을 포함한 국제 기준을 충족합니다.",
       items: [
         "ISO 9001",
         "CE",
@@ -207,7 +214,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     applications: {
       kicker: "02 — Applications",
-      title: "Wherever precision is required.",
+      title: "Anywhere. Precisely.",
+      sub: "From semiconductors to biotech — wherever the process demands it.",
       items: [
         { n: "Semiconductor", k: "반도체 · 디스플레이", slug: "semiconductor" },
         { n: "Fuel Cells", k: "연료전지", slug: "fuel-cells" },
@@ -237,7 +245,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     credentials: {
       kicker: "04 — Certifications",
-      title: "Tested against international standards.",
+      title: "Verified international certifications.",
+      sub: "ISO 9001, CE, and more — meeting every international benchmark.",
       items: ["ISO 9001", "CE", "INNOBIZ", "RoHS / REACH", "KAIST joint R&D"],
     },
     contact: {
@@ -307,7 +316,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     applications: {
       kicker: "02 — 应用领域",
-      title: "任何需要精度的工艺。",
+      title: "随处可用，精准可靠。",
+      sub: "从半导体到生物科技，精密工艺的每个领域。",
       items: [
         { n: "半导体 · 显示", k: "Semiconductor", slug: "semiconductor" },
         { n: "燃料电池", k: "Fuel Cells", slug: "fuel-cells" },
@@ -333,7 +343,8 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     },
     credentials: {
       kicker: "04 — 认证",
-      title: "符合国际标准。",
+      title: "经验证的国际认证",
+      sub: "满足 ISO 9001、CE 等国际认证标准。",
       items: ["ISO 9001", "CE", "INNOBIZ", "RoHS / REACH", "KAIST 联合研发"],
     },
     contact: {


### PR DESCRIPTION
## Summary
- Darken applications page CTA strip to a deeper blue (--lt-primary-700)
- Bump applications grid and series card font sizes up one step for legibility
- Reword applications/credentials section titles across all three locales (ko/en/zh)
- Add sub-headings to applications and credentials sections (were missing vs series/feature)
- Prevent Korean contact sub-line from wrapping with white-space: nowrap

## Test plan
- Check /ko, /en, /zh home pages — all 4 sections should have kicker + title + sub
- Verify CTA on /ko/applications is darker blue, not broken/white
- Check Korean contact block stays on one line on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)