### PR TITLE
fix(ux): search failure message, mega menu keyboard focus-out (#132)

### DIFF
--- a/src/components/layout/HeaderNav/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav/HeaderNav.tsx
@@ -17,11 +17,6 @@ export function HeaderNav({ items }: Props) {
       className="pd-top__nav"
       aria-label={t("primaryNav")}
       onMouseLeave={onItemLeave}
-      onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          setOpenId(null);
-        }
-      }}
     >
       {items.map((item) => {
         const isOpen = openId === item.id;

--- a/src/components/layout/HeaderNav/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav/HeaderNav.tsx
@@ -17,6 +17,11 @@ export function HeaderNav({ items }: Props) {
       className="pd-top__nav"
       aria-label={t("primaryNav")}
       onMouseLeave={onItemLeave}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          setOpenId(null);
+        }
+      }}
     >
       {items.map((item) => {
         const isOpen = openId === item.id;

--- a/src/components/layout/Search/SearchPanel.css
+++ b/src/components/layout/Search/SearchPanel.css
@@ -163,6 +163,18 @@
   font: var(--lt-fs-sm)/1.4 var(--lt-sans);
 }
 
+.pd-search__unavailable {
+  margin: 0;
+  padding: 12px 0;
+  color: var(--pd-muted);
+  font: var(--lt-fs-sm)/1.4 var(--lt-sans);
+}
+
+.pd-search__unavailable a {
+  color: var(--pd-primary);
+  text-decoration: underline;
+}
+
 .pd-search__result-list {
   list-style: none;
   margin: 0;

--- a/src/components/layout/Search/SearchPanel.tsx
+++ b/src/components/layout/Search/SearchPanel.tsx
@@ -51,6 +51,7 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
   const close = useCallback(() => {
     setValue("");
     setResults(null);
+    setIndexError(false);
     onClose();
   }, [onClose]);
 

--- a/src/components/layout/Search/SearchPanel.tsx
+++ b/src/components/layout/Search/SearchPanel.tsx
@@ -46,6 +46,7 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
   const [value, setValue] = useState("");
   const [results, setResults] = useState<SearchEntry[] | null>(null);
   const [indexReady, setIndexReady] = useState(false);
+  const [indexError, setIndexError] = useState(false);
 
   const close = useCallback(() => {
     setValue("");
@@ -70,7 +71,7 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
         setIndexReady(true);
       })
       .catch(() => {
-        console.warn("[search] index not found — run pnpm build:search-index");
+        setIndexError(true);
       });
   }, [open, locale]);
 
@@ -170,6 +171,15 @@ export function SearchPanel({ content, open, onClose, triggerRef }: Props) {
               </li>
             ))}
           </ul>
+
+          {indexError && !indexReady && (
+            <p className="pd-search__unavailable">
+              {content.searchUnavailable}{" "}
+              <Link href="/products" onClick={close}>
+                {content.browseProducts}
+              </Link>
+            </p>
+          )}
 
           <form
             className="pd-search__form"

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -112,6 +112,10 @@ export type ShellSearch = {
   quickChips: { id: string; label: string }[];
   /** Shown when a query returns zero results. Use {q} as query placeholder. */
   noResults: string;
+  /** Shown when the search index fails to load. */
+  searchUnavailable: string;
+  /** Link label shown alongside searchUnavailable. */
+  browseProducts: string;
 };
 
 /** Mobile nav panel copy (#34). Renders below 1000px. */
@@ -294,6 +298,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "certifications", label: "인증서" },
       ],
       noResults: '"{q}"에 대한 결과가 없습니다',
+      searchUnavailable: "검색을 일시적으로 사용할 수 없습니다.",
+      browseProducts: "제품 목록 보기",
     },
     mobileNav: {
       openLabel: "메뉴 열기",
@@ -486,6 +492,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "certifications", label: "Certifications" },
       ],
       noResults: 'No results for "{q}"',
+      searchUnavailable: "Search is temporarily unavailable.",
+      browseProducts: "Browse products",
     },
     mobileNav: {
       openLabel: "Open menu",
@@ -666,6 +674,8 @@ export const LT_SHELL: Record<Locale, ShellContent> = {
         { id: "certifications", label: "认证文件" },
       ],
       noResults: '"{q}"无搜索结果',
+      searchUnavailable: "搜索暂时不可用。",
+      browseProducts: "浏览产品",
     },
     mobileNav: {
       openLabel: "打开菜单",


### PR DESCRIPTION
## Summary

Closes #132 (partially — adds the two remaining fixes on top of the existing branch work).

The remote branch already had: empty states + CTAs, "Request" file links, SLA hint, CJK date formatting, carousel swipe, 44px dot tap targets.

This PR adds:

- **Search failure UX**: `SearchPanel` now tracks `indexError` state. When the search index fetch fails, users see "Search is temporarily unavailable. Browse products →" instead of disabled chips with no explanation.
- **Mega menu keyboard focus-out**: `HeaderNav` closes the open panel when focus leaves the nav entirely (`onBlur` + `relatedTarget` containment check). Keyboard users can now tab out of the mega menu without getting trapped.
- `ShellSearch` type extended with `searchUnavailable` + `browseProducts` fields (all 3 locales).

## Test plan

- [ ] Open search panel, block network, re-open → see unavailable message + Browse products link instead of disabled chips
- [ ] Tab into Products mega menu trigger, tab through panel links, tab past the last link → panel closes
- [ ] Press Escape in mega menu → panel closes and focus returns to trigger (existing behavior, verify not broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)