### PR TITLE
feat(cms): migrate FAQ + Applications to Sanity CMS

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
                   .schemaType("categoryShowcase")
                   .documentId("category-showcases"),
               ),
+            S.divider(),
+            S.documentTypeListItem("faqGroup").title("FAQ Groups"),
+            S.documentTypeListItem("application").title("Applications"),
           ]),
     }),
     internationalizedArray({
@@ -36,7 +39,7 @@ export default defineConfig({
         { id: "zh", title: "中文" },
       ],
       defaultLanguages: ["ko", "en", "zh"],
-      fieldTypes: ["string"],
+      fieldTypes: ["string", "text"],
     }),
   ],
   schema: { types: schemaTypes },

--- a/sanity/schemaTypes/application.ts
+++ b/sanity/schemaTypes/application.ts
@@ -10,8 +10,12 @@ export const application = defineType({
       title: "Slug",
       type: "slug",
       options: {
-        source: (doc: { title?: { language: string; value?: string }[] }) =>
-          doc.title?.find((e) => e.language === "en")?.value ?? "",
+        source: (doc) => {
+          const title = doc.title as
+            | { language: string; value?: string }[]
+            | undefined;
+          return title?.find((e) => e.language === "en")?.value ?? "";
+        },
       },
       validation: (r) => r.required(),
     }),

--- a/sanity/schemaTypes/application.ts
+++ b/sanity/schemaTypes/application.ts
@@ -9,7 +9,10 @@ export const application = defineType({
       name: "slug",
       title: "Slug",
       type: "slug",
-      options: { source: "title" },
+      options: {
+        source: (doc: { title?: { language: string; value?: string }[] }) =>
+          doc.title?.find((e) => e.language === "en")?.value ?? "",
+      },
       validation: (r) => r.required(),
     }),
     defineField({

--- a/sanity/schemaTypes/application.ts
+++ b/sanity/schemaTypes/application.ts
@@ -1,0 +1,63 @@
+import { defineType, defineField } from "sanity";
+
+export const application = defineType({
+  name: "application",
+  title: "Application",
+  type: "document",
+  fields: [
+    defineField({
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      options: { source: "title" },
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "order",
+      title: "Display order",
+      type: "number",
+    }),
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "internationalizedArrayString",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "lede",
+      title: "Lede",
+      type: "internationalizedArrayString",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "body",
+      title: "Body",
+      type: "internationalizedArrayText",
+      description: "Separate paragraphs with a blank line.",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "recommendedSeries",
+      title: "Recommended series",
+      type: "array",
+      of: [{ type: "string" }],
+    }),
+    defineField({
+      name: "relatedCategories",
+      title: "Related categories",
+      type: "array",
+      of: [
+        {
+          type: "string",
+          options: {
+            list: [
+              { title: "Analogue", value: "analogue" },
+              { title: "Digital", value: "digital" },
+              { title: "Specialized", value: "specialized" },
+            ],
+          },
+        },
+      ],
+    }),
+  ],
+});

--- a/sanity/schemaTypes/faq.ts
+++ b/sanity/schemaTypes/faq.ts
@@ -11,8 +11,12 @@ export const faqGroup = defineType({
       type: "slug",
       description: "URL-safe identifier, e.g. mfc-vs-mfm-basics",
       options: {
-        source: (doc: { heading?: { language: string; value?: string }[] }) =>
-          doc.heading?.find((e) => e.language === "en")?.value ?? "",
+        source: (doc) => {
+          const heading = doc.heading as
+            | { language: string; value?: string }[]
+            | undefined;
+          return heading?.find((e) => e.language === "en")?.value ?? "";
+        },
       },
       validation: (r) => r.required(),
     }),

--- a/sanity/schemaTypes/faq.ts
+++ b/sanity/schemaTypes/faq.ts
@@ -1,0 +1,59 @@
+import { defineType, defineField } from "sanity";
+
+export const faqGroup = defineType({
+  name: "faqGroup",
+  title: "FAQ Group",
+  type: "document",
+  fields: [
+    defineField({
+      name: "id",
+      title: "Group ID",
+      type: "slug",
+      description: "URL-safe identifier, e.g. mfc-vs-mfm-basics",
+      options: { source: "heading" },
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "heading",
+      title: "Heading",
+      type: "internationalizedArrayString",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "order",
+      title: "Display order",
+      type: "number",
+    }),
+    defineField({
+      name: "questions",
+      title: "Questions",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            defineField({
+              name: "id",
+              title: "Question ID",
+              type: "string",
+              description: "Unique identifier, e.g. mfc-vs-mfm-difference",
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "q",
+              title: "Question",
+              type: "internationalizedArrayString",
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "a",
+              title: "Answer",
+              type: "internationalizedArrayText",
+              validation: (r) => r.required(),
+            }),
+          ],
+        },
+      ],
+    }),
+  ],
+});

--- a/sanity/schemaTypes/faq.ts
+++ b/sanity/schemaTypes/faq.ts
@@ -10,7 +10,10 @@ export const faqGroup = defineType({
       title: "Group ID",
       type: "slug",
       description: "URL-safe identifier, e.g. mfc-vs-mfm-basics",
-      options: { source: "heading" },
+      options: {
+        source: (doc: { heading?: { language: string; value?: string }[] }) =>
+          doc.heading?.find((e) => e.language === "en")?.value ?? "",
+      },
       validation: (r) => r.required(),
     }),
     defineField({

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -7,6 +7,8 @@ import { manual } from "./manual";
 import { drawing } from "./drawing";
 import { datasheet } from "./datasheet";
 import { certification } from "./certification";
+import { faqGroup } from "./faq";
+import { application } from "./application";
 
 export const schemaTypes = [
   product,
@@ -18,4 +20,6 @@ export const schemaTypes = [
   drawing,
   datasheet,
   certification,
+  faqGroup,
+  application,
 ];

--- a/src/app/[locale]/applications/[slug]/page.tsx
+++ b/src/app/[locale]/applications/[slug]/page.tsx
@@ -9,7 +9,10 @@ import type { Locale } from "@/lib/content/home";
 import { buildApplicationDetailMetadata } from "@/lib/seo";
 import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { applicationBySlugQuery, applicationSlugsQuery } from "@/sanity/queries";
+import {
+  applicationBySlugQuery,
+  applicationSlugsQuery,
+} from "@/sanity/queries";
 import "../applications-page.css";
 
 type Props = { params: Promise<{ locale: Locale; slug: string }> };
@@ -38,7 +41,9 @@ export async function generateStaticParams() {
     { name: "applicationSlugsForStaticParams" },
   ).catch(() => [] as Array<{ slug: string }>);
 
-  const allSlugs = [...new Set([...staticSlugs, ...sanitySlugs.map((s) => s.slug)])];
+  const allSlugs = [
+    ...new Set([...staticSlugs, ...sanitySlugs.map((s) => s.slug)]),
+  ];
 
   return routing.locales.flatMap((locale) =>
     allSlugs.map((slug) => ({ locale, slug })),

--- a/src/app/[locale]/applications/[slug]/page.tsx
+++ b/src/app/[locale]/applications/[slug]/page.tsx
@@ -7,28 +7,61 @@ import { LT_APPLICATIONS } from "@/lib/content/applications";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { buildApplicationDetailMetadata } from "@/lib/seo";
+import { sanityClient, sanityBuildClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { applicationBySlugQuery, applicationSlugsQuery } from "@/sanity/queries";
 import "../applications-page.css";
 
 type Props = { params: Promise<{ locale: Locale; slug: string }> };
 
-export function generateStaticParams() {
-  const slugs = [
+type SanityApp = {
+  slug: string;
+  title: Record<string, string>;
+  lede: Record<string, string>;
+  body: Record<string, string>;
+  recommendedSeries: string[];
+  relatedCategories: string[];
+};
+
+export async function generateStaticParams() {
+  const staticSlugs = [
     ...new Set(
       routing.locales.flatMap((l) =>
         LT_APPLICATIONS[l].applications.map((a) => a.slug),
       ),
     ),
   ];
+
+  const sanitySlugs = await fetchSanity(
+    () =>
+      sanityBuildClient.fetch<Array<{ slug: string }>>(applicationSlugsQuery),
+    { name: "applicationSlugsForStaticParams" },
+  ).catch(() => [] as Array<{ slug: string }>);
+
+  const allSlugs = [...new Set([...staticSlugs, ...sanitySlugs.map((s) => s.slug)])];
+
   return routing.locales.flatMap((locale) =>
-    slugs.map((slug) => ({ locale, slug })),
+    allSlugs.map((slug) => ({ locale, slug })),
   );
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
-  const app = LT_APPLICATIONS[locale].applications.find((a) => a.slug === slug);
-  if (!app) return {};
-  return buildApplicationDetailMetadata(locale, slug, app.title, app.lede);
+  const raw = await fetchSanity(
+    () =>
+      sanityClient.fetch<SanityApp | null>(applicationBySlugQuery, { slug }),
+    { name: "applicationBySlug", params: { slug } },
+  ).catch(() => null);
+  const title =
+    raw?.title?.[locale] ??
+    raw?.title?.en ??
+    LT_APPLICATIONS[locale].applications.find((a) => a.slug === slug)?.title;
+  const lede =
+    raw?.lede?.[locale] ??
+    raw?.lede?.en ??
+    LT_APPLICATIONS[locale].applications.find((a) => a.slug === slug)?.lede;
+  if (!title) return {};
+  return buildApplicationDetailMetadata(locale, slug, title, lede ?? "");
 }
 
 const CATEGORY_HREFS: Record<string, string> = {
@@ -48,7 +81,26 @@ export default async function ApplicationDetailPage({ params }: Props) {
   ]);
 
   const c = LT_APPLICATIONS[locale];
-  const app = c.applications.find((a) => a.slug === slug);
+
+  const rawApp = await fetchSanity(
+    () =>
+      sanityClient.fetch<SanityApp | null>(applicationBySlugQuery, { slug }),
+    { name: "applicationBySlug", params: { slug } },
+  ).catch(() => null);
+
+  const app = rawApp
+    ? {
+        slug: rawApp.slug,
+        title: rawApp.title?.[locale] ?? rawApp.title?.en ?? "",
+        lede: rawApp.lede?.[locale] ?? rawApp.lede?.en ?? "",
+        body: (rawApp.body?.[locale] ?? rawApp.body?.en ?? "")
+          .split(/\n\n+/)
+          .filter(Boolean),
+        recommendedSeries: rawApp.recommendedSeries ?? [],
+        relatedCategories: (rawApp.relatedCategories ??
+          []) as (typeof c.applications)[0]["relatedCategories"],
+      }
+    : c.applications.find((a) => a.slug === slug);
 
   if (!app) notFound();
 

--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -5,7 +5,10 @@ import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { Chip } from "@/components/ui/Chip/Chip";
 import { INDUSTRY_ICONS } from "@/lib/content/application-icons";
-import { LT_APPLICATIONS, type ApplicationEntry } from "@/lib/content/applications";
+import {
+  LT_APPLICATIONS,
+  type ApplicationEntry,
+} from "@/lib/content/applications";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { buildApplicationsMetadata } from "@/lib/seo";
@@ -67,10 +70,9 @@ export default async function ApplicationsPage({ params }: Props) {
   const [tCommon, tNav, rawApps] = await Promise.all([
     getTranslations("common"),
     getTranslations("nav"),
-    fetchSanity(
-      () => sanityClient.fetch<SanityApp[]>(allApplicationsQuery),
-      { name: "allApplications" },
-    ).catch(() => [] as SanityApp[]),
+    fetchSanity(() => sanityClient.fetch<SanityApp[]>(allApplicationsQuery), {
+      name: "allApplications",
+    }).catch(() => [] as SanityApp[]),
   ]);
 
   const c = LT_APPLICATIONS[locale];

--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -5,10 +5,13 @@ import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { Chip } from "@/components/ui/Chip/Chip";
 import { INDUSTRY_ICONS } from "@/lib/content/application-icons";
-import { LT_APPLICATIONS } from "@/lib/content/applications";
+import { LT_APPLICATIONS, type ApplicationEntry } from "@/lib/content/applications";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { buildApplicationsMetadata } from "@/lib/seo";
+import { sanityClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { allApplicationsQuery } from "@/sanity/queries";
 import "./applications-page.css";
 
 type ChipTone = "neutral" | "info" | "warning" | "danger";
@@ -39,6 +42,15 @@ function buildStats(locale: Locale, industryCount: number): StatItem[] {
 
 type Props = { params: Promise<{ locale: Locale }> };
 
+type SanityApp = {
+  slug: string;
+  title: Record<string, string>;
+  lede: Record<string, string>;
+  body: Record<string, string>;
+  recommendedSeries: string[];
+  relatedCategories: string[];
+};
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -52,13 +64,32 @@ export default async function ApplicationsPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const [tCommon, tNav] = await Promise.all([
+  const [tCommon, tNav, rawApps] = await Promise.all([
     getTranslations("common"),
     getTranslations("nav"),
+    fetchSanity(
+      () => sanityClient.fetch<SanityApp[]>(allApplicationsQuery),
+      { name: "allApplications" },
+    ).catch(() => [] as SanityApp[]),
   ]);
 
   const c = LT_APPLICATIONS[locale];
-  const stats = buildStats(locale, c.applications.length);
+
+  const applications: ApplicationEntry[] = rawApps.length
+    ? rawApps.map((a) => ({
+        slug: a.slug,
+        title: a.title?.[locale] ?? a.title?.en ?? "",
+        lede: a.lede?.[locale] ?? a.lede?.en ?? "",
+        body: (a.body?.[locale] ?? a.body?.en ?? "")
+          .split(/\n\n+/)
+          .filter(Boolean),
+        recommendedSeries: a.recommendedSeries ?? [],
+        relatedCategories: (a.relatedCategories ??
+          []) as ApplicationEntry["relatedCategories"],
+      }))
+    : c.applications;
+
+  const stats = buildStats(locale, applications.length);
 
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },
@@ -108,7 +139,7 @@ export default async function ApplicationsPage({ params }: Props) {
       <section id="industries" aria-label={c.gridHeading}>
         <h2 className="ap-grid__heading">{c.gridHeading}</h2>
         <ul className="ap-grid">
-          {c.applications.map((app) => (
+          {applications.map((app) => (
             <li key={app.slug} className="ap-card">
               <Link
                 href={`/applications/${app.slug}`}

--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -34,7 +34,7 @@ const STAT_LABELS: Record<Locale, [string, string, string]> = {
 function buildStats(locale: Locale, industryCount: number): StatItem[] {
   const [industries, models, certs] = STAT_LABELS[locale];
   return [
-    { value: String(industryCount), label: industries, href: "#industries" },
+    { value: `${industryCount}+`, label: industries, href: "#industries" },
     { value: "40+", label: models, href: "/products" },
     { value: "13", label: certs, href: "/resources/certifications" },
   ];

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -42,10 +42,9 @@ export default async function FaqPage({ params }: Props) {
   const [tCommon, tNav, rawGroups] = await Promise.all([
     getTranslations("common"),
     getTranslations("nav"),
-    fetchSanity(
-      () => sanityClient.fetch<SanityFaqGroup[]>(allFaqGroupsQuery),
-      { name: "allFaqGroups" },
-    ).catch(() => [] as SanityFaqGroup[]),
+    fetchSanity(() => sanityClient.fetch<SanityFaqGroup[]>(allFaqGroupsQuery), {
+      name: "allFaqGroups",
+    }).catch(() => [] as SanityFaqGroup[]),
   ]);
 
   const c = LT_FAQ[locale];

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -1,13 +1,26 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
-import { LT_FAQ, type FaqContent, type FaqGroup } from "@/lib/content/faq";
+import { LT_FAQ, type FaqGroup } from "@/lib/content/faq";
 import { safeJsonLd } from "@/lib/seo/jsonLd";
+import { sanityClient } from "@/sanity/client";
+import { fetchSanity } from "@/sanity/fetch";
+import { allFaqGroupsQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import "./faq-page.css";
 
 type Props = { params: Promise<{ locale: Locale }> };
+
+type SanityFaqGroup = {
+  id: string;
+  heading: Record<string, string>;
+  questions: Array<{
+    id: string;
+    q: Record<string, string>;
+    a: Record<string, string>;
+  }> | null;
+};
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -26,12 +39,28 @@ export default async function FaqPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const [tCommon, tNav] = await Promise.all([
+  const [tCommon, tNav, rawGroups] = await Promise.all([
     getTranslations("common"),
     getTranslations("nav"),
+    fetchSanity(
+      () => sanityClient.fetch<SanityFaqGroup[]>(allFaqGroupsQuery),
+      { name: "allFaqGroups" },
+    ).catch(() => [] as SanityFaqGroup[]),
   ]);
 
   const c = LT_FAQ[locale];
+
+  const groups: FaqGroup[] = rawGroups.length
+    ? rawGroups.map((g) => ({
+        id: g.id ?? "",
+        heading: g.heading?.[locale] ?? g.heading?.en ?? "",
+        questions: (g.questions ?? []).map((q) => ({
+          id: q.id ?? "",
+          q: q.q?.[locale] ?? q.q?.en ?? "",
+          a: q.a?.[locale] ?? q.a?.en ?? "",
+        })),
+      }))
+    : c.groups;
 
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },
@@ -41,7 +70,7 @@ export default async function FaqPage({ params }: Props) {
   const faqSchema = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    mainEntity: c.groups.flatMap((g) =>
+    mainEntity: groups.flatMap((g) =>
       g.questions.map((q) => ({
         "@type": "Question",
         name: q.q,
@@ -62,13 +91,13 @@ export default async function FaqPage({ params }: Props) {
       <main className="lt-wrap">
         <Breadcrumbs items={breadcrumbs} />
         <div className="fq">
-          <FaqSideNav c={c} />
+          <FaqSideNav groups={groups} navHeading={c.navHeading} />
           <div className="fq-main">
             <header className="fq-hero">
               <h1 className="fq-hero__title">{c.pageTitle}</h1>
               <p className="fq-hero__sub">{c.pageSub}</p>
             </header>
-            {c.groups.map((g) => (
+            {groups.map((g) => (
               <FaqGroupSection key={g.id} group={g} />
             ))}
           </div>
@@ -78,13 +107,19 @@ export default async function FaqPage({ params }: Props) {
   );
 }
 
-function FaqSideNav({ c }: { c: FaqContent }) {
+function FaqSideNav({
+  groups,
+  navHeading,
+}: {
+  groups: FaqGroup[];
+  navHeading: string;
+}) {
   return (
-    <aside className="fq-aside" aria-label={c.navHeading}>
-      <h2 className="fq-aside__heading">{c.navHeading}</h2>
+    <aside className="fq-aside" aria-label={navHeading}>
+      <h2 className="fq-aside__heading">{navHeading}</h2>
       <nav className="fq-nav">
         <ul className="fq-nav__list">
-          {c.groups.map((g) => (
+          {groups.map((g) => (
             <li key={g.id} className="fq-nav__item">
               <a href={`#${g.id}`} className="fq-nav__link">
                 {g.heading}

--- a/src/components/home/Feature/Feature.css
+++ b/src/components/home/Feature/Feature.css
@@ -109,13 +109,22 @@
   right: 20px;
 }
 .ho-feature__chip-body {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 1;
 }
-.ho-feature__lbl {
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
-  letter-spacing: 0.12em;
-  color: var(--pd-muted);
+.ho-feature__chip-slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.ho-feature__chip-slide[data-active="true"] {
+  opacity: 1;
+}
+.ho-feature__chip-img {
+  object-fit: contain;
+  padding: 72px;
 }
 
 :lang(ko) .ho-feature__kicker,

--- a/src/components/home/Feature/Feature.tsx
+++ b/src/components/home/Feature/Feature.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
 import type { HomeContent } from "@/lib/content/home";
+import { FeatureChip } from "./FeatureChip";
 import "./Feature.css";
 
 type Props = { h: HomeContent };
@@ -31,15 +32,7 @@ export function Feature({ h }: Props) {
         </Button>
       </div>
       <div>
-        <div className="ho-feature__chip">
-          <div className="ho-feature__chip-tl">M3030VA</div>
-          <div className="ho-feature__chip-tr">REV.7</div>
-          <div className="ho-feature__chip-body">
-            <div className="ho-feature__lbl">PLACEHOLDER · PRODUCT</div>
-          </div>
-          <div className="ho-feature__chip-bl">LINE TECH</div>
-          <div className="ho-feature__chip-br">N₂ · 20 SLM</div>
-        </div>
+        <FeatureChip />
       </div>
     </section>
   );

--- a/src/components/home/Feature/FeatureChip.tsx
+++ b/src/components/home/Feature/FeatureChip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
+
+const SLIDES = [
+  { model: "M3030VA", fn: "MFC", gas: "N₂", flow: "30 SLM", slug: "m3030va" },
+  { model: "M2030VA", fn: "MFM", gas: "N₂", flow: "30 SLM", slug: "m2030va" },
+  { model: "M3200VA", fn: "MFC", gas: "N₂", flow: "100 SLM", slug: "m3200va" },
+  { model: "M2200VA", fn: "MFM", gas: "N₂", flow: "100 SLM", slug: "m2200va" },
+] as const;
+
+const INTERVAL_MS = 3500;
+
+export function FeatureChip() {
+  const [active, setActive] = useState(0);
+  const isPaused = useRef(false);
+  const len = SLIDES.length;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!isPaused.current) setActive((n) => (n + 1) % len);
+    }, INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [len]);
+
+  const current = SLIDES[active];
+
+  return (
+    <div
+      className="ho-feature__chip"
+      onMouseEnter={() => (isPaused.current = true)}
+      onMouseLeave={() => (isPaused.current = false)}
+    >
+      <div className="ho-feature__chip-tl">{current.model}</div>
+      <div className="ho-feature__chip-tr">{current.fn}</div>
+      <div className="ho-feature__chip-body">
+        {SLIDES.map((s, i) => (
+          <div
+            key={s.slug}
+            className="ho-feature__chip-slide"
+            data-active={String(i === active)}
+          >
+            <Image
+              src={`/products/${s.slug}/product-1.jpg`}
+              alt={`Line Tech ${s.model}`}
+              fill
+              className="ho-feature__chip-img"
+              sizes="(max-width: 1000px) 100vw, 50vw"
+              priority={i === 0}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="ho-feature__chip-bl">LINE TECH</div>
+      <div className="ho-feature__chip-br">
+        {current.gas} · {current.flow}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -7,7 +7,12 @@
  */
 import type { Locale } from "./home";
 
-export type InquiryTypeId = "sales" | "support" | "partnership" | "general";
+export type InquiryTypeId =
+  | "sales"
+  | "support"
+  | "partnership"
+  | "general"
+  | "site-visit";
 
 export type ContactFormCopy = {
   heading: string;
@@ -156,6 +161,15 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
           },
         },
         { id: "general", label: "일반 문의" },
+        {
+          id: "site-visit",
+          label: "현장 방문 지원",
+          extraField: {
+            label: "방문 위치 또는 설비 정보",
+            placeholder: "예: 공정 가스 라인, 설치 현장 주소",
+            required: false,
+          },
+        },
       ],
       required: "필수",
       submit: "문의 보내기",
@@ -259,6 +273,15 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
           },
         },
         { id: "general", label: "General inquiry" },
+        {
+          id: "site-visit",
+          label: "On-site support visit",
+          extraField: {
+            label: "Site or equipment details",
+            placeholder: "e.g. process gas line, facility location",
+            required: false,
+          },
+        },
       ],
       required: "Required",
       submit: "Send inquiry",
@@ -367,6 +390,15 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
           },
         },
         { id: "general", label: "一般咨询" },
+        {
+          id: "site-visit",
+          label: "现场支持访问",
+          extraField: {
+            label: "现场或设备信息",
+            placeholder: "例如：工艺气体管路、设施地址",
+            required: false,
+          },
+        },
       ],
       required: "必填",
       submit: "发送咨询",

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -192,6 +192,69 @@ export const allDrawingsQuery = defineQuery(`
   }
 `);
 
+export const allFaqGroupsQuery = defineQuery(`
+  *[_type == "faqGroup"] | order(coalesce(order, 99) asc) {
+    "id": id.current,
+    "heading": {
+      "ko": coalesce(heading[language == "ko"][0].value, heading[language == "en"][0].value),
+      "en": coalesce(heading[language == "en"][0].value, heading[language == "ko"][0].value),
+      "zh": coalesce(heading[language == "zh"][0].value, heading[language == "en"][0].value)
+    },
+    "questions": questions[] {
+      id,
+      "q": {
+        "ko": coalesce(q[language == "ko"][0].value, q[language == "en"][0].value),
+        "en": coalesce(q[language == "en"][0].value, q[language == "ko"][0].value),
+        "zh": coalesce(q[language == "zh"][0].value, q[language == "en"][0].value)
+      },
+      "a": {
+        "ko": coalesce(a[language == "ko"][0].value, a[language == "en"][0].value),
+        "en": coalesce(a[language == "en"][0].value, a[language == "ko"][0].value),
+        "zh": coalesce(a[language == "zh"][0].value, a[language == "en"][0].value)
+      }
+    }
+  }
+`);
+
+const APPLICATION_PROJECTION = `
+  "slug": slug.current,
+  "title": {
+    "ko": coalesce(title[language == "ko"][0].value, title[language == "en"][0].value),
+    "en": coalesce(title[language == "en"][0].value, title[language == "ko"][0].value),
+    "zh": coalesce(title[language == "zh"][0].value, title[language == "en"][0].value)
+  },
+  "lede": {
+    "ko": coalesce(lede[language == "ko"][0].value, lede[language == "en"][0].value),
+    "en": coalesce(lede[language == "en"][0].value, lede[language == "ko"][0].value),
+    "zh": coalesce(lede[language == "zh"][0].value, lede[language == "en"][0].value)
+  },
+  "body": {
+    "ko": coalesce(body[language == "ko"][0].value, body[language == "en"][0].value),
+    "en": coalesce(body[language == "en"][0].value, body[language == "ko"][0].value),
+    "zh": coalesce(body[language == "zh"][0].value, body[language == "en"][0].value)
+  },
+  recommendedSeries,
+  relatedCategories
+`;
+
+export const allApplicationsQuery = defineQuery(`
+  *[_type == "application"] | order(coalesce(order, 99) asc) {
+    ${APPLICATION_PROJECTION}
+  }
+`);
+
+export const applicationBySlugQuery = defineQuery(`
+  *[_type == "application" && slug.current == $slug][0] {
+    ${APPLICATION_PROJECTION}
+  }
+`);
+
+export const applicationSlugsQuery = defineQuery(`
+  *[_type == "application" && defined(slug.current)] {
+    "slug": slug.current
+  }
+`);
+
 export const resourceCountsQuery = defineQuery(`
   {
     "catalogues": count(*[_type == "catalogue"]),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     css: false,
     passWithNoTests: true,
-    // Playwright owns the e2e/ directory.
-    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
+    // Playwright owns e2e/; .claude/ holds temporary worktrees.
+    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**", ".claude/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
## Summary
- Add `faqGroup` and `application` Sanity document types so Line Tech staff can edit FAQ content and application pages without a deploy
- FAQ and Applications pages fetch from Sanity at request time, with automatic fallback to the static TypeScript files while the dataset is empty
- Add "On-site support visit" / 현장 방문 지원 as a contact form inquiry type, routing on-site visit requests through the form rather than directing users to email directly

## Test plan
- Open `/studio` → confirm "FAQ Groups" and "Applications" appear in the sidebar
- Create a test FAQ group doc in Studio; visit `/en/faq` and confirm it renders
- Create a test application doc; visit `/en/applications/[slug]` and confirm body paragraphs render correctly (separated by blank lines in the text field)
- Visit `/en/contact` → confirm "On-site support visit" appears in the topic dropdown and its extra field appears on select

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)