### PR TITLE
feat(contact): make global network region cards clickable (#152)

### DIFF
--- a/src/app/[locale]/contact/contact-page.css
+++ b/src/app/[locale]/contact/contact-page.css
@@ -292,6 +292,29 @@
   padding: 20px;
   display: grid;
   gap: 6px;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+}
+.ct-dist__card:hover {
+  border-color: var(--pd-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(24, 86, 134, 0.08);
+}
+.ct-dist__card:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ct-dist__card {
+    transition: none;
+  }
+  .ct-dist__card:hover {
+    transform: none;
+  }
 }
 .ct-dist__region {
   font-size: var(--lt-fs-xs);

--- a/src/app/[locale]/contact/network/[region]/page.tsx
+++ b/src/app/[locale]/contact/network/[region]/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { Link } from "@/i18n/navigation";
+import { LT_CONTACT, type DistributorRegionId } from "@/lib/content/contact";
+import { routing, type Locale } from "@/i18n/routing";
+import "./region-page.css";
+
+const REGION_IDS: DistributorRegionId[] = ["kr", "cn", "sea", "other"];
+
+type Props = {
+  params: Promise<{ locale: Locale; region: string }>;
+};
+
+export function generateStaticParams() {
+  return routing.locales.flatMap((locale) =>
+    REGION_IDS.map((region) => ({ locale, region })),
+  );
+}
+
+function findRegion(locale: Locale, regionId: string) {
+  return LT_CONTACT[locale].distributors.regions.find((r) => r.id === regionId);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, region } = await params;
+  const r = findRegion(locale, region);
+  if (!r) return {};
+  const c = LT_CONTACT[locale];
+  return {
+    title: `${r.name} — ${c.distributors.heading} — Line Tech`,
+    description: c.regionPage.comingSoonBody,
+    robots: { index: false, follow: true },
+  };
+}
+
+export default async function RegionPlaceholderPage({ params }: Props) {
+  const { locale, region } = await params;
+  setRequestLocale(locale);
+
+  const r = findRegion(locale, region);
+  if (!r) notFound();
+
+  const tCommon = await getTranslations("common");
+  const c = LT_CONTACT[locale];
+
+  const breadcrumbs = [
+    { label: tCommon("home"), href: "/" },
+    { label: c.breadcrumbLabel, href: "/contact" },
+    { label: r.name },
+  ];
+
+  return (
+    <main className="lt-wrap">
+      <Breadcrumbs items={breadcrumbs} />
+      <section className="ct-region">
+        <span className="ct-region__eyebrow">{c.distributors.heading}</span>
+        <h1 className="ct-region__title">{r.name}</h1>
+        <p className="ct-region__status">{r.status}</p>
+        <div className="ct-region__panel">
+          <h2 className="ct-region__soon-title">
+            {c.regionPage.comingSoonTitle}
+          </h2>
+          <p className="ct-region__soon-body">{c.regionPage.comingSoonBody}</p>
+        </div>
+        <Link href="/contact" className="ct-region__back">
+          ← {c.regionPage.backLabel}
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/contact/network/[region]/region-page.css
+++ b/src/app/[locale]/contact/network/[region]/region-page.css
@@ -1,0 +1,65 @@
+.ct-region {
+  display: grid;
+  gap: 16px;
+  max-width: 720px;
+  padding: 32px 0 64px;
+}
+.ct-region__eyebrow {
+  font: 500 var(--lt-fs-xs) / 1 var(--lt-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+}
+:lang(ko) .ct-region__eyebrow,
+:lang(zh) .ct-region__eyebrow {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.ct-region__title {
+  margin: 0;
+  font: 500 var(--lt-fs-2xl) / 1.15 var(--lt-sans);
+  letter-spacing: -0.015em;
+  color: var(--pd-fg-strong);
+}
+.ct-region__status {
+  margin: 0;
+  font-size: var(--lt-fs-base);
+  line-height: 1.5;
+  color: var(--pd-muted);
+}
+.ct-region__panel {
+  margin-top: 8px;
+  padding: 28px;
+  border: 1px solid var(--pd-border);
+  border-radius: var(--pd-r-lg);
+  background: var(--pd-surface);
+  display: grid;
+  gap: 8px;
+}
+.ct-region__soon-title {
+  margin: 0;
+  font: 500 var(--lt-fs-lg) / 1.2 var(--lt-sans);
+  color: var(--pd-fg-strong);
+}
+.ct-region__soon-body {
+  margin: 0;
+  font-size: var(--lt-fs-sm);
+  line-height: 1.6;
+  color: var(--pd-fg);
+}
+.ct-region__back {
+  justify-self: start;
+  margin-top: 8px;
+  font-size: var(--lt-fs-sm);
+  color: var(--pd-primary);
+  text-decoration: none;
+}
+.ct-region__back:hover {
+  text-decoration: underline;
+}
+.ct-region__back:focus-visible {
+  outline: 2px solid var(--pd-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -3,6 +3,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { buildContactMetadata } from "@/lib/seo";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { Button } from "@/components/ui/Button";
+import { Link } from "@/i18n/navigation";
 import { LT_CONTACT } from "@/lib/content/contact";
 import { LT_SHELL } from "@/lib/content/shell";
 import type { Locale } from "@/lib/content/home";
@@ -167,9 +168,14 @@ export default async function ContactPage({ params, searchParams }: Props) {
           </header>
           <ul className="ct-dist__grid">
             {c.distributors.regions.map((region) => (
-              <li key={region.id} className="ct-dist__card">
-                <span className="ct-dist__region">{region.name}</span>
-                <span className="ct-dist__status">{region.status}</span>
+              <li key={region.id}>
+                <Link
+                  href={`/contact/network/${region.id}`}
+                  className="ct-dist__card"
+                >
+                  <span className="ct-dist__region">{region.name}</span>
+                  <span className="ct-dist__status">{region.status}</span>
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -71,10 +71,18 @@ export type ContactFormCopy = {
   };
 };
 
+export type DistributorRegionId = "kr" | "cn" | "sea" | "other";
+
 export type DistributorRegion = {
-  id: string;
+  id: DistributorRegionId;
   name: string;
   status: string;
+};
+
+export type RegionPageCopy = {
+  comingSoonTitle: string;
+  comingSoonBody: string;
+  backLabel: string;
 };
 
 export type ContactContent = {
@@ -95,6 +103,7 @@ export type ContactContent = {
     lede: string;
     regions: DistributorRegion[];
   };
+  regionPage: RegionPageCopy;
   map: {
     heading: string;
     caption: string;
@@ -220,6 +229,12 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
           status: "유럽 · 북미 · 일본 — 본사 직접 문의",
         },
       ],
+    },
+    regionPage: {
+      comingSoonTitle: "준비 중입니다",
+      comingSoonBody:
+        "이 지역의 페이지는 곧 공개될 예정입니다. 그동안 문의는 본사로 직접 보내주세요.",
+      backLabel: "문의 페이지로 돌아가기",
     },
     map: {
       heading: "오시는 길",
@@ -351,6 +366,12 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
         },
       ],
     },
+    regionPage: {
+      comingSoonTitle: "Coming soon",
+      comingSoonBody:
+        "A dedicated page for this region is on the way. In the meantime, please reach out to headquarters directly.",
+      backLabel: "Back to contact page",
+    },
     map: {
       heading: "Find us",
       caption: "Line Tech HQ · Daejeon, Korea",
@@ -474,6 +495,12 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
           status: "欧洲 · 北美 · 日本 — 请联系总部",
         },
       ],
+    },
+    regionPage: {
+      comingSoonTitle: "敬请期待",
+      comingSoonBody:
+        "该地区的专属页面即将上线。在此期间，欢迎您直接联系总部咨询。",
+      backLabel: "返回联系页面",
     },
     map: {
       heading: "公司位置",


### PR DESCRIPTION
## Summary

- Each of the four region cards on `/contact` (Korea HQ, China, SEA, Other) now links to a per-region placeholder page at `/contact/network/<id>`.
- Placeholder shows the region name, current network status, a "Coming soon" panel, and a back link. Locale-aware in ko / en / zh.
- Card affordances added: hover lift + brand-blue border, `:focus-visible` outline, reduced-motion respected.
- Region pages set `robots: { index: false, follow: true }` so the stubs don't get indexed while we wait for real subsidiary/distributor content.

Closes #152.

## Test plan

- [ ] Visit `/ko/contact`, `/en/contact`, `/zh/contact` — all four cards visibly clickable (hover, focus ring, keyboard Tab/Enter)
- [ ] Click each card → lands on the placeholder with the right region name and locale
- [ ] Direct visit to `/contact/network/foo` → 404
- [ ] Back link returns to `/contact` in current locale
- [ ] `vitest run` passes (57/57 ✓ locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)