### PR TITLE
feat(catalogue): KO/ZH translation drafts for 2026 lineup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,11 @@ yarn-error.log*
 docs/handoff/uploads/
 
 # extracted catalogue page renders — regenerate from docs/handoff/uploads/catalog.pdf
-docs/catalog-extract/
+# (allow translation drafts — they're hand-curated, not regenerated)
+docs/catalog-extract/*
+!docs/catalog-extract/2026/
+docs/catalog-extract/2026/*
+!docs/catalog-extract/2026/translations/
 
 # internal-only drafts and planning docs (lives in ~/Dev/linetech/company-docs-private/)
 docs/internal/

--- a/docs/catalog-extract/2026/translations/do400.md
+++ b/docs/catalog-extract/2026/translations/do400.md
@@ -1,0 +1,21 @@
+# DO400 translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ex1000c.md
+++ b/docs/catalog-extract/2026/translations/ex1000c.md
@@ -1,0 +1,3 @@
+# EX1000C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ex1000m.md
+++ b/docs/catalog-extract/2026/translations/ex1000m.md
@@ -1,0 +1,3 @@
+# EX1000M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ex70c.md
+++ b/docs/catalog-extract/2026/translations/ex70c.md
@@ -1,0 +1,3 @@
+# EX70C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ex70m.md
+++ b/docs/catalog-extract/2026/translations/ex70m.md
@@ -1,0 +1,3 @@
+# EX70M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/lepc.md
+++ b/docs/catalog-extract/2026/translations/lepc.md
@@ -1,0 +1,3 @@
+# LEPC translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/lti1000.md
+++ b/docs/catalog-extract/2026/translations/lti1000.md
@@ -1,0 +1,3 @@
+# LTI1000 translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/lti2000.md
+++ b/docs/catalog-extract/2026/translations/lti2000.md
@@ -1,0 +1,3 @@
+# LTI2000 translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/m2030va.md
+++ b/docs/catalog-extract/2026/translations/m2030va.md
@@ -1,0 +1,3 @@
+# M2030VA translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/m2200va.md
+++ b/docs/catalog-extract/2026/translations/m2200va.md
@@ -1,0 +1,21 @@
+# M2200VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/m3030va.md
+++ b/docs/catalog-extract/2026/translations/m3030va.md
@@ -1,0 +1,21 @@
+# M3030VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/m3200va.md
+++ b/docs/catalog-extract/2026/translations/m3200va.md
@@ -1,0 +1,21 @@
+# M3200VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/md150c.md
+++ b/docs/catalog-extract/2026/translations/md150c.md
@@ -1,0 +1,3 @@
+# MD150C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md150m.md
+++ b/docs/catalog-extract/2026/translations/md150m.md
@@ -1,0 +1,3 @@
+# MD150M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md30c.md
+++ b/docs/catalog-extract/2026/translations/md30c.md
@@ -1,0 +1,3 @@
+# MD30C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md30m.md
+++ b/docs/catalog-extract/2026/translations/md30m.md
@@ -1,0 +1,3 @@
+# MD30M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md400c.md
+++ b/docs/catalog-extract/2026/translations/md400c.md
@@ -1,0 +1,3 @@
+# MD400C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md400m.md
+++ b/docs/catalog-extract/2026/translations/md400m.md
@@ -1,0 +1,3 @@
+# MD400M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md500c.md
+++ b/docs/catalog-extract/2026/translations/md500c.md
@@ -1,0 +1,3 @@
+# MD500C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md500m.md
+++ b/docs/catalog-extract/2026/translations/md500m.md
@@ -1,0 +1,3 @@
+# MD500M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md600c.md
+++ b/docs/catalog-extract/2026/translations/md600c.md
@@ -1,0 +1,3 @@
+# MD600C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md600m.md
+++ b/docs/catalog-extract/2026/translations/md600m.md
@@ -1,0 +1,3 @@
+# MD600M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md700c.md
+++ b/docs/catalog-extract/2026/translations/md700c.md
@@ -1,0 +1,3 @@
+# MD700C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md700m.md
+++ b/docs/catalog-extract/2026/translations/md700m.md
@@ -1,0 +1,3 @@
+# MD700M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md800c.md
+++ b/docs/catalog-extract/2026/translations/md800c.md
@@ -1,0 +1,3 @@
+# MD800C translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/md800m.md
+++ b/docs/catalog-extract/2026/translations/md800m.md
@@ -1,0 +1,3 @@
+# MD800M translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ms2150va.md
+++ b/docs/catalog-extract/2026/translations/ms2150va.md
@@ -1,0 +1,3 @@
+# MS2150VA translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ms2400va.md
+++ b/docs/catalog-extract/2026/translations/ms2400va.md
@@ -1,0 +1,3 @@
+# MS2400VA translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ms2500va.md
+++ b/docs/catalog-extract/2026/translations/ms2500va.md
@@ -1,0 +1,21 @@
+# MS2500VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms2600va.md
+++ b/docs/catalog-extract/2026/translations/ms2600va.md
@@ -1,0 +1,21 @@
+# MS2600VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms2700va.md
+++ b/docs/catalog-extract/2026/translations/ms2700va.md
@@ -1,0 +1,3 @@
+# MS2700VA translations
+
+_TODO: no source prose in records.json — borrow from analogue equivalent or write fresh._

--- a/docs/catalog-extract/2026/translations/ms2800va.md
+++ b/docs/catalog-extract/2026/translations/ms2800va.md
@@ -1,0 +1,21 @@
+# MS2800VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3150va.md
+++ b/docs/catalog-extract/2026/translations/ms3150va.md
@@ -1,0 +1,21 @@
+# MS3150VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3400va.md
+++ b/docs/catalog-extract/2026/translations/ms3400va.md
@@ -1,0 +1,21 @@
+# MS3400VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3500va.md
+++ b/docs/catalog-extract/2026/translations/ms3500va.md
@@ -1,0 +1,21 @@
+# MS3500VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3600va.md
+++ b/docs/catalog-extract/2026/translations/ms3600va.md
@@ -1,0 +1,21 @@
+# MS3600VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3700va.md
+++ b/docs/catalog-extract/2026/translations/ms3700va.md
@@ -1,0 +1,21 @@
+# MS3700VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |

--- a/docs/catalog-extract/2026/translations/ms3800va.md
+++ b/docs/catalog-extract/2026/translations/ms3800va.md
@@ -1,0 +1,21 @@
+# MS3800VA translations
+
+## description
+
+- **en (cleaned):** Line Tech mass flow controllers are widely deployed in semiconductor manufacturing and many other gas-control applications.
+- **ko (draft):** 라인테크의 매스 플로우 컨트롤러는 반도체 산업을 비롯해 다양한 가스 제어 시스템에 폭넓게 사용되고 있습니다.
+- **zh (draft):** Line Tech 质量流量控制器广泛应用于半导体制造及其他多种气体控制系统。
+
+## features
+
+| en (cleaned)                            | ko (draft)                | zh (draft)           |
+| --------------------------------------- | ------------------------- | -------------------- |
+| Accurate at low flow rates              | 저유량에서도 정확한 측정  | 低流量下精准测量     |
+| Fast response time                      | 빠른 응답 속도            | 快速响应             |
+| Compact connection design               | 컴팩트한 연결 구조        | 紧凑连接设计         |
+| Removable, highly stable sensor         | 분리 가능한 고안정성 센서 | 可拆卸高稳定性传感器 |
+| High corrosion resistance               | 우수한 내식성             | 高耐腐蚀性           |
+| Excellent linearity                     | 우수한 직선성             | 卓越的线性度         |
+| Excellent long-term stability           | 우수한 장기 안정성        | 卓越的长期稳定性     |
+| Modular design                          | 모듈식 설계               | 模块化设计           |
+| Wide operating pressure range available | 넓은 작동 압력 범위 제공  | 宽工作压力范围可选   |


### PR DESCRIPTION
Closes #166.

## Summary

- **13 products with prose** (DO400, M-series, MS-series analogues) share an identical EN source in `records.json`. All 13 ship the same cleaned-EN + KO draft + ZH draft.
- **25 products with no source prose** (MD-series digital, EX, LD/LTI, LM, LEPC, plus M2030VA / MS2150VA / MS2400VA / MS2700VA) ship as TODO placeholders for hand-authoring during the catalogue review pass.
- Output lives at `docs/catalog-extract/2026/translations/<slug>.md` (38 files). `.gitignore` updated with a narrow allow-rule so the wider `catalog-extract/` tree stays ignored.

## Deviations from issue spec

The issue assumed:
- Korean-source .docx manuals → **wrong**, all 15 .docx are English-only (zero Hangul). Pivoted to EN(cleaned) → KO + ZH.
- A `productLabel` field per product → **doesn't exist** in records.json. Omitted.
- A standalone `@anthropic-ai/sdk` script → **dropped**, since Claude Code can produce the drafts directly without a new dep, API key, or script to maintain.

## Test plan

- [ ] Native KO speaker reviews drafts in the 13 with-prose files; flag any that should switch from "매스 플로우 컨트롤러" (transliteration) to "질량 유량 제어기" (technical Korean), or any term-of-art mismatches
- [ ] ZH reviewer sanity-checks Simplified-Chinese phrasing
- [ ] For the 25 placeholders: decide per-product whether to borrow analogue prose or write fresh
- [ ] No model codes / units / spec numbers leaked into KO or ZH (spot check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)