### PR TITLE
fix(data-room): rework misclassified PDFs and link manuals correctly

### DIFF
--- a/sanity/schemaTypes/datasheet.ts
+++ b/sanity/schemaTypes/datasheet.ts
@@ -12,11 +12,14 @@ export const datasheet = defineType({
       validation: (r) => r.required(),
     }),
     defineField({
-      name: "model",
-      title: "Model",
-      type: "string",
-      description: "Product model code (e.g. M3030VA)",
-      validation: (r) => r.required(),
+      name: "models",
+      title: "Models",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
+      description:
+        "Product model codes covered by this datasheet (e.g. M3030VA). Multiple entries supported.",
+      validation: (r) => r.min(1),
     }),
     defineField({
       name: "series",
@@ -48,13 +51,32 @@ export const datasheet = defineType({
       title: "Published",
       type: "date",
     }),
+    defineField({
+      name: "archived",
+      title: "Archived",
+      type: "boolean",
+      description:
+        "Hide from Data Room and product pages (e.g. retired product). File remains in Sanity.",
+      initialValue: false,
+    }),
   ],
   preview: {
-    select: { title: "title", model: "model", series: "series" },
-    prepare({ title, model, series }) {
+    select: {
+      title: "title",
+      models: "models",
+      series: "series",
+      archived: "archived",
+    },
+    prepare({ title, models, series, archived }) {
+      const modelLabel =
+        Array.isArray(models) && models.length > 0
+          ? models.join(", ")
+          : undefined;
       return {
-        title: title ?? "(untitled)",
-        subtitle: [model, series].filter(Boolean).join(" · "),
+        title: archived
+          ? `[Archived] ${title ?? "(untitled)"}`
+          : (title ?? "(untitled)"),
+        subtitle: [modelLabel, series].filter(Boolean).join(" · "),
       };
     },
   },

--- a/sanity/schemaTypes/drawing.ts
+++ b/sanity/schemaTypes/drawing.ts
@@ -12,11 +12,14 @@ export const drawing = defineType({
       validation: (r) => r.required(),
     }),
     defineField({
-      name: "model",
-      title: "Model",
-      type: "string",
-      description: "Product model code (e.g. M3030VA)",
-      validation: (r) => r.required(),
+      name: "models",
+      title: "Models",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
+      description:
+        "Product model codes covered by this drawing (e.g. M3030VA). Multiple entries supported when one drawing covers several models.",
+      validation: (r) => r.min(1),
     }),
     defineField({
       name: "series",
@@ -43,11 +46,34 @@ export const drawing = defineType({
       type: "file",
       options: { accept: ".stp,.step" },
     }),
+    defineField({
+      name: "pdfFile",
+      title: "PDF dimensional drawing",
+      type: "file",
+      options: { accept: ".pdf" },
+    }),
+    defineField({
+      name: "archived",
+      title: "Archived",
+      type: "boolean",
+      description:
+        "Hide from Data Room and product pages (e.g. retired product). File remains in Sanity.",
+      initialValue: false,
+    }),
   ],
   preview: {
-    select: { title: "title", model: "model" },
-    prepare({ title, model }) {
-      return { title: title ?? "(untitled)", subtitle: model };
+    select: { title: "title", models: "models", archived: "archived" },
+    prepare({ title, models, archived }) {
+      const modelLabel =
+        Array.isArray(models) && models.length > 0
+          ? models.join(", ")
+          : undefined;
+      return {
+        title: archived
+          ? `[Archived] ${title ?? "(untitled)"}`
+          : (title ?? "(untitled)"),
+        subtitle: modelLabel,
+      };
     },
   },
 });

--- a/sanity/schemaTypes/manual.ts
+++ b/sanity/schemaTypes/manual.ts
@@ -12,10 +12,13 @@ export const manual = defineType({
       validation: (r) => r.required(),
     }),
     defineField({
-      name: "model",
-      title: "Model",
-      type: "string",
-      description: "Product model code (e.g. M3030VA)",
+      name: "models",
+      title: "Models",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
+      description:
+        "Product model codes covered by this manual (e.g. M3030VA). Multiple entries when the manual covers a series (e.g. MS3500VA + MS3600VA).",
     }),
     defineField({
       name: "series",
@@ -47,13 +50,32 @@ export const manual = defineType({
       title: "Published",
       type: "date",
     }),
+    defineField({
+      name: "archived",
+      title: "Archived",
+      type: "boolean",
+      description:
+        "Hide from Data Room and product pages (e.g. retired product). File remains in Sanity.",
+      initialValue: false,
+    }),
   ],
   preview: {
-    select: { title: "title", model: "model", series: "series" },
-    prepare({ title, model, series }) {
+    select: {
+      title: "title",
+      models: "models",
+      series: "series",
+      archived: "archived",
+    },
+    prepare({ title, models, series, archived }) {
+      const modelLabel =
+        Array.isArray(models) && models.length > 0
+          ? models.join(", ")
+          : undefined;
       return {
-        title: title ?? "(untitled)",
-        subtitle: [model, series].filter(Boolean).join(" · "),
+        title: archived
+          ? `[Archived] ${title ?? "(untitled)"}`
+          : (title ?? "(untitled)"),
+        subtitle: [modelLabel, series].filter(Boolean).join(" · "),
       };
     },
   },

--- a/scripts/rework-doc-types.ts
+++ b/scripts/rework-doc-types.ts
@@ -1,0 +1,328 @@
+/**
+ * One-shot Sanity migration to fix doc-type drift introduced by PR #167.
+ *
+ * What it does:
+ *   1. Move 30 `catalogue` docs → `drawing` docs (they're dimensional drawings,
+ *      not brochures). PDF asset is reused as `pdfFile`. `models[]` and
+ *      `series` carry over. Title "<X> Brochure" → "<X> Dimensional Drawing".
+ *   2. Move 4 `datasheet` docs → `manual` docs (MS3150, MS3400, MS3700,
+ *      MS3800). They're full instruction manuals.
+ *   3. Delete the MS3600 standalone `datasheet` — covered by the existing
+ *      MS3500&MS3600 combined manual.
+ *   4. Delete the M3030 "Maunal.pdf" + M3200 "Maunal.pdf" duplicate manuals
+ *      (keep the cleaner "M3030 Series.pdf" / "M3200 Series.pdf" versions).
+ *   5. Archive `M3100 Series Manual` (model is retired in 2026 lineup).
+ *
+ * Run:  pnpm tsx scripts/rework-doc-types.ts
+ *       pnpm tsx scripts/rework-doc-types.ts --dry-run
+ *
+ * Idempotent — re-running is a no-op once everything is migrated.
+ */
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+
+function loadEnv(path: string) {
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) process.env[m[1]] ??= m[2].trimEnd();
+  }
+}
+loadEnv(".env.local");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+if (!projectId || !dataset || !token) {
+  console.error("Missing Sanity env vars (project id / dataset / write token)");
+  process.exit(1);
+}
+
+const dryRun = process.argv.includes("--dry-run");
+
+const client = createClient({
+  projectId,
+  dataset,
+  apiVersion: "2024-01-01",
+  useCdn: false,
+  token,
+});
+
+type Catalogue = {
+  _id: string;
+  title: string;
+  models?: string[] | null;
+  series?: string | null;
+  publishedAt?: string | null;
+  fileRef?: string;
+};
+
+type Datasheet = {
+  _id: string;
+  title: string;
+  model?: string | null;
+  series?: string | null;
+  rev?: string | null;
+  publishedAt?: string | null;
+  fileRef?: string;
+};
+
+type Manual = {
+  _id: string;
+  title: string;
+  model?: string | null;
+  models?: string[] | null;
+};
+type ProductRef = { model: string };
+
+function reworkTitle(oldTitle: string): string {
+  return (
+    oldTitle
+      .replace(/\s*\(Controller \+ Meter\)\s*$/, "")
+      .replace(/\s*Brochure\s*$/, "")
+      .trim() + " Dimensional Drawing"
+  );
+}
+
+function deriveModels(title: string, productModels: string[]): string[] {
+  const upper = title.toUpperCase();
+  const tokens = upper.split(/[^A-Z0-9]+/).filter(Boolean);
+
+  // 1. Direct exact-token match (e.g. "M3030VA Brochure" → ["M3030VA"]).
+  const direct = productModels.filter((m) => tokens.includes(m.toUpperCase()));
+  if (direct.length > 0) return direct;
+
+  // 2. Token-prefix match. Manual titles use shorter prefixes ("M3030 Manual"
+  //    for product "M3030VA"). Each token expands to all products that start
+  //    with it; require ≥3 chars to avoid spurious matches on series letters.
+  const STOP = new Set([
+    "MANUAL",
+    "MAUNAL",
+    "MAUNUAL",
+    "SERIES",
+    "BROCHURE",
+    "DRAWING",
+    "DIMENSIONAL",
+    "CONTROLLER",
+    "METER",
+    "AND",
+    "OR",
+  ]);
+  const expanded = new Set<string>();
+  for (const t of tokens) {
+    if (t.length < 3) continue;
+    if (STOP.has(t)) continue;
+    for (const m of productModels) {
+      if (m.toUpperCase().startsWith(t)) expanded.add(m);
+    }
+  }
+  if (expanded.size > 0) return [...expanded];
+
+  return [];
+}
+
+async function main() {
+  const products = await client.fetch<ProductRef[]>(
+    `*[_type == "product"]{ model }`,
+  );
+  const productModels = products.map((p) => p.model);
+
+  const catalogues = await client.fetch<Catalogue[]>(`
+    *[_type == "catalogue"] | order(title asc) {
+      _id, title, models, series, publishedAt,
+      "fileRef": file.asset._ref
+    }
+  `);
+
+  const datasheets = await client.fetch<Datasheet[]>(`
+    *[_type == "datasheet"] | order(title asc) {
+      _id, title, model, series, rev, publishedAt,
+      "fileRef": file.asset._ref
+    }
+  `);
+
+  const manuals = await client.fetch<Manual[]>(
+    `*[_type == "manual"]{_id, title, model, models} | order(title asc)`,
+  );
+
+  // Plan datasheet → manual moves
+  const datasheetMigrate = new Set(["MS3150", "MS3400", "MS3700", "MS3800"]);
+  const datasheetDelete = new Set(["MS3600"]);
+
+  // Plan duplicate manual deletes (keep the "Series" version, drop "Manual" alias)
+  const manualDeleteIds: string[] = [];
+  for (const dupModel of ["M3030", "M3200"]) {
+    const dupes = manuals.filter((m) => m.model === dupModel);
+    if (dupes.length > 1) {
+      const keep = dupes.find((m) => /Series/i.test(m.title));
+      const drop = dupes.filter((m) => m._id !== keep?._id);
+      if (keep) manualDeleteIds.push(...drop.map((m) => m._id));
+    }
+  }
+
+  // Plan archive (retired)
+  const retiredManual = manuals.find(
+    (m) => m.model === "M3100" && /Manual/i.test(m.title),
+  );
+
+  // Plan manual model→models[] migration (existing docs use legacy `model` prefix
+  // like "M3030" while products use full codes like "M3030VA"). For each manual
+  // without `models[]` set, derive from title using the same algorithm as the
+  // catalogue→drawing migration. Skips docs already having models[].
+  const productModelsList = products.map((p) => p.model);
+  const manualModelMigrations: Array<{
+    id: string;
+    title: string;
+    models: string[];
+  }> = [];
+  const manualModelSkipped: string[] = [];
+  for (const m of manuals) {
+    if (manualDeleteIds.includes(m._id)) continue;
+    if (m._id === retiredManual?._id) continue;
+    if (m.models && m.models.length > 0) continue;
+    const derived = deriveModels(m.title, productModelsList);
+    if (derived.length > 0) {
+      manualModelMigrations.push({
+        id: m._id,
+        title: m.title,
+        models: derived,
+      });
+    } else {
+      manualModelSkipped.push(m.title);
+    }
+  }
+
+  // ----- Print plan -----
+  console.log(`\nPlan summary:\n`);
+
+  console.log(`  catalogue → drawing  (${catalogues.length} docs):`);
+  for (const c of catalogues) {
+    const models =
+      c.models && c.models.length > 0
+        ? c.models
+        : deriveModels(c.title, productModels);
+    console.log(
+      `    "${c.title}" → "${reworkTitle(c.title)}"  models=[${models.join(", ")}]`,
+    );
+  }
+
+  const dsMigrate = datasheets.filter((d) =>
+    d.model ? datasheetMigrate.has(d.model) : false,
+  );
+  const dsDelete = datasheets.filter((d) =>
+    d.model ? datasheetDelete.has(d.model) : false,
+  );
+  console.log(`\n  datasheet → manual  (${dsMigrate.length} docs):`);
+  for (const d of dsMigrate) {
+    console.log(`    "${d.title}" (model=${d.model})`);
+  }
+
+  console.log(`\n  delete datasheet (collision)  (${dsDelete.length} docs):`);
+  for (const d of dsDelete) console.log(`    "${d.title}" (model=${d.model})`);
+
+  console.log(
+    `\n  delete duplicate manuals  (${manualDeleteIds.length} docs):`,
+  );
+  for (const id of manualDeleteIds) {
+    const m = manuals.find((x) => x._id === id);
+    if (m) console.log(`    "${m.title}" (model=${m.model})`);
+  }
+
+  console.log(
+    `\n  archive (retired)  (${retiredManual ? 1 : 0} doc${retiredManual ? "" : "s"}):`,
+  );
+  if (retiredManual)
+    console.log(`    "${retiredManual.title}" (model=${retiredManual.model})`);
+
+  console.log(
+    `\n  manual model→models[]  (${manualModelMigrations.length} docs):`,
+  );
+  for (const m of manualModelMigrations) {
+    console.log(`    "${m.title}" → models=[${m.models.join(", ")}]`);
+  }
+  if (manualModelSkipped.length > 0) {
+    console.log(
+      `\n  manual model→models[] skipped (no product match — likely product not yet seeded):`,
+    );
+    for (const t of manualModelSkipped) console.log(`    "${t}"`);
+  }
+
+  if (dryRun) {
+    console.log(`\n--dry-run: no writes performed.`);
+    return;
+  }
+
+  // ----- Execute -----
+  let tx = client.transaction();
+
+  for (const c of catalogues) {
+    const models =
+      c.models && c.models.length > 0
+        ? c.models
+        : deriveModels(c.title, productModels);
+    if (models.length === 0) {
+      console.warn(
+        `  skipping ${c._id} — could not derive models from title "${c.title}"`,
+      );
+      continue;
+    }
+    if (!c.fileRef) {
+      console.warn(`  skipping ${c._id} — no file asset`);
+      continue;
+    }
+    tx = tx.create({
+      _type: "drawing",
+      title: reworkTitle(c.title),
+      models,
+      ...(c.series ? { series: c.series } : {}),
+      pdfFile: {
+        _type: "file",
+        asset: { _type: "reference", _ref: c.fileRef },
+      },
+      archived: false,
+    });
+    tx = tx.delete(c._id);
+  }
+
+  for (const d of dsMigrate) {
+    if (!d.fileRef) {
+      console.warn(`  skipping ${d._id} — no file asset`);
+      continue;
+    }
+    tx = tx.create({
+      _type: "manual",
+      title: d.title,
+      ...(d.model ? { model: d.model } : {}),
+      ...(d.series ? { series: d.series } : {}),
+      ...(d.rev ? { rev: d.rev } : {}),
+      ...(d.publishedAt ? { publishedAt: d.publishedAt } : {}),
+      file: { _type: "file", asset: { _type: "reference", _ref: d.fileRef } },
+      archived: false,
+    });
+    tx = tx.delete(d._id);
+  }
+
+  for (const d of dsDelete) {
+    tx = tx.delete(d._id);
+  }
+
+  for (const id of manualDeleteIds) {
+    tx = tx.delete(id);
+  }
+
+  if (retiredManual) {
+    tx = tx.patch(retiredManual._id, (p) => p.set({ archived: true }));
+  }
+
+  for (const m of manualModelMigrations) {
+    tx = tx.patch(m.id, (p) => p.set({ models: m.models }).unset(["model"]));
+  }
+
+  console.log(`\nCommitting transaction…`);
+  const result = await tx.commit();
+  console.log(`Done. ${result.results.length} mutations applied.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/rework-doc-types.ts
+++ b/scripts/rework-doc-types.ts
@@ -164,9 +164,7 @@ async function main() {
   // Plan archive (retired). Skip if already archived so re-runs are a true no-op.
   const retiredManual = manuals.find(
     (m) =>
-      m.model === "M3100" &&
-      /Manual/i.test(m.title) &&
-      m.archived !== true,
+      m.model === "M3100" && /Manual/i.test(m.title) && m.archived !== true,
   );
 
   // Plan manual model→models[] migration (existing docs use legacy `model` prefix

--- a/scripts/rework-doc-types.ts
+++ b/scripts/rework-doc-types.ts
@@ -16,7 +16,8 @@
  * Run:  pnpm tsx scripts/rework-doc-types.ts
  *       pnpm tsx scripts/rework-doc-types.ts --dry-run
  *
- * Idempotent — re-running is a no-op once everything is migrated.
+ * Single-pass and idempotent: a fresh run does steps 1-5 in one transaction;
+ * re-running on already-migrated data writes nothing.
  */
 import { readFileSync } from "node:fs";
 import { createClient } from "@sanity/client";
@@ -71,6 +72,7 @@ type Manual = {
   title: string;
   model?: string | null;
   models?: string[] | null;
+  archived?: boolean | null;
 };
 type ProductRef = { model: string };
 
@@ -141,7 +143,7 @@ async function main() {
   `);
 
   const manuals = await client.fetch<Manual[]>(
-    `*[_type == "manual"]{_id, title, model, models} | order(title asc)`,
+    `*[_type == "manual"]{_id, title, model, models, archived} | order(title asc)`,
   );
 
   // Plan datasheet → manual moves
@@ -159,9 +161,12 @@ async function main() {
     }
   }
 
-  // Plan archive (retired)
+  // Plan archive (retired). Skip if already archived so re-runs are a true no-op.
   const retiredManual = manuals.find(
-    (m) => m.model === "M3100" && /Manual/i.test(m.title),
+    (m) =>
+      m.model === "M3100" &&
+      /Manual/i.test(m.title) &&
+      m.archived !== true,
   );
 
   // Plan manual model→models[] migration (existing docs use legacy `model` prefix
@@ -213,7 +218,8 @@ async function main() {
   );
   console.log(`\n  datasheet → manual  (${dsMigrate.length} docs):`);
   for (const d of dsMigrate) {
-    console.log(`    "${d.title}" (model=${d.model})`);
+    const derived = deriveModels(d.title, productModels);
+    console.log(`    "${d.title}" → models=[${derived.join(", ")}]`);
   }
 
   console.log(`\n  delete datasheet (collision)  (${dsDelete.length} docs):`);
@@ -288,10 +294,17 @@ async function main() {
       console.warn(`  skipping ${d._id} — no file asset`);
       continue;
     }
+    const derived = deriveModels(d.title, productModels);
+    if (derived.length === 0) {
+      console.warn(
+        `  skipping ${d._id} — could not derive models from "${d.title}"`,
+      );
+      continue;
+    }
     tx = tx.create({
       _type: "manual",
       title: d.title,
-      ...(d.model ? { model: d.model } : {}),
+      models: derived,
       ...(d.series ? { series: d.series } : {}),
       ...(d.rev ? { rev: d.rev } : {}),
       ...(d.publishedAt ? { publishedAt: d.publishedAt } : {}),

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -207,6 +207,15 @@ export default async function ProductPage({ params }: Props) {
       })),
     ...product.drawings.flatMap<DownloadItem>((d) => {
       const items: DownloadItem[] = [];
+      if (d.pdfUrl) {
+        items.push({
+          label: d.title,
+          type: "PDF",
+          href: d.pdfUrl,
+          size: formatBytes(d.pdfSize),
+          date: formatDate(d.updatedAt, locale),
+        });
+      }
       if (d.dwgUrl) {
         items.push({
           label: `${d.title} (DWG)`,

--- a/src/app/[locale]/resources/datasheets/page.tsx
+++ b/src/app/[locale]/resources/datasheets/page.tsx
@@ -17,12 +17,16 @@ const SERIES_ORDER: Series[] = ["analogue", "digital", "specialized"];
 type DatasheetItem = {
   _id: string;
   title: string;
-  model?: string | null;
+  models?: string[] | null;
   series?: string | null;
   rev?: string | null;
   publishedAt?: string | null;
   fileUrl?: string | null;
 };
+
+function modelLabel(item: DatasheetItem): string | null {
+  return item.models && item.models.length > 0 ? item.models.join(" / ") : null;
+}
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -92,10 +96,10 @@ export default async function DatasheetsPage({ params }: Props) {
                   </span>
                   <div>
                     <div className="dr-list__label">{item.title}</div>
-                    {(item.model || item.rev || item.publishedAt) && (
+                    {(modelLabel(item) || item.rev || item.publishedAt) && (
                       <div className="dr-list__meta">
-                        {item.model && <span>{item.model}</span>}
-                        {item.model && (item.rev || item.publishedAt) && (
+                        {modelLabel(item) && <span>{modelLabel(item)}</span>}
+                        {modelLabel(item) && (item.rev || item.publishedAt) && (
                           <span className="dr-list__sep">·</span>
                         )}
                         {item.rev && <span>{item.rev}</span>}
@@ -124,10 +128,10 @@ export default async function DatasheetsPage({ params }: Props) {
               <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
               <div>
                 <div className="dr-list__label">{item.title}</div>
-                {(item.model || item.rev || item.publishedAt) && (
+                {(modelLabel(item) || item.rev || item.publishedAt) && (
                   <div className="dr-list__meta">
-                    {item.model && <span>{item.model}</span>}
-                    {item.model && (item.rev || item.publishedAt) && (
+                    {modelLabel(item) && <span>{modelLabel(item)}</span>}
+                    {modelLabel(item) && (item.rev || item.publishedAt) && (
                       <span className="dr-list__sep">·</span>
                     )}
                     {item.rev && <span>{item.rev}</span>}

--- a/src/app/[locale]/resources/drawings/page.tsx
+++ b/src/app/[locale]/resources/drawings/page.tsx
@@ -17,10 +17,11 @@ type Props = { params: Promise<{ locale: string }> };
 type DrawingItem = {
   _id: string;
   title: string;
-  model: string;
+  models?: string[] | null;
   series?: string | null;
   dwgUrl?: string | null;
   stpUrl?: string | null;
+  pdfUrl?: string | null;
 };
 
 export function generateStaticParams() {
@@ -75,62 +76,77 @@ export default async function DrawingsPage({ params }: Props) {
             </tr>
           </thead>
           <tbody>
-            {drawings.map((item) => (
-              <tr key={item._id}>
-                <td>
-                  <div className="dr-drawings__model">{item.model}</div>
-                  <div className="dr-drawings__series">{item.title}</div>
-                </td>
-                <td>
-                  {item.series && (
-                    <span className="dr-drawings__series">
-                      {tRes(
-                        `seriesLabel.${item.series as "analogue" | "digital" | "specialized"}`,
+            {drawings.map((item) => {
+              const modelLabel =
+                item.models && item.models.length > 0
+                  ? item.models.join(" / ")
+                  : "—";
+              const hasFile = item.pdfUrl || item.dwgUrl || item.stpUrl;
+              return (
+                <tr key={item._id}>
+                  <td>
+                    <div className="dr-drawings__model">{modelLabel}</div>
+                    <div className="dr-drawings__series">{item.title}</div>
+                  </td>
+                  <td>
+                    {item.series && (
+                      <span className="dr-drawings__series">
+                        {tRes(
+                          `seriesLabel.${item.series as "analogue" | "digital" | "specialized"}`,
+                        )}
+                      </span>
+                    )}
+                  </td>
+                  <td>
+                    <div className="dr-drawings__files">
+                      {item.pdfUrl && (
+                        <span className="dr-list__badge dr-list__badge--pdf">
+                          PDF
+                        </span>
                       )}
-                    </span>
-                  )}
-                </td>
-                <td>
-                  <div className="dr-drawings__files">
-                    {item.dwgUrl && (
-                      <span className="dr-list__badge dr-list__badge--dwg">
-                        DWG
-                      </span>
-                    )}
-                    {item.stpUrl && (
-                      <span className="dr-list__badge dr-list__badge--stp">
-                        STP
-                      </span>
-                    )}
-                    {!item.dwgUrl && !item.stpUrl && (
-                      <span className="dr-list__badge">—</span>
-                    )}
-                  </div>
-                </td>
-                <td>
-                  <div className="dr-drawings__actions">
-                    {item.dwgUrl && (
-                      <a href={item.dwgUrl} download className="dr-list__btn">
-                        DWG
-                      </a>
-                    )}
-                    {item.stpUrl && (
-                      <a href={item.stpUrl} download className="dr-list__btn">
-                        STP
-                      </a>
-                    )}
-                    {!item.dwgUrl && !item.stpUrl && (
-                      <Link
-                        href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
-                        className="dr-list__btn dr-list__btn--request"
-                      >
-                        {tRes("requestFile")}
-                      </Link>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ))}
+                      {item.dwgUrl && (
+                        <span className="dr-list__badge dr-list__badge--dwg">
+                          DWG
+                        </span>
+                      )}
+                      {item.stpUrl && (
+                        <span className="dr-list__badge dr-list__badge--stp">
+                          STP
+                        </span>
+                      )}
+                      {!hasFile && <span className="dr-list__badge">—</span>}
+                    </div>
+                  </td>
+                  <td>
+                    <div className="dr-drawings__actions">
+                      {item.pdfUrl && (
+                        <a href={item.pdfUrl} download className="dr-list__btn">
+                          PDF
+                        </a>
+                      )}
+                      {item.dwgUrl && (
+                        <a href={item.dwgUrl} download className="dr-list__btn">
+                          DWG
+                        </a>
+                      )}
+                      {item.stpUrl && (
+                        <a href={item.stpUrl} download className="dr-list__btn">
+                          STP
+                        </a>
+                      )}
+                      {!hasFile && (
+                        <Link
+                          href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                          className="dr-list__btn dr-list__btn--request"
+                        >
+                          {tRes("requestFile")}
+                        </Link>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -22,12 +22,16 @@ const SERIES_ORDER: Series[] = ["analogue", "digital", "specialized"];
 type ManualItem = {
   _id: string;
   title: string;
-  model?: string | null;
+  models?: string[] | null;
   series?: string | null;
   rev?: string | null;
   publishedAt?: string | null;
   fileUrl?: string | null;
 };
+
+function modelLabel(item: ManualItem): string | null {
+  return item.models && item.models.length > 0 ? item.models.join(" / ") : null;
+}
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -97,10 +101,10 @@ export default async function ManualsPage({ params }: Props) {
                   </span>
                   <div>
                     <div className="dr-list__label">{item.title}</div>
-                    {(item.model || item.rev || item.publishedAt) && (
+                    {(modelLabel(item) || item.rev || item.publishedAt) && (
                       <div className="dr-list__meta">
-                        {item.model && <span>{item.model}</span>}
-                        {item.model && (item.rev || item.publishedAt) && (
+                        {modelLabel(item) && <span>{modelLabel(item)}</span>}
+                        {modelLabel(item) && (item.rev || item.publishedAt) && (
                           <span className="dr-list__sep">·</span>
                         )}
                         {item.rev && <span>{item.rev}</span>}
@@ -134,10 +138,10 @@ export default async function ManualsPage({ params }: Props) {
               <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
               <div>
                 <div className="dr-list__label">{item.title}</div>
-                {(item.model || item.rev || item.publishedAt) && (
+                {(modelLabel(item) || item.rev || item.publishedAt) && (
                   <div className="dr-list__meta">
-                    {item.model && <span>{item.model}</span>}
-                    {item.model && (item.rev || item.publishedAt) && (
+                    {modelLabel(item) && <span>{modelLabel(item)}</span>}
+                    {modelLabel(item) && (item.rev || item.publishedAt) && (
                       <span className="dr-list__sep">·</span>
                     )}
                     {item.rev && <span>{item.rev}</span>}

--- a/src/lib/types/product-drawings.test.ts
+++ b/src/lib/types/product-drawings.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { SanityProductSchema } from "./product";
+import { productFixture } from "@/test/fixtures/products";
+
+const SANITY_BASE = {
+  ...productFixture,
+  // The Sanity-side schema uses bare image objects, fixture has none.
+  images: null,
+  cutout: null,
+  dimensionDrawing: null,
+  digitalCommunication: null,
+};
+
+describe("SanityProductSchema drawings (#174)", () => {
+  it("accepts drawings with models[], pdfUrl, and pdfSize", () => {
+    const parsed = SanityProductSchema.parse({
+      ...SANITY_BASE,
+      drawings: [
+        {
+          _id: "drawing-1",
+          title: "M3030VA outline",
+          models: ["M3030VA", "M3030VB"],
+          pdfUrl: "https://cdn.sanity.io/files/x/y.pdf",
+          pdfSize: 12345,
+          dwgUrl: "https://cdn.sanity.io/files/x/y.dwg",
+          stpUrl: null,
+          updatedAt: "2026-05-07T00:00:00Z",
+        },
+      ],
+    });
+    expect(parsed.drawings).toHaveLength(1);
+    expect(parsed.drawings[0]!.models).toEqual(["M3030VA", "M3030VB"]);
+    expect(parsed.drawings[0]!.pdfUrl).toBe(
+      "https://cdn.sanity.io/files/x/y.pdf",
+    );
+    expect(parsed.drawings[0]!.pdfSize).toBe(12345);
+  });
+
+  it("accepts drawings with pdf-only (no DWG/STP)", () => {
+    const parsed = SanityProductSchema.parse({
+      ...SANITY_BASE,
+      drawings: [
+        {
+          _id: "drawing-2",
+          title: "PDF-only outline",
+          models: ["LD030C"],
+          pdfUrl: "https://cdn.sanity.io/files/a/b.pdf",
+          pdfSize: 9876,
+        },
+      ],
+    });
+    expect(parsed.drawings[0]!.dwgUrl ?? null).toBeNull();
+    expect(parsed.drawings[0]!.stpUrl ?? null).toBeNull();
+    expect(parsed.drawings[0]!.pdfUrl).toBeTruthy();
+  });
+
+  it("accepts drawings with null models (legacy/incomplete data)", () => {
+    const parsed = SanityProductSchema.parse({
+      ...SANITY_BASE,
+      drawings: [
+        {
+          _id: "drawing-3",
+          title: "Legacy",
+          models: null,
+        },
+      ],
+    });
+    expect(parsed.drawings[0]!.models ?? null).toBeNull();
+  });
+
+  it("rejects drawings with non-string entries in models[]", () => {
+    expect(() =>
+      SanityProductSchema.parse({
+        ...SANITY_BASE,
+        drawings: [
+          {
+            _id: "drawing-4",
+            title: "Bad",
+            models: ["M3030VA", 123],
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -166,10 +166,13 @@ export const SanityProductSchema = z.object({
       z.object({
         _id: z.string(),
         title: z.string(),
+        models: z.array(z.string()).nullable().optional(),
         dwgUrl: z.string().nullable().optional(),
         dwgSize: z.number().nullable().optional(),
         stpUrl: z.string().nullable().optional(),
         stpSize: z.number().nullable().optional(),
+        pdfUrl: z.string().nullable().optional(),
+        pdfSize: z.number().nullable().optional(),
         updatedAt: z.string().nullable().optional(),
       }),
     )

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -36,7 +36,7 @@ const PRODUCT_DETAIL_PROJECTION = `
   digitalCommunication,
   images,
   dimensionDrawing,
-  "datasheets": *[_type == "datasheet" && lower(model) == lower(^.model)]
+  "datasheets": *[_type == "datasheet" && archived != true && ^.model in coalesce(models, [])]
     | order(coalesce(publishedAt, _updatedAt) desc) {
       _id,
       title,
@@ -46,7 +46,7 @@ const PRODUCT_DETAIL_PROJECTION = `
       "size": file.asset->size,
       "updatedAt": _updatedAt
     },
-  "manuals": *[_type == "manual" && lower(model) == lower(^.model)]
+  "manuals": *[_type == "manual" && archived != true && ^.model in coalesce(models, [])]
     | order(coalesce(publishedAt, _updatedAt) desc) {
       _id,
       title,
@@ -56,14 +56,17 @@ const PRODUCT_DETAIL_PROJECTION = `
       "size": file.asset->size,
       "updatedAt": _updatedAt
     },
-  "drawings": *[_type == "drawing" && lower(model) == lower(^.model)]
+  "drawings": *[_type == "drawing" && archived != true && ^.model in coalesce(models, [])]
     | order(_updatedAt desc) {
       _id,
       title,
+      models,
       "dwgUrl": dwgFile.asset->url,
       "dwgSize": dwgFile.asset->size,
       "stpUrl": stpFile.asset->url,
       "stpSize": stpFile.asset->size,
+      "pdfUrl": pdfFile.asset->url,
+      "pdfSize": pdfFile.asset->size,
       "updatedAt": _updatedAt
     }
 `;
@@ -157,14 +160,14 @@ export const allCataloguesQuery = defineQuery(`
 `);
 
 export const allManualsQuery = defineQuery(`
-  *[_type == "manual"]
+  *[_type == "manual" && archived != true]
   | order(
     select(series == "analogue" => 0, series == "digital" => 1, 2),
-    model asc
+    models[0] asc
   ) {
     _id,
     title,
-    model,
+    models,
     series,
     rev,
     publishedAt,
@@ -173,14 +176,14 @@ export const allManualsQuery = defineQuery(`
 `);
 
 export const allDatasheetsQuery = defineQuery(`
-  *[_type == "datasheet"]
+  *[_type == "datasheet" && archived != true]
   | order(
     select(series == "analogue" => 0, series == "digital" => 1, 2),
-    model asc
+    models[0] asc
   ) {
     _id,
     title,
-    model,
+    models,
     series,
     rev,
     publishedAt,
@@ -189,17 +192,18 @@ export const allDatasheetsQuery = defineQuery(`
 `);
 
 export const allDrawingsQuery = defineQuery(`
-  *[_type == "drawing"]
+  *[_type == "drawing" && archived != true]
   | order(
     select(series == "analogue" => 0, series == "digital" => 1, 2),
-    model asc
+    models[0] asc
   ) {
     _id,
     title,
-    model,
+    models,
     series,
     "dwgUrl": dwgFile.asset->url,
-    "stpUrl": stpFile.asset->url
+    "stpUrl": stpFile.asset->url,
+    "pdfUrl": pdfFile.asset->url
   }
 `);
 
@@ -269,9 +273,9 @@ export const applicationSlugsQuery = defineQuery(`
 export const resourceCountsQuery = defineQuery(`
   {
     "catalogues": count(*[_type == "catalogue"]),
-    "datasheets": count(*[_type == "datasheet"]),
-    "manuals": count(*[_type == "manual"]),
-    "drawings": count(*[_type == "drawing"]),
+    "datasheets": count(*[_type == "datasheet" && archived != true]),
+    "manuals": count(*[_type == "manual" && archived != true]),
+    "drawings": count(*[_type == "drawing" && archived != true]),
     "certifications": count(*[_type == "certification"])
   }
 `);


### PR DESCRIPTION
Closes #168

## Background

PR #167 uploaded 50 PDFs but most were misclassified:
- 30 docs in `catalogue` were dimensional assembly drawings (조립도)
- 5 docs in `datasheet` were full instruction manuals
- The `catalogue` docs were uploaded under a folder labeled "카달로그 모델 PDF" but the contents are CAD dimension sheets, not marketing brochures
- **No actual marketing brochures exist in the source set** — the Catalogues card legitimately stays at 0 until real ones are produced

Plus pre-existing linking drift: `manual.model` stored short prefix codes (`"M3030"`) while products use full codes (`"M3030VA"`) — manuals never showed on product pages.

## Schema/code

- `drawing`: new `pdfFile` + `archived` fields, `model` → `models[]` (multi-product brochures); product pages render PDF alongside DWG/STEP
- `manual`, `datasheet`: `model` → `models[]`, `archived` field
- GROQ: `^.model in coalesce(models, [])` for matching, `archived != true` for filtering
- `/resources/drawings` table renders new PDF column + multi-model labels

## Migration (already ran cleanly via `scripts/rework-doc-types.ts`)

- 30 catalogue → drawing (titles renamed `Brochure` → `Dimensional Drawing`)
- 4 datasheet → manual (MS3150, MS3400, MS3700, MS3800)
- 1 datasheet deleted (MS3600 standalone — collides with combined manual)
- 2 duplicate manuals deleted (M3030 / M3200 `Maunal.pdf` typo aliases)
- 1 manual archived (M3100 — model retired in 2026 lineup)
- 15 manuals get `models[]` derived from titles via product lookup
  - DO400 manual skipped: product not yet seeded in Sanity (open question — separate from this PR)

Final state: **0 catalogues, 0 datasheets, 30 drawings, 17 manuals (16 active, 1 archived)**.

## Verified live

- M3030VA product page → shows M3030 Series Manual + M3030VA Dimensional Drawing
- M2200VA → shows shared `M3200VA / M2200VA Dimensional Drawing`
- EX70C → shows shared `EX70 Series Dimensional Drawing`
- `/resources/drawings` → all 30 listed with PDF column
- `/resources/catalogues` → empty (correct, no real brochures exist)

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 57/57 pass
- [x] Manual + drawing both render on M3030VA product page
- [x] Multi-model brochure shows on each covered product
- [x] M3100 manual hidden from /resources/manuals (archived)
- [ ] Once merged: re-run `tag-catalogue-models.ts` is no-op; re-run `rework-doc-types.ts` is no-op (idempotency check)

## Follow-up not in this PR

- Verify whether DO400 + LTI-2000 source materials exist (specs, images) — Phase 2 of the 2026 catalogue resync
- Once DO400 product is seeded, re-run `pnpm tsx scripts/rework-doc-types.ts` to link DO400 manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)