### PR TITLE
feat(catalogue): Phase 2 — 2026 lineup, connectorType, redirects, Sanity sync

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,7 +38,25 @@ const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
 ];
 
+// Renamed slugs from 2020 → 2026 catalogue resync
+const SLUG_REDIRECTS = [
+  { from: "specialized/ex070c", to: "specialized/ex70c" },
+  { from: "specialized/ex070m", to: "specialized/ex70m" },
+  { from: "digital/md100c", to: "digital/md150c" },
+  { from: "digital/md100m", to: "digital/md150m" },
+];
+
 const nextConfig: NextConfig = {
+  async redirects() {
+    const locales = ["ko", "en", "zh"];
+    return locales.flatMap((locale) =>
+      SLUG_REDIRECTS.map(({ from, to }) => ({
+        source: `/${locale}/products/${from}`,
+        destination: `/${locale}/products/${to}`,
+        permanent: true,
+      })),
+    );
+  },
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },

--- a/public/products/_manifest.json
+++ b/public/products/_manifest.json
@@ -5,193 +5,705 @@
       "model": "M3030VA",
       "slug": "m3030va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/m3030va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_quJLON0m_3d8f8ed67af192fed678cab52e003866edc4688e.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m3030va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_WubZJExP_40b3e03b5dafc089c7ce6c7ca0913574c46312c7.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m3030va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740442699_68.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "M3200VA",
       "slug": "m3200va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/m3200va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_JATSwy9U_26afa6e320722b09f5598c5dce1186d8c37c7668.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m3200va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_fr3zKWAC_8f73a18636f6b1fe86ecde203da81a08153342f6.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m3200va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740443875_1825.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3150VA",
       "slug": "ms3150va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3150va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_m6CBE2Ly_22e1a3f963c29c9ef431151f6b8edf2130385b48.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3150va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_FwUPg4DO_692d7c599d41637fa9341aaaf4644c0134bc681c.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3150va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444505_0648.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3400VA",
       "slug": "ms3400va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3400va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_lqRIHEP8_c5a035e55bd4ea9905886f10198f8916021f6c8e.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3400va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_9f3DsW2z_e0e13792eaea4fdc5dba23f9b418c3fd0b419888.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3400va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444658_2279.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3500VA",
       "slug": "ms3500va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3500va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_G2Wy7Cix_06a66570d11b5680f8afb823bf8b9b1e42f837cc.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3500va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_u60QDTK9_1094fa50239a273920bbe6d335879e8d57588fc6.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3500va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444878_4445.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3600VA",
       "slug": "ms3600va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3600va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_ZDzKECaW_0356458f1bbd702f76572eb4a699da61c8dac316.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3600va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_6sG9JIRt_af5c27f678fff98b22fb4362b21f554bd461401a.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3600va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444971_2802.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3700VA",
       "slug": "ms3700va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3700va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_neROvL4o_b5bd349f3138034fd345aab21549e1e79d8c709e.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3700va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_LUbu6xap_22096b908f5d1f8a08271530369d9b62b91e6166.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3700va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445105_8889.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS3800VA",
       "slug": "ms3800va",
       "category": "analogue-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms3800va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_emtwLMFP_39846f7f1d8cb4f1688401b68870282a538bf6d8.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3800va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_PMeAQ3EC_4a632b4109cef14495896446bfe0ae92eb871352.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms3800va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445205_9116.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "M2030VA",
       "slug": "m2030va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/m2030va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yiYz1K0D_0c2d1a39216d8d06e852775a33f9b6b9f52c1bba.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m2030va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yftBoNzx_6b9c8e9610beb697c177a74f6b194f1679e8cd37.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m2030va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445966_7484.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "M2200VA",
       "slug": "m2200va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/m2200va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_hJ8LRQn0_5b602bd64c1a49c53159e46b33095325cd9b2edf.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m2200va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_WfqnOrFT_d439d3c64f28c1e69fe975726a9197a82eabe5c7.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/m2200va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446059_4602.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2150VA",
       "slug": "ms2150va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2150va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_3LBGnyjT_efd9f8db89d068ab318234fad49d29a4f8cf6571.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2150va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_y60ahVJO_cfc1c1c906123027e4c43baa624cb1e0f44cbd80.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2150va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446141_1092.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2400VA",
       "slug": "ms2400va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2400va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_lZ1x37E4_958c7fe632db338760ee29d098cef572126a3da7.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2400va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_g5bFQAjL_a9527a73369e3c033aaf8155b6cc37aec821707d.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2400va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446240_1699.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2500VA",
       "slug": "ms2500va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2500va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_vmObF5To_1640e2b75fd858251feb3287243bf216a8674865.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2500va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_PFTru5kz_d36b4104c2a7049ba89922b1785734c5aba2cb4a.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2500va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446321_3853.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2600VA",
       "slug": "ms2600va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2600va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_4T2iUyuV_f54b9c4e70a73de1485d126eaed3893b69770ff2.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2600va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_UW3a2pYq_71efb8a0f94a32d60a0ca02a0a7c1d755c25398e.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2600va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446395_9264.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2700VA",
       "slug": "ms2700va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2700va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yb1nfP9Q_3349c78bd99f3983786780a25e43128dfc6fafda.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2700va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_e48FGLzD_7e78c428a4f041e5b3a2e16f0e033e9de72dbea7.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2700va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446482_1017.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MS2800VA",
       "slug": "ms2800va",
       "category": "analogue-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ms2800va/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_qAyYCfp1_3542fbdd6c0b988b8b35df2ca01deb931af61871.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2800va/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_4HFmtAsX_4661334d6cdb908bb5a1471d1e43a48c61b6a307.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ms2800va/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446550_5989.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD150C",
       "slug": "md150c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md100c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_B5LCviJy_f92d55c7c3332660c45abba8c338f555777063fe.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md100c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_b6L5HewT_c3cab287540724ed4bb61c2db9cff5afef4066ef.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md100c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610530539_2925.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD30C",
       "slug": "md30c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md30c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_ACtj6EhN_e980fca897ec389ff8b880a5836113a0bdc6c607.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md30c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_YudhPXqi_bb7ec314f50272c23e339758450b1f078b2bb4e0.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md30c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610521894_3247.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD400C",
       "slug": "md400c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md400c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_LShmBWeJ_8b3e9ad89d7cefa30d214321c395a1063e2cfc32.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md400c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_fyDm2h69_af056124ad87eb69a90bd2e76dd4d4951ef492ac.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md400c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610530831_5408.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD500C",
       "slug": "md500c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md500c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_1Acf6Gba_5daa9f5da9c9ce4ef495ff9d516a3751d0bdcb4e.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md500c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_6xOVDyPE_a55d48ae6e01399719d3f584cf568e93ea80521c.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md500c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531003_0146.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD600C",
       "slug": "md600c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md600c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_nimbgv6W_b7137447ab1986b02e05c020d25b80806c0a4d85.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md600c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_oC4Dx5IO_18b64cb792b6cc6db64dd0c0acfb26c88c8988d4.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md600c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531114_6135.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD700C",
       "slug": "md700c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md700c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_jP5iH3Ry_339e472a73b0d0dfc11f05672d5f1ae519471a57.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md700c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_O5M86DdJ_cea8db0476c634d4e7801494330394e1d41de4e1.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md700c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531206_9308.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD800C",
       "slug": "md800c",
       "category": "digital-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md800c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_Rq4SZHtU_ee35b9688368a760f8beb2d30dd32e8913982eb9.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md800c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_LlQWJx0g_0c7673e6c7f5927d0ee13c8874093e2b2ee4a135.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md800c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531357_2558.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD150M",
       "slug": "md150m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md100m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_4Os0PARd_80ef67428433c6755db138dd5d102df5fc345ab7.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md100m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_0vmxSg3Y_9779982bf00d0963d5fc300ce0f2e8a7571807c6.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md100m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533337_7587.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD30M",
       "slug": "md30m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md30m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_I4OcqnXL_b4534ba059b8a173ae590d1f6cb1152340e6b4aa.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md30m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_eSmVDvXf_46c3080d4935f5263802f89ca492176f01bc62f5.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md30m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610532966_1922.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD400M",
       "slug": "md400m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md400m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_PjulRifE_87418057213946bf8b13a8e18644bb6e13517647.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md400m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_k1QlH3za_708de5bfa3401f9e4999bb2733b13d25a48626ea.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md400m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533862_5106.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD500M",
       "slug": "md500m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md500m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_8xlPKyI7_85c6cfe5841337f106b32709ff5a002491be93fd.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md500m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_IbxewuSK_b6b8796b4c0ce0e1df09de048f0da1ef2f022270.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md500m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533991_1347.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD600M",
       "slug": "md600m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md600m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_rhdp0ftV_ca92014a6897a70efbe6ae397419455c59536697.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md600m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_HMNKFLuQ_dcd72acffd3c107a43c7cdbe2c4d6e8abe8021a5.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md600m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610534103_276.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD700M",
       "slug": "md700m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md700m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_DIv9Hzj7_7c4aadb43c2d63efa1bb22b568411fd6f7143893.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md700m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_FJhPmqRI_cff641a8c0262ce2c6bf0ef119d162a75a6782a9.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md700m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543303_2138.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "MD800M",
       "slug": "md800m",
       "category": "digital-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/md800m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_t3hfpwMk_1ba4e47a001b543843a84c305619eb8f66c4a709.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md800m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_vES3JqoK_9c89dc143c70151d8a745f57cea45e542132db4f.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/md800m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543592_213.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "EX1000C",
       "slug": "ex1000c",
       "category": "specialized-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ex1000c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_QCRE517J_3b301496e6b0a83df1ee935b55bfda28de3e2435.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex1000c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_WdLRsvrN_0034eef93dae4032d1e60562ab9c19a02cdf5168.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex1000c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592471_2419.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "EX70C",
       "slug": "ex70c",
       "category": "specialized-mfc",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ex070c/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_dsinrUW6_bd8d9df7a5038af87556cdd621a6050f4899f711.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex070c/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_SxoJt9TO_46525cc09444571d2deb81485360d72d2969ba2c.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex070c/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592285_2101.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "LEPC",
@@ -203,13 +715,45 @@
       "model": "EX1000M",
       "slug": "ex1000m",
       "category": "specialized-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ex1000m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_InJHbtMN_420d3c3552365412b8a82f41c718207fe5fba763.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex1000m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_5oT3UjAK_63c0b825c09d2db917ac79b5cc60cc2acf837e26.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex1000m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592923_3115.jpg",
+          "kind": "editor"
+        }
+      ]
     },
     {
       "model": "EX70M",
       "slug": "ex70m",
       "category": "specialized-mfm",
-      "images": []
+      "images": [
+        {
+          "path": "/products/ex070m/product-1.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_qxGUdjVH_fddd4e125e35852245c5af2c6189be3c1502e576.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex070m/product-2.jpg",
+          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_FB3dYNVm_3177f76098a7c5ba5d04de1f98087b6c5b6e1dec.jpg",
+          "kind": "product"
+        },
+        {
+          "path": "/products/ex070m/editor-1.jpg",
+          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592746_796.jpg",
+          "kind": "editor"
+        }
+      ]
     }
   ]
 }

--- a/public/products/_manifest.json
+++ b/public/products/_manifest.json
@@ -1,941 +1,215 @@
 {
-  "generatedAt": "2026-04-24T18:46:34.414Z",
+  "generatedAt": "2026-05-08T02:51:20.877948Z",
   "products": [
     {
-      "model": "MS3700VA",
-      "slug": "ms3700va",
+      "model": "M3030VA",
+      "slug": "m3030va",
       "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 10,
-      "images": [
-        {
-          "path": "/products/ms3700va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_neROvL4o_b5bd349f3138034fd345aab21549e1e79d8c709e.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3700va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_LUbu6xap_22096b908f5d1f8a08271530369d9b62b91e6166.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3700va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445105_8889.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS3600VA",
-      "slug": "ms3600va",
-      "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 11,
-      "images": [
-        {
-          "path": "/products/ms3600va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_ZDzKECaW_0356458f1bbd702f76572eb4a699da61c8dac316.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3600va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_6sG9JIRt_af5c27f678fff98b22fb4362b21f554bd461401a.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3600va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444971_2802.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS3500VA",
-      "slug": "ms3500va",
-      "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 12,
-      "images": [
-        {
-          "path": "/products/ms3500va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_G2Wy7Cix_06a66570d11b5680f8afb823bf8b9b1e42f837cc.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3500va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_u60QDTK9_1094fa50239a273920bbe6d335879e8d57588fc6.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3500va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444878_4445.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS3400VA",
-      "slug": "ms3400va",
-      "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 13,
-      "images": [
-        {
-          "path": "/products/ms3400va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_lqRIHEP8_c5a035e55bd4ea9905886f10198f8916021f6c8e.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3400va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_9f3DsW2z_e0e13792eaea4fdc5dba23f9b418c3fd0b419888.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3400va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444658_2279.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS3150VA",
-      "slug": "ms3150va",
-      "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 14,
-      "images": [
-        {
-          "path": "/products/ms3150va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_m6CBE2Ly_22e1a3f963c29c9ef431151f6b8edf2130385b48.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3150va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_FwUPg4DO_692d7c599d41637fa9341aaaf4644c0134bc681c.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3150va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740444505_0648.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "M3200VA",
       "slug": "m3200va",
       "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 15,
-      "images": [
-        {
-          "path": "/products/m3200va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_JATSwy9U_26afa6e320722b09f5598c5dce1186d8c37c7668.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m3200va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_fr3zKWAC_8f73a18636f6b1fe86ecde203da81a08153342f6.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m3200va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740443875_1825.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
-      "model": "M3030VA",
-      "slug": "m3030va",
+      "model": "MS3150VA",
+      "slug": "ms3150va",
       "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 16,
-      "images": [
-        {
-          "path": "/products/m3030va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_quJLON0m_3d8f8ed67af192fed678cab52e003866edc4688e.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m3030va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_WubZJExP_40b3e03b5dafc089c7ce6c7ca0913574c46312c7.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m3030va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740442699_68.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
+    },
+    {
+      "model": "MS3400VA",
+      "slug": "ms3400va",
+      "category": "analogue-mfc",
+      "images": []
+    },
+    {
+      "model": "MS3500VA",
+      "slug": "ms3500va",
+      "category": "analogue-mfc",
+      "images": []
+    },
+    {
+      "model": "MS3600VA",
+      "slug": "ms3600va",
+      "category": "analogue-mfc",
+      "images": []
+    },
+    {
+      "model": "MS3700VA",
+      "slug": "ms3700va",
+      "category": "analogue-mfc",
+      "images": []
     },
     {
       "model": "MS3800VA",
       "slug": "ms3800va",
       "category": "analogue-mfc",
-      "boTable": "02_01_e",
-      "wrId": 17,
-      "images": [
-        {
-          "path": "/products/ms3800va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_emtwLMFP_39846f7f1d8cb4f1688401b68870282a538bf6d8.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3800va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_01_e/3543863211_PMeAQ3EC_4a632b4109cef14495896446bfe0ae92eb871352.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms3800va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445205_9116.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS2600VA",
-      "slug": "ms2600va",
-      "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 10,
-      "images": [
-        {
-          "path": "/products/ms2600va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_4T2iUyuV_f54b9c4e70a73de1485d126eaed3893b69770ff2.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2600va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_UW3a2pYq_71efb8a0f94a32d60a0ca02a0a7c1d755c25398e.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2600va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446395_9264.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS2500VA",
-      "slug": "ms2500va",
-      "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 11,
-      "images": [
-        {
-          "path": "/products/ms2500va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_vmObF5To_1640e2b75fd858251feb3287243bf216a8674865.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2500va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_PFTru5kz_d36b4104c2a7049ba89922b1785734c5aba2cb4a.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2500va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446321_3853.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MS2400VA",
-      "slug": "ms2400va",
-      "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 12,
-      "images": [
-        {
-          "path": "/products/ms2400va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_lZ1x37E4_958c7fe632db338760ee29d098cef572126a3da7.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2400va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_g5bFQAjL_a9527a73369e3c033aaf8155b6cc37aec821707d.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2400va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446240_1699.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "M2030VA",
       "slug": "m2030va",
       "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 13,
-      "images": [
-        {
-          "path": "/products/m2030va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yiYz1K0D_0c2d1a39216d8d06e852775a33f9b6b9f52c1bba.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m2030va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yftBoNzx_6b9c8e9610beb697c177a74f6b194f1679e8cd37.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m2030va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740445966_7484.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "M2200VA",
       "slug": "m2200va",
       "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 14,
-      "images": [
-        {
-          "path": "/products/m2200va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_hJ8LRQn0_5b602bd64c1a49c53159e46b33095325cd9b2edf.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m2200va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_WfqnOrFT_d439d3c64f28c1e69fe975726a9197a82eabe5c7.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/m2200va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446059_4602.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "MS2150VA",
       "slug": "ms2150va",
       "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 15,
-      "images": [
-        {
-          "path": "/products/ms2150va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_3LBGnyjT_efd9f8db89d068ab318234fad49d29a4f8cf6571.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2150va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_y60ahVJO_cfc1c1c906123027e4c43baa624cb1e0f44cbd80.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2150va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446141_1092.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
+    },
+    {
+      "model": "MS2400VA",
+      "slug": "ms2400va",
+      "category": "analogue-mfm",
+      "images": []
+    },
+    {
+      "model": "MS2500VA",
+      "slug": "ms2500va",
+      "category": "analogue-mfm",
+      "images": []
+    },
+    {
+      "model": "MS2600VA",
+      "slug": "ms2600va",
+      "category": "analogue-mfm",
+      "images": []
     },
     {
       "model": "MS2700VA",
       "slug": "ms2700va",
       "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 16,
-      "images": [
-        {
-          "path": "/products/ms2700va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_yb1nfP9Q_3349c78bd99f3983786780a25e43128dfc6fafda.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2700va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_e48FGLzD_7e78c428a4f041e5b3a2e16f0e033e9de72dbea7.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2700va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446482_1017.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "MS2800VA",
       "slug": "ms2800va",
       "category": "analogue-mfm",
-      "boTable": "02_02_e",
-      "wrId": 17,
-      "images": [
-        {
-          "path": "/products/ms2800va/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_qAyYCfp1_3542fbdd6c0b988b8b35df2ca01deb931af61871.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2800va/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_02_e/3543863211_4HFmtAsX_4661334d6cdb908bb5a1471d1e43a48c61b6a307.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ms2800va/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2502/97d4894ee7166ddedb8dd3748e815901_1740446550_5989.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
-      "model": "MD700C",
-      "slug": "md700c",
+      "model": "MD150C",
+      "slug": "md150c",
       "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 2,
-      "images": [
-        {
-          "path": "/products/md700c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_jP5iH3Ry_339e472a73b0d0dfc11f05672d5f1ae519471a57.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md700c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_O5M86DdJ_cea8db0476c634d4e7801494330394e1d41de4e1.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md700c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531206_9308.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MD600C",
-      "slug": "md600c",
-      "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 3,
-      "images": [
-        {
-          "path": "/products/md600c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_nimbgv6W_b7137447ab1986b02e05c020d25b80806c0a4d85.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md600c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_oC4Dx5IO_18b64cb792b6cc6db64dd0c0acfb26c88c8988d4.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md600c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531114_6135.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MD500C",
-      "slug": "md500c",
-      "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 4,
-      "images": [
-        {
-          "path": "/products/md500c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_1Acf6Gba_5daa9f5da9c9ce4ef495ff9d516a3751d0bdcb4e.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md500c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_6xOVDyPE_a55d48ae6e01399719d3f584cf568e93ea80521c.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md500c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531003_0146.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MD400C",
-      "slug": "md400c",
-      "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 5,
-      "images": [
-        {
-          "path": "/products/md400c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_LShmBWeJ_8b3e9ad89d7cefa30d214321c395a1063e2cfc32.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md400c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_fyDm2h69_af056124ad87eb69a90bd2e76dd4d4951ef492ac.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md400c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610530831_5408.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MD800C",
-      "slug": "md800c",
-      "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 6,
-      "images": [
-        {
-          "path": "/products/md800c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_Rq4SZHtU_ee35b9688368a760f8beb2d30dd32e8913982eb9.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md800c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_LlQWJx0g_0c7673e6c7f5927d0ee13c8874093e2b2ee4a135.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md800c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610531357_2558.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "MD100C",
-      "slug": "md100c",
-      "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 7,
-      "images": [
-        {
-          "path": "/products/md100c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_B5LCviJy_f92d55c7c3332660c45abba8c338f555777063fe.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md100c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_b6L5HewT_c3cab287540724ed4bb61c2db9cff5afef4066ef.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md100c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610530539_2925.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "MD30C",
       "slug": "md30c",
       "category": "digital-mfc",
-      "boTable": "02_03_e",
-      "wrId": 8,
-      "images": [
-        {
-          "path": "/products/md30c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_ACtj6EhN_e980fca897ec389ff8b880a5836113a0bdc6c607.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md30c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_03_e/3543863211_YudhPXqi_bb7ec314f50272c23e339758450b1f078b2bb4e0.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md30c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610521894_3247.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
-      "model": "MD600M",
-      "slug": "md600m",
-      "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/md600m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_rhdp0ftV_ca92014a6897a70efbe6ae397419455c59536697.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md600m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_HMNKFLuQ_dcd72acffd3c107a43c7cdbe2c4d6e8abe8021a5.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md600m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610534103_276.jpg",
-          "kind": "editor"
-        }
-      ]
+      "model": "MD400C",
+      "slug": "md400c",
+      "category": "digital-mfc",
+      "images": []
     },
     {
-      "model": "MD500M",
-      "slug": "md500m",
-      "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 2,
-      "images": [
-        {
-          "path": "/products/md500m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_8xlPKyI7_85c6cfe5841337f106b32709ff5a002491be93fd.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md500m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_IbxewuSK_b6b8796b4c0ce0e1df09de048f0da1ef2f022270.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md500m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533991_1347.jpg",
-          "kind": "editor"
-        }
-      ]
+      "model": "MD500C",
+      "slug": "md500c",
+      "category": "digital-mfc",
+      "images": []
     },
     {
-      "model": "MD400M",
-      "slug": "md400m",
-      "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 3,
-      "images": [
-        {
-          "path": "/products/md400m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_PjulRifE_87418057213946bf8b13a8e18644bb6e13517647.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md400m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_k1QlH3za_708de5bfa3401f9e4999bb2733b13d25a48626ea.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md400m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533862_5106.jpg",
-          "kind": "editor"
-        }
-      ]
+      "model": "MD600C",
+      "slug": "md600c",
+      "category": "digital-mfc",
+      "images": []
     },
     {
-      "model": "MD100M",
-      "slug": "md100m",
+      "model": "MD700C",
+      "slug": "md700c",
+      "category": "digital-mfc",
+      "images": []
+    },
+    {
+      "model": "MD800C",
+      "slug": "md800c",
+      "category": "digital-mfc",
+      "images": []
+    },
+    {
+      "model": "MD150M",
+      "slug": "md150m",
       "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 4,
-      "images": [
-        {
-          "path": "/products/md100m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_4Os0PARd_80ef67428433c6755db138dd5d102df5fc345ab7.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md100m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_0vmxSg3Y_9779982bf00d0963d5fc300ce0f2e8a7571807c6.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md100m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610533337_7587.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "MD30M",
       "slug": "md30m",
       "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 5,
-      "images": [
-        {
-          "path": "/products/md30m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_I4OcqnXL_b4534ba059b8a173ae590d1f6cb1152340e6b4aa.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md30m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_eSmVDvXf_46c3080d4935f5263802f89ca492176f01bc62f5.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md30m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610532966_1922.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
+    },
+    {
+      "model": "MD400M",
+      "slug": "md400m",
+      "category": "digital-mfm",
+      "images": []
+    },
+    {
+      "model": "MD500M",
+      "slug": "md500m",
+      "category": "digital-mfm",
+      "images": []
+    },
+    {
+      "model": "MD600M",
+      "slug": "md600m",
+      "category": "digital-mfm",
+      "images": []
     },
     {
       "model": "MD700M",
       "slug": "md700m",
       "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 6,
-      "images": [
-        {
-          "path": "/products/md700m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_DIv9Hzj7_7c4aadb43c2d63efa1bb22b568411fd6f7143893.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md700m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_FJhPmqRI_cff641a8c0262ce2c6bf0ef119d162a75a6782a9.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md700m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543303_2138.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "MD800M",
       "slug": "md800m",
       "category": "digital-mfm",
-      "boTable": "02_04_e",
-      "wrId": 7,
-      "images": [
-        {
-          "path": "/products/md800m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_t3hfpwMk_1ba4e47a001b543843a84c305619eb8f66c4a709.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md800m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_04_e/3543863211_vES3JqoK_9c89dc143c70151d8a745f57cea45e542132db4f.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/md800m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543592_213.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "PR-030",
-      "slug": "pr-030",
-      "category": "component",
-      "boTable": "02_06_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/pr-030/product-1.gif",
-          "source": "https://line-tech.co.kr/data/file/02_06_e/981398834_kPtGsvh3_58f14c97f8edd339f384860da86d7c7d9ee2ff31.gif",
-          "kind": "product"
-        },
-        {
-          "path": "/products/pr-030/product-2.gif",
-          "source": "https://line-tech.co.kr/data/file/02_06_e/981398834_7ntRvgIU_cda5aa4b4e2d8f75742831b9e87695529a8e14f9.gif",
-          "kind": "product"
-        },
-        {
-          "path": "/products/pr-030/editor-1.jpg",
-          "source": "http://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543932_9424.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "FC-050S",
-      "slug": "fc-050s",
-      "category": "component",
-      "boTable": "02_06_e",
-      "wrId": 2,
-      "images": [
-        {
-          "path": "/products/fc-050s/product-1.gif",
-          "source": "https://line-tech.co.kr/data/file/02_06_e/981398834_XTNHKYyS_fc4b0bf8a1c499d3240fb44c22997dffbb652ed2.gif",
-          "kind": "product"
-        },
-        {
-          "path": "/products/fc-050s/product-2.gif",
-          "source": "https://line-tech.co.kr/data/file/02_06_e/981398834_esXdf0xG_d5c27553a810ced7f3b5c0bab17478c49113017a.gif",
-          "kind": "product"
-        },
-        {
-          "path": "/products/fc-050s/editor-1.jpg",
-          "source": "http://line-tech.co.kr/data/editor/2101/6c6493ad98045f5ce9beacb6900e06e4_1610543854_7436.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "LD030C",
-      "slug": "ld030c",
-      "category": "display-mfc",
-      "boTable": "02_07_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/ld030c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_e/3543863211_CdeskEhF_97f05749a279f5a4f92a02319b784b428d496c06.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ld030c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_e/3543863211_HSiGUaOd_10ecf442b07f91036c6b6f89d3c1155014d28dcb.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ld030c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610590518_9411.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "LM030C",
-      "slug": "lm030c",
-      "category": "mems-mfc",
-      "boTable": "02_07_02_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/lm030c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_02_e/3543863211_QW4HdDF9_205884698179f8cb2b7ec8f041abfbfd9420f806.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/lm030c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_02_e/3543863211_fGm1Tq5k_3d9fbc2d4458f02756d3ce7a7930dc18c774492f.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/lm030c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610591686_3478.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "LM030M",
-      "slug": "lm030m",
-      "category": "mems-mfm",
-      "boTable": "02_07_03_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/lm030m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_03_e/3543863211_n2Np1RmA_c853b9b085b01e3a52bb7131f4f307e458c36164.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/lm030m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_03_e/3543863211_WGOiYtue_1c19e50c5aefa2fad2f35621e12a4f1f5370261d.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/lm030m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610591838_3011.jpg",
-          "kind": "editor"
-        }
-      ]
-    },
-    {
-      "model": "EX070C",
-      "slug": "ex070c",
-      "category": "exproof-mfc",
-      "boTable": "02_07_04_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/ex070c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_dsinrUW6_bd8d9df7a5038af87556cdd621a6050f4899f711.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex070c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_SxoJt9TO_46525cc09444571d2deb81485360d72d2969ba2c.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex070c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592285_2101.jpg",
-          "kind": "editor"
-        }
-      ]
+      "images": []
     },
     {
       "model": "EX1000C",
       "slug": "ex1000c",
-      "category": "exproof-mfc",
-      "boTable": "02_07_04_e",
-      "wrId": 2,
-      "images": [
-        {
-          "path": "/products/ex1000c/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_QCRE517J_3b301496e6b0a83df1ee935b55bfda28de3e2435.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex1000c/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_04_e/3543863211_WdLRsvrN_0034eef93dae4032d1e60562ab9c19a02cdf5168.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex1000c/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592471_2419.jpg",
-          "kind": "editor"
-        }
-      ]
+      "category": "specialized-mfc",
+      "images": []
     },
     {
-      "model": "EX070M",
-      "slug": "ex070m",
-      "category": "exproof-mfm",
-      "boTable": "02_07_05_e",
-      "wrId": 1,
-      "images": [
-        {
-          "path": "/products/ex070m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_qxGUdjVH_fddd4e125e35852245c5af2c6189be3c1502e576.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex070m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_FB3dYNVm_3177f76098a7c5ba5d04de1f98087b6c5b6e1dec.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex070m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592746_796.jpg",
-          "kind": "editor"
-        }
-      ]
+      "model": "EX70C",
+      "slug": "ex70c",
+      "category": "specialized-mfc",
+      "images": []
+    },
+    {
+      "model": "LEPC",
+      "slug": "lepc",
+      "category": "specialized-mfc",
+      "images": []
     },
     {
       "model": "EX1000M",
       "slug": "ex1000m",
-      "category": "exproof-mfm",
-      "boTable": "02_07_05_e",
-      "wrId": 2,
-      "images": [
-        {
-          "path": "/products/ex1000m/product-1.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_InJHbtMN_420d3c3552365412b8a82f41c718207fe5fba763.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex1000m/product-2.jpg",
-          "source": "https://line-tech.co.kr/data/file/02_07_05_e/3543863211_5oT3UjAK_63c0b825c09d2db917ac79b5cc60cc2acf837e26.jpg",
-          "kind": "product"
-        },
-        {
-          "path": "/products/ex1000m/editor-1.jpg",
-          "source": "https://line-tech.co.kr/data/editor/2101/a8cf6b714608d1ea29d5c103657b47bd_1610592923_3115.jpg",
-          "kind": "editor"
-        }
-      ]
+      "category": "specialized-mfm",
+      "images": []
+    },
+    {
+      "model": "EX70M",
+      "slug": "ex70m",
+      "category": "specialized-mfm",
+      "images": []
     }
   ]
 }

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -226,6 +226,12 @@ export const product = defineType({
         "Background-removed PNG for chip/card frames. Optional — surfaces fall back to images[0].",
     }),
     defineField({
+      name: "connectorType",
+      title: "Electrical connector",
+      type: "string",
+      description: "e.g. '15-Pin D-Connector', '9-Pin D-Connector'",
+    }),
+    defineField({
       name: "dimensionDrawing",
       type: "image",
     }),

--- a/scripts/delete-retired-products.ts
+++ b/scripts/delete-retired-products.ts
@@ -1,0 +1,68 @@
+import { createClient } from "@sanity/client";
+import { readFileSync } from "node:fs";
+
+for (const line of readFileSync(".env.local", "utf-8").split("\n")) {
+  const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+  if (m) process.env[m[1]] ??= m[2].trimEnd();
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  token: process.env.SANITY_WRITE_TOKEN!,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+async function main() {
+  // 1. Replace retired specialized entries with EX70C/LEPC
+  await client
+    .patch("category-showcases")
+    .set({
+      specialized: [
+        {
+          _key: "EX70C",
+          _type: "object",
+          caption: "Ex-proof, IP 65 — for hazardous environments",
+          product: { _ref: "product-ex70c", _type: "reference" },
+        },
+        {
+          _key: "LEPC",
+          _type: "object",
+          caption: "Low-pressure precision control, 0.1–6 barA",
+          product: { _ref: "product-lepc", _type: "reference" },
+        },
+      ],
+    })
+    .commit();
+  console.log("  patched  category-showcases.specialized");
+
+  // 2. Update the stale md100c → md150c ref in digital
+  const doc = await client.fetch<{
+    digital: { _key: string; caption: string; product: { _ref: string } }[];
+  }>(`*[_id == "category-showcases"][0]{ digital }`);
+
+  const updatedDigital = doc.digital.map((item) =>
+    item.product._ref === "product-md100c"
+      ? {
+          ...item,
+          _key: "MD150C",
+          product: { _ref: "product-md150c", _type: "reference" },
+        }
+      : item,
+  );
+
+  await client
+    .patch("category-showcases")
+    .set({ digital: updatedDigital })
+    .commit();
+  console.log("  patched  category-showcases.digital");
+
+  // 3. Delete the now-unreferenced retired docs
+  for (const slug of ["ld030c", "lm030c"]) {
+    await client.delete(`product-${slug}`);
+    console.log(`  deleted  product-${slug}`);
+  }
+}
+
+main();

--- a/scripts/delete-retired-products.ts
+++ b/scripts/delete-retired-products.ts
@@ -42,6 +42,9 @@ async function main() {
     digital: { _key: string; caption: string; product: { _ref: string } }[];
   }>(`*[_id == "category-showcases"][0]{ digital }`);
 
+  if (!doc?.digital)
+    throw new Error("category-showcases not found or has no digital field");
+
   const updatedDigital = doc.digital.map((item) =>
     item.product._ref === "product-md100c"
       ? {

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -387,7 +387,7 @@ function parseMaxPressure(raw: string): MaxPressure | undefined {
   const rangeMatch = raw.match(/([\d.]+)\s*~\s*([\d.]+)\s*barA/i);
   if (rangeMatch) {
     const value = parseFloat(rangeMatch[2]);
-    return { display: `${value} barA`, value, unit: "barA", comparator: "lt" };
+    return { display: `${value} barA`, value, unit: "barA", comparator: "eq" };
   }
   throw new Error(`Cannot parse max pressure: "${raw}"`);
 }

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -26,11 +26,18 @@ const CATALOG_PATH =
   process.env.CATALOG_PATH ??
   resolve(
     homedir(),
-    "Dev/linetech/company-docs-private/docs/product-catalog-2020-en.md",
+    "Dev/linetech/company-docs-private/docs/product-catalog-2026.md",
   );
 const OUTPUT_PATH = resolve(__dirname, "../src/lib/fixtures/products.json");
 
-const SKIP_MODELS = new Set(["LTI-200", "LTI-1000", "FC-050S", "PR-030"]);
+// DO400 is a special-order SKU with no fluid connection table in the 2026 catalog.
+const SKIP_MODELS = new Set([
+  "LTI-200",
+  "LTI-1000",
+  "FC-050S",
+  "PR-030",
+  "DO400",
+]);
 
 // Translation table.
 // - Korean follows modern Korean technical writing: spaces between native words
@@ -258,10 +265,24 @@ const FEATURES_EX = [
   "High Corrosion Resistance",
 ];
 
+// LEPC is a low-pressure specialized controller — no source feature text in 2026 catalog.
+const FEATURES_LEPC = [
+  "Accurate at Low Flow",
+  "Excellent Linearity",
+  "Long-Term Stability",
+  "High Corrosion Resistance",
+  "Compact Connection",
+];
+
+// 2026 catalog: EX1000(Controller) → EX1000C, EX70(Meter) → EX70M, etc.
+function normalizeModelName(raw: string): string {
+  return raw.replace(/\(Controller\)$/, "C").replace(/\(Meter\)$/, "M");
+}
+
 function determineSeries(model: string): Product["series"] {
   if (/^MD/.test(model)) return "digital";
   if (/^M[S]?\d/.test(model)) return "analogue";
-  if (/^(LD|LM|EX)/.test(model)) return "specialized";
+  if (/^(LD|LM|EX|LEPC)/.test(model)) return "specialized";
   throw new Error(`Cannot determine series for model "${model}"`);
 }
 
@@ -275,6 +296,7 @@ function featuresFor(model: string): string[] {
   if (/^LD/.test(model)) return FEATURES_LD;
   if (/^LM/.test(model)) return FEATURES_LM;
   if (/^EX/.test(model)) return FEATURES_EX;
+  if (/^LEPC/.test(model)) return FEATURES_LEPC;
   return SHARED_FEATURES_M_MS_MD;
 }
 
@@ -355,15 +377,19 @@ function parseSupplyPower(raw: string): SupplyPower {
 
 function parseMaxPressure(raw: string): MaxPressure | undefined {
   if (/inquiry/i.test(raw)) return undefined;
-  const m = raw.match(/<\s*([\d.]+)\s*bar/i);
-  if (!m) throw new Error(`Cannot parse max pressure: "${raw}"`);
-  const value = parseFloat(m[1]);
-  return {
-    display: `<${value} bar`,
-    value,
-    unit: "bar",
-    comparator: "lt",
-  };
+  // Standard format: "< 90bar", "< 13 barG"
+  const ltMatch = raw.match(/<\s*([\d.]+)\s*bar/i);
+  if (ltMatch) {
+    const value = parseFloat(ltMatch[1]);
+    return { display: `<${value} bar`, value, unit: "bar", comparator: "lt" };
+  }
+  // LEPC format: "0.1~6 barA" (absolute pressure range — use upper bound as max)
+  const rangeMatch = raw.match(/([\d.]+)\s*~\s*([\d.]+)\s*barA/i);
+  if (rangeMatch) {
+    const value = parseFloat(rangeMatch[2]);
+    return { display: `${value} barA`, value, unit: "barA", comparator: "lt" };
+  }
+  throw new Error(`Cannot parse max pressure: "${raw}"`);
 }
 
 function parseTempRange(raw: string): TempRange {
@@ -462,7 +488,7 @@ function parseAtAGlance(catalog: string): Map<string, AtAGlanceRow> {
       if (j >= lines.length) continue;
       const { rows, endIdx } = parseMarkdownTable(lines, j);
       for (const row of rows) {
-        const model = row["Model"];
+        const model = normalizeModelName(row["Model"] ?? "");
         if (!model) continue;
         map.set(model, {
           flowRange: row["Full Scale N2 (slpm)"] ?? "",
@@ -497,8 +523,8 @@ function extractProductSections(catalog: string): ProductSection[] {
   for (const line of lines) {
     // top-level section markers we care about
     if (/^##\s+\d+\.\s/.test(line)) {
-      // entering a new ## section
-      if (/##\s+(4|5|6)\./.test(line)) inMassFlowSection = true;
+      // entering a new ## section — 2026 product sections are 5, 6, 7, 8
+      if (/##\s+(5|6|7|8)\./.test(line)) inMassFlowSection = true;
       else inMassFlowSection = false;
       if (current) sections.push(current);
       current = null;
@@ -507,19 +533,21 @@ function extractProductSections(catalog: string): ProductSection[] {
 
     if (!inMassFlowSection) continue;
 
+    // 2026 headings: "### M3030VA — Mass Flow Controller" (no page number)
+    // 2026 EX headings: "### EX1000(Controller) — Mass Flow Controller"
     const headingMatch = line.match(
-      /^###\s+([\w-]+)\s+—\s+(.+?)\s+\(page\s+(\d+)\)/,
+      /^###\s+([\w()-]+)\s+—\s+(.+?)(?:\s+\(page\s+\d+\))?\s*$/,
     );
     if (headingMatch) {
       if (current) sections.push(current);
-      const model = headingMatch[1];
+      const model = normalizeModelName(headingMatch[1]);
       if (SKIP_MODELS.has(model)) {
         current = null;
       } else {
         current = {
           model,
           headingTitle: headingMatch[2],
-          page: parseInt(headingMatch[3], 10),
+          page: 0,
           body: [],
         };
       }
@@ -538,7 +566,8 @@ function parseConnectionTable(body: string[]): Connection[] {
       const { rows } = parseMarkdownTable(body, i);
       return rows.map((row) => {
         const type = normalizeQuotes(row["Connection"] ?? "").trim();
-        const lengthRaw = row["A (mm)"] ?? "";
+        // 2026 catalog uses '"A" Dimension (mm)', 2020 used 'A (mm)'
+        const lengthRaw = row['"A" Dimension (mm)'] ?? row["A (mm)"] ?? "";
         return { type, length: `${lengthRaw} mm` };
       });
     }
@@ -557,6 +586,7 @@ type MiniSpecTable = {
   maxTemp?: string;
   leakRate?: string;
   controlRange?: string;
+  connectorType?: string;
 };
 
 function parseMiniSpecTable(body: string[]): MiniSpecTable {
@@ -576,11 +606,13 @@ function parseMiniSpecTable(body: string[]): MiniSpecTable {
         accuracy: map["Accuracy"],
         repeatability: map["Repeatability"],
         ioSignal: map["In/Out Signal"],
-        supply: map["Supply"],
+        // 2026 catalog uses "Supply Power"; 2020 used "Supply"
+        supply: map["Supply Power"] ?? map["Supply"],
         maxPressure: map["Max Operating Pressure"],
         maxTemp: map["Max Operating Temp"],
         leakRate: map["Leak Rate"],
         controlRange: map["Control Range"],
+        connectorType: map["Electrical Connection"],
       };
     }
   }
@@ -611,12 +643,19 @@ function buildMassFlowSpecs(
     mini.repeatability ?? glance?.repeatability ?? "±0.25 %";
   const repeatability = parseRepeatability(repeatabilityRaw);
 
-  // Response time: only for MFC
+  // Response time: only for MFC. Specialized series (e.g., LEPC) may omit it.
   let responseTime: ResponseTime | undefined;
   if (function_ === "MFC") {
-    const responseRaw =
-      mini.responseTime ?? glance?.response ?? defaultResponse(series);
-    responseTime = parseResponseTime(responseRaw);
+    const explicitResponse =
+      mini.responseTime ??
+      (glance?.response && glance.response !== "-"
+        ? glance.response
+        : undefined);
+    if (explicitResponse) {
+      responseTime = parseResponseTime(explicitResponse);
+    } else if (series !== "specialized") {
+      responseTime = parseResponseTime(defaultResponse(series));
+    }
   }
 
   // IO signal
@@ -690,6 +729,7 @@ function buildProduct(
     datasheets: [],
     manuals: [],
     drawings: [],
+    ...(mini.connectorType ? { connectorType: mini.connectorType } : {}),
   };
   if (series === "digital") {
     product.digitalCommunication = STANDARD_DIGITAL_COMM;
@@ -713,7 +753,8 @@ function validate(p: Product): void {
     throw new Error(`${p.model}: bad flowRange`);
   if (s.accuracy.value! <= 0)
     throw new Error(`${p.model}: bad accuracy ${s.accuracy.value}`);
-  if (p.function === "MFC" && !s.responseTime)
+  // Specialized MFCs (e.g., LEPC) legitimately omit response time
+  if (p.function === "MFC" && p.series !== "specialized" && !s.responseTime)
     throw new Error(`${p.model}: MFC missing responseTime`);
   if (p.series === "digital" && !p.digitalCommunication)
     throw new Error(`${p.model}: digital missing digitalCommunication`);

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -56,6 +56,9 @@ function productToSeedFields(p: Product) {
   if (p.digitalCommunication) {
     fields.digitalCommunication = p.digitalCommunication;
   }
+  if (p.connectorType) {
+    fields.connectorType = p.connectorType;
+  }
   return fields;
 }
 

--- a/scripts/seed-tags.ts
+++ b/scripts/seed-tags.ts
@@ -91,25 +91,20 @@ const TAGS: TagDef[] = [
       zh: "危险环境",
     },
   },
+  {
+    slug: "mid-flow",
+    kind: "capability",
+    label: { ko: "중간 유량", en: "Mid flow", zh: "中等流量" },
+  },
+  {
+    slug: "low-pressure",
+    kind: "capability",
+    label: { ko: "저압", en: "Low pressure", zh: "低压" },
+  },
 ];
 
 function tagsForProduct(p: Product): string[] {
-  const tags: string[] = [];
-  if (p.series === "digital") tags.push("digital");
-  if (p.model.startsWith("LM")) tags.push("mems");
-  if (p.model.startsWith("EX")) {
-    tags.push("explosion-proof");
-    tags.push("hazardous-environment");
-  }
-  if (p.model.startsWith("LD")) tags.push("integrated-display");
-  const { min, max } = p.massFlowSpecs.flowRange;
-  if (min !== undefined && max !== undefined) {
-    // Catalog tops out at 30 slpm for ultra-low models; >=1000 marks the high-flow band.
-    if (min <= 0.01 && max <= 30) tags.push("ultra-low-flow");
-    if (max >= 1000) tags.push("high-flow");
-  }
-  if (p.function === "MFM") tags.push("meter-only");
-  return tags;
+  return p.tagSlugs ?? [];
 }
 
 function tagDocFields(t: TagDef) {

--- a/scripts/upload-cutouts-2026.ts
+++ b/scripts/upload-cutouts-2026.ts
@@ -1,0 +1,60 @@
+import { readFileSync, createReadStream, existsSync } from "node:fs";
+import path from "node:path";
+import { createClient } from "@sanity/client";
+
+for (const line of readFileSync(".env.local", "utf-8").split("\n")) {
+  const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+  if (m) process.env[m[1]] ??= m[2].trimEnd();
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  token: process.env.SANITY_WRITE_TOKEN!,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+const PRODUCTS_DIR = path.join(process.cwd(), "public/products");
+
+// Products with updated 2026 cutout PNGs (prefer cutout-2026.png over cutout.png)
+const CUTOUT_2026 = [
+  "m2030va", "m3030va",
+  "ms2400va", "ms2500va", "ms2600va", "ms2700va", "ms2800va",
+  "ms3150va", "ms3400va", "ms3500va", "ms3600va", "ms3700va", "ms3800va",
+];
+
+// Renamed slugs — their Sanity docs are brand new, need cutout.png uploaded
+const RENAMED_NEW_CUTOUTS = ["ex70c", "ex70m", "md150c", "md150m"];
+
+async function uploadCutout(slug: string, filename: string) {
+  const filePath = path.join(PRODUCTS_DIR, slug, filename);
+  if (!existsSync(filePath)) {
+    console.log(`  missing  ${slug}/${filename}`);
+    return;
+  }
+
+  const asset = await client.assets.upload("image", createReadStream(filePath), {
+    filename: `${slug}-cutout.png`,
+  });
+
+  await client
+    .patch(`product-${slug}`)
+    .set({ cutout: { _type: "image", asset: { _type: "reference", _ref: asset._id } } })
+    .commit();
+
+  console.log(`  uploaded ${slug} (${filename})`);
+}
+
+async function main() {
+  console.log("Uploading 2026 cutouts...");
+  for (const slug of CUTOUT_2026) {
+    await uploadCutout(slug, "cutout-2026.png");
+  }
+  for (const slug of RENAMED_NEW_CUTOUTS) {
+    await uploadCutout(slug, "cutout.png");
+  }
+  console.log("Done.");
+}
+
+main();

--- a/scripts/upload-cutouts-2026.ts
+++ b/scripts/upload-cutouts-2026.ts
@@ -19,9 +19,19 @@ const PRODUCTS_DIR = path.join(process.cwd(), "public/products");
 
 // Products with updated 2026 cutout PNGs (prefer cutout-2026.png over cutout.png)
 const CUTOUT_2026 = [
-  "m2030va", "m3030va",
-  "ms2400va", "ms2500va", "ms2600va", "ms2700va", "ms2800va",
-  "ms3150va", "ms3400va", "ms3500va", "ms3600va", "ms3700va", "ms3800va",
+  "m2030va",
+  "m3030va",
+  "ms2400va",
+  "ms2500va",
+  "ms2600va",
+  "ms2700va",
+  "ms2800va",
+  "ms3150va",
+  "ms3400va",
+  "ms3500va",
+  "ms3600va",
+  "ms3700va",
+  "ms3800va",
 ];
 
 // Renamed slugs — their Sanity docs are brand new, need cutout.png uploaded
@@ -34,13 +44,22 @@ async function uploadCutout(slug: string, filename: string) {
     return;
   }
 
-  const asset = await client.assets.upload("image", createReadStream(filePath), {
-    filename: `${slug}-cutout.png`,
-  });
+  const asset = await client.assets.upload(
+    "image",
+    createReadStream(filePath),
+    {
+      filename: `${slug}-cutout.png`,
+    },
+  );
 
   await client
     .patch(`product-${slug}`)
-    .set({ cutout: { _type: "image", asset: { _type: "reference", _ref: asset._id } } })
+    .set({
+      cutout: {
+        _type: "image",
+        asset: { _type: "reference", _ref: asset._id },
+      },
+    })
     .commit();
 
   console.log(`  uploaded ${slug} (${filename})`);

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -92,17 +92,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -113,7 +107,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -139,9 +133,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "15-Pin D-Connector",
-    "tagSlugs": [
-      "ultra-low-flow"
-    ]
+    "tagSlugs": ["ultra-low-flow"]
   },
   {
     "model": "M3200VA",
@@ -236,17 +228,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -257,7 +243,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -283,9 +269,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "mid-flow"
-    ]
+    "tagSlugs": ["mid-flow"]
   },
   {
     "model": "MS3150VA",
@@ -380,17 +364,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -401,7 +379,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -427,9 +405,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "mid-flow"
-    ]
+    "tagSlugs": ["mid-flow"]
   },
   {
     "model": "MS3400VA",
@@ -524,17 +500,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -545,7 +515,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -571,9 +541,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow"
-    ]
+    "tagSlugs": ["high-flow"]
   },
   {
     "model": "MS3500VA",
@@ -664,17 +632,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -685,7 +647,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -711,9 +673,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow"
-    ]
+    "tagSlugs": ["high-flow"]
   },
   {
     "model": "MS3600VA",
@@ -804,17 +764,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -825,7 +779,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -851,9 +805,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow"
-    ]
+    "tagSlugs": ["high-flow"]
   },
   {
     "model": "MS3700VA",
@@ -940,17 +892,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -961,7 +907,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -987,9 +933,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow"
-    ]
+    "tagSlugs": ["high-flow"]
   },
   {
     "model": "MS3800VA",
@@ -1076,17 +1020,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1097,7 +1035,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1123,9 +1061,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow"
-    ]
+    "tagSlugs": ["high-flow"]
   },
   {
     "model": "M2030VA",
@@ -1220,17 +1156,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1241,7 +1171,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1261,10 +1191,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "15-Pin D-Connector",
-    "tagSlugs": [
-      "ultra-low-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["ultra-low-flow", "meter-only"]
   },
   {
     "model": "M2200VA",
@@ -1359,17 +1286,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1380,7 +1301,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1400,9 +1321,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "meter-only"
-    ]
+    "tagSlugs": ["meter-only"]
   },
   {
     "model": "MS2150VA",
@@ -1497,17 +1416,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1518,7 +1431,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1537,9 +1450,7 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "tagSlugs": [
-      "meter-only"
-    ]
+    "tagSlugs": ["meter-only"]
   },
   {
     "model": "MS2400VA",
@@ -1634,17 +1545,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1655,7 +1560,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1675,10 +1580,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["high-flow", "meter-only"]
   },
   {
     "model": "MS2500VA",
@@ -1769,17 +1671,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1790,7 +1686,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1810,10 +1706,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["high-flow", "meter-only"]
   },
   {
     "model": "MS2600VA",
@@ -1904,17 +1797,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -1925,7 +1812,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1945,10 +1832,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["high-flow", "meter-only"]
   },
   {
     "model": "MS2700VA",
@@ -2035,17 +1919,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2056,7 +1934,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2076,10 +1954,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["high-flow", "meter-only"]
   },
   {
     "model": "MS2800VA",
@@ -2166,17 +2041,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2187,7 +2056,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2207,10 +2076,7 @@
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
-    "tagSlugs": [
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["high-flow", "meter-only"]
   },
   {
     "model": "MD150C",
@@ -2305,17 +2171,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2326,7 +2186,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2358,9 +2218,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital"
-    ]
+    "tagSlugs": ["digital"]
   },
   {
     "model": "MD30C",
@@ -2455,17 +2313,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2476,7 +2328,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2508,10 +2360,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "ultra-low-flow"
-    ]
+    "tagSlugs": ["digital", "ultra-low-flow"]
   },
   {
     "model": "MD400C",
@@ -2606,17 +2455,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2627,7 +2470,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2659,9 +2502,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital"
-    ]
+    "tagSlugs": ["digital"]
   },
   {
     "model": "MD500C",
@@ -2752,17 +2593,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2773,7 +2608,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2805,10 +2640,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow"
-    ]
+    "tagSlugs": ["digital", "high-flow"]
   },
   {
     "model": "MD600C",
@@ -2899,17 +2731,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -2920,7 +2746,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2952,10 +2778,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow"
-    ]
+    "tagSlugs": ["digital", "high-flow"]
   },
   {
     "model": "MD700C",
@@ -3042,17 +2865,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3063,7 +2880,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3095,10 +2912,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow"
-    ]
+    "tagSlugs": ["digital", "high-flow"]
   },
   {
     "model": "MD800C",
@@ -3185,17 +2999,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3206,7 +3014,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3238,10 +3046,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow"
-    ]
+    "tagSlugs": ["digital", "high-flow"]
   },
   {
     "model": "MD150M",
@@ -3336,17 +3141,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3357,7 +3156,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3383,10 +3182,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "meter-only"]
   },
   {
     "model": "MD30M",
@@ -3481,17 +3277,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3502,7 +3292,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3528,11 +3318,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "ultra-low-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "ultra-low-flow", "meter-only"]
   },
   {
     "model": "MD400M",
@@ -3627,17 +3413,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3648,7 +3428,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3674,10 +3454,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "meter-only"]
   },
   {
     "model": "MD500M",
@@ -3768,17 +3545,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3789,7 +3560,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3815,11 +3586,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "high-flow", "meter-only"]
   },
   {
     "model": "MD600M",
@@ -3910,17 +3677,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -3931,7 +3692,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3957,11 +3718,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "high-flow", "meter-only"]
   },
   {
     "model": "MD700M",
@@ -4048,17 +3805,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4069,7 +3820,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4095,11 +3846,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "high-flow", "meter-only"]
   },
   {
     "model": "MD800M",
@@ -4186,17 +3933,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4207,7 +3948,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4233,11 +3974,7 @@
       "stopBits": 1,
       "parity": "None"
     },
-    "tagSlugs": [
-      "digital",
-      "high-flow",
-      "meter-only"
-    ]
+    "tagSlugs": ["digital", "high-flow", "meter-only"]
   },
   {
     "model": "EX1000C",
@@ -4336,17 +4073,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4357,7 +4088,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4382,11 +4113,7 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "tagSlugs": [
-      "explosion-proof",
-      "hazardous-environment",
-      "high-flow"
-    ]
+    "tagSlugs": ["explosion-proof", "hazardous-environment", "high-flow"]
   },
   {
     "model": "EX70C",
@@ -4489,17 +4216,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4510,7 +4231,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4535,10 +4256,7 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "tagSlugs": [
-      "explosion-proof",
-      "hazardous-environment"
-    ]
+    "tagSlugs": ["explosion-proof", "hazardous-environment"]
   },
   {
     "model": "LEPC",
@@ -4618,17 +4336,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4639,7 +4351,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4658,10 +4370,7 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "tagSlugs": [
-      "low-pressure",
-      "ultra-low-flow"
-    ]
+    "tagSlugs": ["low-pressure", "ultra-low-flow"]
   },
   {
     "model": "EX1000M",
@@ -4760,17 +4469,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4781,7 +4484,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4908,17 +4611,11 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": [
-          "0-5Vdc",
-          "4-20mA"
-        ]
+        "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [
-          15,
-          24
-        ],
+        "voltages": [15, 24],
         "currentMA": 350
       },
       "tempRange": {
@@ -4929,7 +4626,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-09,
+        "value": 1e-9,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4948,10 +4645,6 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "tagSlugs": [
-      "explosion-proof",
-      "hazardous-environment",
-      "meter-only"
-    ]
+    "tagSlugs": ["explosion-proof", "hazardous-environment", "meter-only"]
   }
 ]

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -56,15 +56,15 @@
     ],
     "connections": [
       {
-        "type": "1/8\" SW",
+        "type": "1/8\" SWG",
         "length": "126.7 mm"
       },
       {
-        "type": "1/4\" SW",
-        "length": "128 mm"
+        "type": "1/4\" SWG",
+        "length": "131.3 mm"
       },
       {
-        "type": "3/8\" SW",
+        "type": "3/8\" SWG",
         "length": "134.3 mm"
       },
       {
@@ -92,11 +92,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -129,400 +135,10 @@
         "comparator": "lt"
       }
     },
-    "description": {
-      "en": "Precision analogue MFC for ultra-low flow rates down to 0.01 slpm. Ideal for semiconductor deposition, R&D gas blending, and precision analysis where sub-1 slpm accuracy is critical.",
-      "ko": "0.01 slpm까지의 초저유량을 위한 정밀 아날로그 MFC입니다. 1 slpm 이하의 정확도가 중요한 반도체 증착, 연구개발용 가스 블렌딩 및 정밀 분석에 적합합니다.",
-      "zh": "适用于低至0.01 slpm超低流量的精密模拟质量流量控制器，适合1 slpm以下精度要求严格的半导体沉积、研发气体混合及精密分析应用。"
-    }
-  },
-  {
-    "model": "M2030VA",
-    "slug": {
-      "current": "m2030va"
-    },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "104.5 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "111.9 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "115.3 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "107.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "M3100VA",
-    "slug": {
-      "current": "m3100va"
-    },
-    "series": "analogue",
-    "function": "MFC",
-    "productLabel": {
-      "en": "Mass Flow Controller",
-      "ko": "질량 유량 제어기 (MFC)",
-      "zh": "质量流量控制器 (MFC)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\" SW",
-        "length": "145.9 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "149.3 mm"
-      },
-      {
-        "type": "1/2\" SW",
-        "length": "161.5 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "141.5 mm"
-      },
-      {
-        "type": "1/2\" VCR",
-        "length": "149 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
-    "description": {
-      "en": "Mid-range analogue MFC at 30–100 slpm with the broadest fitting selection in the lineup — five options from 1/4” to 1/2” SW and VCR. Built for integration-flexible gas control in CVD, etching, and industrial processes.",
-      "ko": "라인업 내 가장 다양한 피팅 옵션(1/4”~1/2” SW 및 VCR 5종)을 갖춘 30~100 slpm 중간 유량 아날로그 MFC입니다. CVD, 식각 및 산업 공정에서의 유연한 통합 설치에 적합합니다.",
-      "zh": "30–100 slpm中等流量模拟MFC，提供产品线中最丰富的接头选项（1/4”至1/2” SW及VCR，共五种），专为CVD、刻蚀及工业气体控制的灵活集成而设计。"
-    }
-  },
-  {
-    "model": "M2100VA",
-    "slug": {
-      "current": "m2100va"
-    },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\" SW",
-        "length": "127.4 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "130.8 mm"
-      },
-      {
-        "type": "1/2\" SW",
-        "length": "143 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "123 mm"
-      },
-      {
-        "type": "1/2\" VCR",
-        "length": "130.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "15-Pin D-Connector"
   },
   {
     "model": "M3200VA",
@@ -539,133 +155,6 @@
     "tags": [],
     "features": [
       {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\"SW",
-        "length": "145.9 mm"
-      },
-      {
-        "type": "3/8\"SW",
-        "length": "149.3 mm"
-      },
-      {
-        "type": "1/4\"VCR",
-        "length": "141.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
-    "description": {
-      "en": "Mid-range analogue MFC at 30–100 slpm in a flat-profile body — same performance as the M3100VA in a form factor better suited to space-constrained panel installations.",
-      "ko": "평판형 바디를 채택한 30~100 slpm 중간 유량 아날로그 MFC입니다. M3100VA와 동일한 성능을 공간 제약이 있는 패널 설치에 최적화된 폼팩터로 제공합니다.",
-      "zh": "采用扁平机身的30–100 slpm中等流量模拟MFC，性能与M3100VA相同，外形更适合空间受限的面板安装场合。"
-    }
-  },
-  {
-    "model": "M2200VA",
-    "slug": {
-      "current": "m2200va"
-    },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
         "en": "Accurate at Low Flow",
         "ko": "저유량에서도 정밀한 측정",
         "zh": "低流量下精准测量"
@@ -708,16 +197,20 @@
     ],
     "connections": [
       {
-        "type": "1/4\"SW",
-        "length": "145.9 mm"
+        "type": "1/4\" SWG",
+        "length": "144.8 mm"
       },
       {
-        "type": "3/8\"SW",
-        "length": "149.3 mm"
+        "type": "3/8\" SWG",
+        "length": "147.8 mm"
       },
       {
-        "type": "1/4\"VCR",
+        "type": "1/4\" VCR",
         "length": "141.5 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "148.8 mm"
       }
     ],
     "massFlowSpecs": {
@@ -740,11 +233,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -764,13 +263,23 @@
         "max": 100,
         "unit": "%"
       },
+      "responseTime": {
+        "display": "<2 seconds",
+        "value": 2,
+        "unit": "s",
+        "comparator": "lt"
+      },
       "maxPressure": {
         "display": "<90 bar",
         "value": 90,
         "unit": "bar",
         "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3150VA",
@@ -787,133 +296,6 @@
     "tags": [],
     "features": [
       {
-        "en": "Compact PCB Design",
-        "ko": "소형 PCB 설계",
-        "zh": "紧凑型PCB设计"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\"SW",
-        "length": "145.9 mm"
-      },
-      {
-        "type": "3/8\"SW",
-        "length": "149.3 mm"
-      },
-      {
-        "type": "1/4\"VCR",
-        "length": "141.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
-    "description": {
-      "en": "MS-Series compact evolution of the mid-range MFC. Same 30–100 slpm performance as the M3200VA with a smaller PCB footprint — for builds where enclosure space is at a premium.",
-      "ko": "MS 시리즈의 컴팩트한 중간 유량 MFC입니다. M3200VA와 동일한 30~100 slpm 성능을 더 작은 PCB 폼팩터로 제공하여 공간이 제한된 인클로저에 적합합니다.",
-      "zh": "MS系列紧凑型中等流量MFC，性能与M3200VA相同（30–100 slpm），PCB尺寸更小，适用于机箱空间紧张的应用场合。"
-    }
-  },
-  {
-    "model": "MS2150VA",
-    "slug": {
-      "current": "ms2150va"
-    },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
         "en": "Accurate at Low Flow",
         "ko": "저유량에서도 정밀한 측정",
         "zh": "低流量下精准测量"
@@ -956,22 +338,26 @@
     ],
     "connections": [
       {
-        "type": "1/4\"SW",
-        "length": "145.9 mm"
+        "type": "1/4\" SWG",
+        "length": "144.8 mm"
       },
       {
-        "type": "3/8\"SW",
-        "length": "149.3 mm"
+        "type": "3/8\" SWG",
+        "length": "147.8 mm"
       },
       {
-        "type": "1/4\"VCR",
-        "length": "141.5 mm"
+        "type": "1/4\" VCR",
+        "length": "141.3 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "148.9 mm"
       }
     ],
     "massFlowSpecs": {
       "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
+        "display": "0.01–100 slpm",
+        "min": 0.01,
         "max": 100,
         "unit": "slpm",
         "referenceGas": "N2"
@@ -988,11 +374,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -1012,13 +404,23 @@
         "max": 100,
         "unit": "%"
       },
+      "responseTime": {
+        "display": "<2 seconds",
+        "value": 2,
+        "unit": "s",
+        "comparator": "lt"
+      },
       "maxPressure": {
         "display": "<90 bar",
         "value": 90,
         "unit": "bar",
         "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3400VA",
@@ -1035,131 +437,6 @@
     "tags": [],
     "features": [
       {
-        "en": "High Flow Capacity",
-        "ko": "대용량 유량 제어",
-        "zh": "大流量控制能力"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      }
-    ],
-    "connections": [
-      {
-        "type": "3/8\"SW",
-        "length": "196.7 mm"
-      },
-      {
-        "type": "1/2\"SW",
-        "length": "209 mm"
-      },
-      {
-        "type": "3/4\"SW",
-        "length": "210.6 mm"
-      },
-      {
-        "type": "1/2\"VCR",
-        "length": "196.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "100–300 slpm",
-        "min": 100,
-        "max": 300,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      }
-    },
-    "description": {
-      "en": "High-volume analogue MFC for bulk gas delivery at 100–300 slpm. Large-bore fittings up to 3/4” SW, ±2% FS accuracy, and inlet pressure above 40 psig required for flows over 100 slpm. Operating pressure on request.",
-      "ko": "100~300 slpm의 대용량 가스 공급을 위한 고유량 아날로그 MFC입니다. 최대 3/4” SW 대구경 피팅, ±2% FS 정확도를 제공하며, 100 slpm 초과 유량에서는 40 psig 이상의 입구 압력이 필요합니다. 최대 운전 압력은 별도 문의 바랍니다.",
-      "zh": "适用于100–300 slpm大流量气体输送的模拟MFC。提供最大3/4” SW大口径接头，精度±2% FS，流量超过100 slpm时需40 psig以上入口压力。最大工作压力请询价。"
-    }
-  },
-  {
-    "model": "MS2400VA",
-    "slug": {
-      "current": "ms2400va"
-    },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
         "en": "Accurate at Low Flow",
         "ko": "저유량에서도 정밀한 측정",
         "zh": "低流量下精准测量"
@@ -1202,20 +479,20 @@
     ],
     "connections": [
       {
-        "type": "3/8\"SW",
-        "length": "152.8 mm"
+        "type": "3/8\" SWG",
+        "length": "196.7 mm"
       },
       {
-        "type": "1/2\"SW",
-        "length": "165 mm"
+        "type": "1/2\" SWG",
+        "length": "202.4 mm"
       },
       {
-        "type": "3/4\"SW",
-        "length": "166.6 mm"
+        "type": "3/4\" SWG",
+        "length": "210.6 mm"
       },
       {
-        "type": "1/2\"VCR",
-        "length": "152.5 mm"
+        "type": "1/2\" VCR",
+        "length": "197.5 mm"
       }
     ],
     "massFlowSpecs": {
@@ -1238,11 +515,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -1261,8 +544,24 @@
         "min": 3,
         "max": 100,
         "unit": "%"
+      },
+      "responseTime": {
+        "display": "<2 seconds",
+        "value": 2,
+        "unit": "s",
+        "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3500VA",
@@ -1321,15 +620,15 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "1/2\" SWG",
         "length": "246 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "247.6 mm"
+        "type": "3/4\" SWG",
+        "length": "246 mm"
       },
       {
-        "type": "1\" SW",
+        "type": "1 Inch\" SWG",
         "length": "254.6 mm"
       }
     ],
@@ -1353,11 +652,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -1382,123 +687,18 @@
         "value": 2,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
-  },
-  {
-    "model": "MS2500VA",
-    "slug": {
-      "current": "ms2500va"
     },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SW",
-        "length": "209 mm"
-      },
-      {
-        "type": "3/4\" SW",
-        "length": "210.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "217.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "300–1000 slpm",
-        "min": 300,
-        "max": 1000,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    }
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3600VA",
@@ -1557,15 +757,15 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "1/2\" SWG",
         "length": "246 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "247.6 mm"
+        "type": "3/4\" SWG",
+        "length": "246 mm"
       },
       {
-        "type": "1\" SW",
+        "type": "1 Inch\" SWG",
         "length": "254.6 mm"
       }
     ],
@@ -1589,11 +789,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -1618,123 +824,18 @@
         "value": 2,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
-  },
-  {
-    "model": "MS2600VA",
-    "slug": {
-      "current": "ms2600va"
     },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SW",
-        "length": "209 mm"
-      },
-      {
-        "type": "3/4\" SW",
-        "length": "210.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "217.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "1000–1500 slpm",
-        "min": 1000,
-        "max": 1500,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    }
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3700VA",
@@ -1793,15 +894,11 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "3/4\" SWG",
         "length": "248 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "249.6 mm"
-      },
-      {
-        "type": "1\" SW",
+        "type": "1 Inch\" SWG",
         "length": "256.6 mm"
       }
     ],
@@ -1825,11 +922,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -1854,123 +957,18 @@
         "value": 2,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
-  },
-  {
-    "model": "MS2700VA",
-    "slug": {
-      "current": "ms2700va"
     },
-    "series": "analogue",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter",
-      "ko": "질량 유량 측정기 (MFM)",
-      "zh": "质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SW",
-        "length": "213 mm"
-      },
-      {
-        "type": "3/4\" SW",
-        "length": "214.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "221.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "1500–2500 slpm",
-        "min": 1500,
-        "max": 2500,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    }
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS3800VA",
@@ -2029,16 +1027,12 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
-        "length": "257 mm"
+        "type": "3/4\" SWG",
+        "length": "250 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "259.8 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "267.8 mm"
+        "type": "1 Inch\" SWG",
+        "length": "268.6 mm"
       }
     ],
     "massFlowSpecs": {
@@ -2061,11 +1055,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -2090,8 +1090,946 @@
         "value": 2,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
+  },
+  {
+    "model": "M2030VA",
+    "slug": {
+      "current": "m2030va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/8\" SWG",
+        "length": "106.2 mm"
+      },
+      {
+        "type": "1/4\" SWG",
+        "length": "110.8 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "113.8 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "107.2 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–30 slpm",
+        "min": 0.01,
+        "max": 30,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "15-Pin D-Connector"
+  },
+  {
+    "model": "M2200VA",
+    "slug": {
+      "current": "m2200va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/4\" SWG",
+        "length": "144.8 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "147.8 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "141.5 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "148.8 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "30–100 slpm",
+        "min": 30,
+        "max": 100,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
+  },
+  {
+    "model": "MS2150VA",
+    "slug": {
+      "current": "ms2150va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/4\" SWG",
+        "length": "132.3 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "135.3 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "128.7 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "136.3 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–100 slpm",
+        "min": 0.01,
+        "max": 100,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
+  },
+  {
+    "model": "MS2400VA",
+    "slug": {
+      "current": "ms2400va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "3/8\" SWG",
+        "length": "152.8 mm"
+      },
+      {
+        "type": "1/2\" SWG",
+        "length": "158.4 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "166.6 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "152.5 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "100–300 slpm",
+        "min": 100,
+        "max": 300,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
+  },
+  {
+    "model": "MS2500VA",
+    "slug": {
+      "current": "ms2500va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/2\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "217.6 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "300–1000 slpm",
+        "min": 300,
+        "max": 1000,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
+  },
+  {
+    "model": "MS2600VA",
+    "slug": {
+      "current": "ms2600va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/2\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "217.6 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "1000–1500 slpm",
+        "min": 1000,
+        "max": 1500,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
+  },
+  {
+    "model": "MS2700VA",
+    "slug": {
+      "current": "ms2700va"
+    },
+    "series": "analogue",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "3/4\" SWG",
+        "length": "213 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "221.6 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "1500–2500 slpm",
+        "min": 1500,
+        "max": 2500,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
     "model": "MS2800VA",
@@ -2150,16 +2088,12 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
-        "length": "215 mm"
+        "type": "3/4\" SWG",
+        "length": "223 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "217 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "225.8 mm"
+        "type": "1 Inch\" SWG",
+        "length": "231.6 mm"
       }
     ],
     "massFlowSpecs": {
@@ -2182,11 +2116,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -2205,20 +2145,30 @@
         "min": 3,
         "max": 100,
         "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "connectorType": "9-Pin D-Connector"
   },
   {
-    "model": "MD30C",
+    "model": "MD150C",
     "slug": {
-      "current": "md30c"
+      "current": "md150c"
     },
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -2265,15 +2215,162 @@
     ],
     "connections": [
       {
-        "type": "1/8\" SW",
+        "type": "1/4\" SWG",
+        "length": "144.8 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "147.8 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "141.2 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "148.8 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–100 slpm",
+        "min": 0.01,
+        "max": 100,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "responseTime": {
+        "display": "<1 second",
+        "value": 1,
+        "unit": "s",
+        "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD30C",
+    "slug": {
+      "current": "md30c"
+    },
+    "series": "digital",
+    "function": "MFC",
+    "productLabel": {
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/8\" SWG",
         "length": "126.7 mm"
       },
       {
-        "type": "1/4\" SW",
-        "length": "128 mm"
+        "type": "1/4\" SWG",
+        "length": "131.3 mm"
       },
       {
-        "type": "3/8\" SW",
+        "type": "3/8\" SWG",
         "length": "134.3 mm"
       },
       {
@@ -2301,11 +2398,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -2338,416 +2441,9 @@
         "comparator": "lt"
       }
     },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD30M",
-    "slug": {
-      "current": "md30m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "104.5 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "111.9 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "115.3 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "107.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD100C",
-    "slug": {
-      "current": "md100c"
-    },
-    "series": "digital",
-    "function": "MFC",
-    "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\" SW",
-        "length": "145.9 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "149.3 mm"
-      },
-      {
-        "type": "1/2\" SW",
-        "length": "161.5 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "141.5 mm"
-      },
-      {
-        "type": "1/2\" VCR",
-        "length": "149 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<1 second",
-        "value": 1,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD100M",
-    "slug": {
-      "current": "md100m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/4\" SW",
-        "length": "127.4 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "130.8 mm"
-      },
-      {
-        "type": "1/2\" SW",
-        "length": "143 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "123 mm"
-      },
-      {
-        "type": "1/2\" VCR",
-        "length": "130.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "30–100 slpm",
-        "min": 30,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -2764,9 +2460,9 @@
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -2813,20 +2509,20 @@
     ],
     "connections": [
       {
-        "type": "3/8\"SWG",
-        "length": "196.8 mm"
+        "type": "3/8\" SWG",
+        "length": "196.7 mm"
       },
       {
-        "type": "1/2\"SWG",
-        "length": "209 mm"
+        "type": "1/2\" SWG",
+        "length": "202.4 mm"
       },
       {
-        "type": "3/4\"SWG",
+        "type": "3/4\" SWG",
         "length": "210.6 mm"
       },
       {
-        "type": "1/2\"VCR",
-        "length": "196.5 mm"
+        "type": "1/2\" VCR",
+        "length": "196.4 mm"
       }
     ],
     "massFlowSpecs": {
@@ -2849,11 +2545,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -2878,134 +2580,17 @@
         "value": 1,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD400M",
-    "slug": {
-      "current": "md400m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "3/8\"SWG",
-        "length": "152.8 mm"
-      },
-      {
-        "type": "1/2\"SWG",
-        "length": "165 mm"
-      },
-      {
-        "type": "3/4\"SWG",
-        "length": "166.6 mm"
-      },
-      {
-        "type": "1/2\"VCR",
-        "length": "152.5 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "100–300 slpm",
-        "min": 100,
-        "max": 300,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -3022,9 +2607,9 @@
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -3071,16 +2656,16 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "1/2\" SWG",
         "length": "246 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "247.6 mm"
+        "type": "3/4\" SWG",
+        "length": "246 mm"
       },
       {
-        "type": "1\" SW",
-        "length": "254.6 mm"
+        "type": "1 Inch\" SWG",
+        "length": "254.7 mm"
       }
     ],
     "massFlowSpecs": {
@@ -3103,11 +2688,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -3132,130 +2723,17 @@
         "value": 1,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD500M",
-    "slug": {
-      "current": "md500m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SW",
-        "length": "209 mm"
-      },
-      {
-        "type": "3/4\" SW",
-        "length": "210.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "217.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "300–1000 slpm",
-        "min": 300,
-        "max": 1000,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -3272,9 +2750,9 @@
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -3321,16 +2799,16 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "1/2\" SWG",
         "length": "246 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "247.6 mm"
+        "type": "3/4\" SWG",
+        "length": "246 mm"
       },
       {
-        "type": "1\" SW",
-        "length": "254.6 mm"
+        "type": "1 Inch\" SWG",
+        "length": "254.7 mm"
       }
     ],
     "massFlowSpecs": {
@@ -3353,11 +2831,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -3382,130 +2866,17 @@
         "value": 1,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD600M",
-    "slug": {
-      "current": "md600m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SW",
-        "length": "209 mm"
-      },
-      {
-        "type": "3/4\" SW",
-        "length": "210.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "217.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "1000–1500 slpm",
-        "min": 1000,
-        "max": 1500,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -3522,9 +2893,9 @@
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -3571,16 +2942,12 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "3/4\" SWG",
         "length": "248 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "249.6 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "256.6 mm"
+        "type": "1 Inch\" SWG",
+        "length": "256.7 mm"
       }
     ],
     "massFlowSpecs": {
@@ -3603,11 +2970,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -3632,130 +3005,17 @@
         "value": 1,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
-    "digitalCommunication": {
-      "protocol": "RS-485",
-      "baudRate": 38400,
-      "dataBits": 8,
-      "stopBits": 1,
-      "parity": "None"
-    }
-  },
-  {
-    "model": "MD700M",
-    "slug": {
-      "current": "md700m"
-    },
-    "series": "digital",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate at Low Flow",
-        "ko": "저유량에서도 정밀한 측정",
-        "zh": "低流量下精准测量"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Highly Stable Removable Sensor",
-        "ko": "고안정 분리형 센서",
-        "zh": "高稳定可拆卸式传感器"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/2\" SWG",
-        "length": "213 mm"
-      },
-      {
-        "type": "3/4\" SWG",
-        "length": "214.6 mm"
-      },
-      {
-        "type": "1\" SWG",
-        "length": "221.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "1500–2500 slpm",
-        "min": 1500,
-        "max": 2500,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      }
-    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -3772,9 +3032,9 @@
     "series": "digital",
     "function": "MFC",
     "productLabel": {
-      "en": "Digital Mass Flow Controller",
-      "ko": "디지털 질량 유량 제어기 (Digital MFC)",
-      "zh": "数字式质量流量控制器 (Digital MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -3821,16 +3081,12 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
-        "length": "257 mm"
+        "type": "3/4\" SWG",
+        "length": "260 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "259.8 mm"
-      },
-      {
-        "type": "1\" SW",
-        "length": "267.8 mm"
+        "type": "1 Inch\" SWG",
+        "length": "268.7 mm"
       }
     ],
     "massFlowSpecs": {
@@ -3853,11 +3109,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -3882,8 +3144,17 @@
         "value": 1,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
@@ -3893,16 +3164,439 @@
     }
   },
   {
-    "model": "MD800M",
+    "model": "MD150M",
     "slug": {
-      "current": "md800m"
+      "current": "md150m"
     },
     "series": "digital",
     "function": "MFM",
     "productLabel": {
-      "en": "Digital Mass Flow Meter",
-      "ko": "디지털 질량 유량 측정기 (Digital MFM)",
-      "zh": "数字式质量流量计 (Digital MFM)"
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/4\" SWG",
+        "length": "132.3 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "135.3 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "128.7 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "136.3 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–100 slpm",
+        "min": 0.01,
+        "max": 100,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD30M",
+    "slug": {
+      "current": "md30m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/8\" SWG",
+        "length": "106.2 mm"
+      },
+      {
+        "type": "1/4\" SWG",
+        "length": "110.8 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "113.8 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "107.2 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–30 slpm",
+        "min": 0.01,
+        "max": 30,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD400M",
+    "slug": {
+      "current": "md400m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "3/8\" SWG",
+        "length": "152.8 mm"
+      },
+      {
+        "type": "1/2\" SWG",
+        "length": "158.4 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "166.6 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "152.4 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "100–300 slpm",
+        "min": 100,
+        "max": 300,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD500M",
+    "slug": {
+      "current": "md500m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
     },
     "tags": [],
     "features": [
@@ -3950,15 +3644,418 @@
     "connections": [
       {
         "type": "1/2\" SWG",
-        "length": "215 mm"
+        "length": "209 mm"
       },
       {
         "type": "3/4\" SWG",
-        "length": "217 mm"
+        "length": "209 mm"
       },
       {
-        "type": "1\" SWG",
-        "length": "225.8 mm"
+        "type": "1 Inch\" SWG",
+        "length": "217.7 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "300–1000 slpm",
+        "min": 300,
+        "max": 1000,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD600M",
+    "slug": {
+      "current": "md600m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/2\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "209 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "217.7 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "1000–1500 slpm",
+        "min": 1000,
+        "max": 1500,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD700M",
+    "slug": {
+      "current": "md700m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "3/4\" SWG",
+        "length": "213 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "221.7 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "1500–2500 slpm",
+        "min": 1500,
+        "max": 2500,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±1% of FS",
+        "value": 1,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
+    "digitalCommunication": {
+      "protocol": "RS-485",
+      "baudRate": 38400,
+      "dataBits": 8,
+      "stopBits": 1,
+      "parity": "None"
+    }
+  },
+  {
+    "model": "MD800M",
+    "slug": {
+      "current": "md800m"
+    },
+    "series": "digital",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Fast Response",
+        "ko": "빠른 응답 속도",
+        "zh": "快速响应"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Highly Stable Removable Sensor",
+        "ko": "고안정 분리형 센서",
+        "zh": "高稳定可拆卸式传感器"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "3/4\" SWG",
+        "length": "223 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "231.7 mm"
       }
     ],
     "massFlowSpecs": {
@@ -3981,11 +4078,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -4004,774 +4107,23 @@
         "min": 3,
         "max": 100,
         "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
       }
     },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": [],
     "digitalCommunication": {
       "protocol": "RS-485",
       "baudRate": 38400,
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
-  },
-  {
-    "model": "LD030C",
-    "slug": {
-      "current": "ld030c"
-    },
-    "series": "specialized",
-    "function": "MFC",
-    "productLabel": {
-      "en": "Mass Flow Controller with Display",
-      "ko": "디스플레이 일체형 질량 유량 제어기 (MFC)",
-      "zh": "带显示屏质量流量控制器 (MFC)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate Real Time Flow Measurements",
-        "ko": "실시간 정밀 유량 측정",
-        "zh": "实时精准流量测量"
-      },
-      {
-        "en": "Real Time Setting Changes",
-        "ko": "실시간 설정 변경 지원",
-        "zh": "支持实时参数调整"
-      },
-      {
-        "en": "Built-in 7-Segment Display",
-        "ko": "7-세그먼트 디스플레이 내장",
-        "zh": "内置七段数码显示屏"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "140.2 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "141.5 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "147.8 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "141.3 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc",
-        "outputs": ["0-5Vdc"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "LD030M",
-    "slug": {
-      "current": "ld030m"
-    },
-    "series": "specialized",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Mass Flow Meter with Display",
-      "ko": "디스플레이 일체형 질량 유량 측정기 (MFM)",
-      "zh": "带显示屏质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Accurate Real Time Flow Measurements",
-        "ko": "실시간 정밀 유량 측정",
-        "zh": "实时精准流量测量"
-      },
-      {
-        "en": "Real Time Setting Changes",
-        "ko": "실시간 설정 변경 지원",
-        "zh": "支持实时参数调整"
-      },
-      {
-        "en": "Built-in 7-Segment Display",
-        "ko": "7-세그먼트 디스플레이 내장",
-        "zh": "内置七段数码显示屏"
-      },
-      {
-        "en": "Fast Response",
-        "ko": "빠른 응답 속도",
-        "zh": "快速响应"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "140.2 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "141.5 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "147.8 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "141.3 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc",
-        "outputs": ["0-5Vdc"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "LM030C",
-    "slug": {
-      "current": "lm030c"
-    },
-    "series": "specialized",
-    "function": "MFC",
-    "productLabel": {
-      "en": "MEMS-Tech Mass Flow Controller",
-      "ko": "MEMS 기반 질량 유량 제어기 (MFC)",
-      "zh": "MEMS 技术质量流量控制器 (MFC)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "MEMS-Tech Sensor",
-        "ko": "MEMS 기반 센서",
-        "zh": "MEMS 传感器"
-      },
-      {
-        "en": "Cost-Efficient Design",
-        "ko": "경제적인 설계",
-        "zh": "高性价比设计"
-      },
-      {
-        "en": "Improved Response Time",
-        "ko": "향상된 응답 속도",
-        "zh": "更快的响应速度"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "126.7 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "128 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "134.3 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "127.8 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<1 second",
-        "value": 1,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<10 bar",
-        "value": 10,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "LM030M",
-    "slug": {
-      "current": "lm030m"
-    },
-    "series": "specialized",
-    "function": "MFM",
-    "productLabel": {
-      "en": "MEMS-Tech Mass Flow Meter",
-      "ko": "MEMS 기반 질량 유량 측정기 (MFM)",
-      "zh": "MEMS 技术质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "MEMS-Tech Sensor",
-        "ko": "MEMS 기반 센서",
-        "zh": "MEMS 传感器"
-      },
-      {
-        "en": "Cost-Efficient Design",
-        "ko": "경제적인 설계",
-        "zh": "高性价比设计"
-      },
-      {
-        "en": "Improved Response Time",
-        "ko": "향상된 응답 속도",
-        "zh": "更快的响应速度"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      },
-      {
-        "en": "Compact Connection",
-        "ko": "컴팩트한 연결부",
-        "zh": "紧凑型连接结构"
-      }
-    ],
-    "connections": [
-      {
-        "type": "1/8\" SW",
-        "length": "106.2 mm"
-      },
-      {
-        "type": "1/4\" SW",
-        "length": "107.5 mm"
-      },
-      {
-        "type": "3/8\" SW",
-        "length": "113.8 mm"
-      },
-      {
-        "type": "1/4\" VCR",
-        "length": "107.3 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–30 slpm",
-        "min": 0.01,
-        "max": 30,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<10 bar",
-        "value": 10,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "EX070C",
-    "slug": {
-      "current": "ex070c"
-    },
-    "series": "specialized",
-    "function": "MFC",
-    "productLabel": {
-      "en": "Ex-Proof Mass Flow Controller",
-      "ko": "방폭형 질량 유량 제어기 (MFC)",
-      "zh": "防爆型质量流量控制器 (MFC)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Explosion-Proof for Hazardous Environments",
-        "ko": "위험 지역용 방폭 설계",
-        "zh": "适用于危险场所的防爆设计"
-      },
-      {
-        "en": "Ex ec IIC T4 Gc Certified",
-        "ko": "Ex ec IIC T4 Gc 방폭 인증",
-        "zh": "Ex ec IIC T4 Gc 防爆认证"
-      },
-      {
-        "en": "IP 65 Rated",
-        "ko": "IP 65 보호 등급",
-        "zh": "IP 65 防护等级"
-      },
-      {
-        "en": "Robust Industrial Construction",
-        "ko": "견고한 산업용 구조",
-        "zh": "坚固的工业级结构"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      }
-    ],
-    "connections": [
-      {
-        "type": "3/8\"SW",
-        "length": "178.8 mm"
-      },
-      {
-        "type": "1/2\"SW",
-        "length": "191 mm"
-      },
-      {
-        "type": "3/4\"SW",
-        "length": "192.6 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–100 slpm",
-        "min": 0.01,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "responseTime": {
-        "display": "<2 seconds",
-        "value": 2,
-        "unit": "s",
-        "comparator": "lt"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
-    }
-  },
-  {
-    "model": "EX070M",
-    "slug": {
-      "current": "ex070m"
-    },
-    "series": "specialized",
-    "function": "MFM",
-    "productLabel": {
-      "en": "Ex-Proof Mass Flow Meter",
-      "ko": "방폭형 질량 유량 측정기 (MFM)",
-      "zh": "防爆型质量流量计 (MFM)"
-    },
-    "tags": [],
-    "features": [
-      {
-        "en": "Explosion-Proof for Hazardous Environments",
-        "ko": "위험 지역용 방폭 설계",
-        "zh": "适用于危险场所的防爆设计"
-      },
-      {
-        "en": "Ex ec IIC T4 Gc Certified",
-        "ko": "Ex ec IIC T4 Gc 방폭 인증",
-        "zh": "Ex ec IIC T4 Gc 防爆认证"
-      },
-      {
-        "en": "IP 65 Rated",
-        "ko": "IP 65 보호 등급",
-        "zh": "IP 65 防护等级"
-      },
-      {
-        "en": "Robust Industrial Construction",
-        "ko": "견고한 산업용 구조",
-        "zh": "坚固的工业级结构"
-      },
-      {
-        "en": "Wide Pressure Range Compatibility",
-        "ko": "넓은 압력 범위 대응",
-        "zh": "宽压力范围适用"
-      },
-      {
-        "en": "Excellent Linearity",
-        "ko": "우수한 선형성",
-        "zh": "优异的线性度"
-      },
-      {
-        "en": "Long-Term Stability",
-        "ko": "장기 안정성",
-        "zh": "长期稳定性"
-      },
-      {
-        "en": "High Corrosion Resistance",
-        "ko": "강한 내부식성",
-        "zh": "高耐腐蚀性"
-      }
-    ],
-    "connections": [
-      {
-        "type": "3/8\"SWG",
-        "length": "197 mm"
-      },
-      {
-        "type": "1/2\"SWG",
-        "length": "206 mm"
-      },
-      {
-        "type": "3/4\"SWG",
-        "length": "209 mm"
-      }
-    ],
-    "massFlowSpecs": {
-      "flowRange": {
-        "display": "0.01–100 slpm",
-        "min": 0.01,
-        "max": 100,
-        "unit": "slpm",
-        "referenceGas": "N2"
-      },
-      "accuracy": {
-        "display": "±1% of FS",
-        "value": 1,
-        "unit": "%FS"
-      },
-      "repeatability": {
-        "display": "±0.25% of FS",
-        "value": 0.25,
-        "unit": "%FS"
-      },
-      "ioSignal": {
-        "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
-      },
-      "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
-        "currentMA": 350
-      },
-      "tempRange": {
-        "display": "0–50 °C",
-        "min": 0,
-        "max": 50,
-        "unit": "°C"
-      },
-      "leakRate": {
-        "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
-        "unit": "atm·cc/sec"
-      },
-      "controlRange": {
-        "display": "3–100%",
-        "min": 3,
-        "max": 100,
-        "unit": "%"
-      },
-      "maxPressure": {
-        "display": "<90 bar",
-        "value": 90,
-        "unit": "bar",
-        "comparator": "lt"
-      }
     }
   },
   {
@@ -4782,9 +4134,9 @@
     "series": "specialized",
     "function": "MFC",
     "productLabel": {
-      "en": "Ex-Proof Mass Flow Controller",
-      "ko": "방폭형 질량 유량 제어기 (MFC)",
-      "zh": "防爆型质量流量控制器 (MFC)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -4831,22 +4183,30 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
+        "type": "1/2\" SWG",
         "length": "221 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "222.6 mm"
+        "type": "3/4\" SWG",
+        "length": "221 mm"
       },
       {
-        "type": "1\" SW",
-        "length": "229.6 mm"
+        "type": "1 Inch\" SWG",
+        "length": "229.7 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "199 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "210.2 mm"
       }
     ],
     "massFlowSpecs": {
       "flowRange": {
-        "display": "100–1000 slpm",
-        "min": 100,
+        "display": "70–1000 slpm",
+        "min": 70,
         "max": 1000,
         "unit": "slpm",
         "referenceGas": "N2"
@@ -4863,11 +4223,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -4892,20 +4258,29 @@
         "value": 2,
         "unit": "s",
         "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
   },
   {
-    "model": "EX1000M",
+    "model": "EX70C",
     "slug": {
-      "current": "ex1000m"
+      "current": "ex70c"
     },
     "series": "specialized",
-    "function": "MFM",
+    "function": "MFC",
     "productLabel": {
-      "en": "Ex-Proof Mass Flow Meter",
-      "ko": "방폭형 질량 유량 측정기 (MFM)",
-      "zh": "防爆型质量流量计 (MFM)"
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
     },
     "tags": [],
     "features": [
@@ -4952,29 +4327,41 @@
     ],
     "connections": [
       {
-        "type": "1/2\" SW",
-        "length": "218 mm"
+        "type": "1/4\" SWG",
+        "length": "175.8 mm"
       },
       {
-        "type": "3/4\" SW",
-        "length": "221 mm"
+        "type": "3/8\" SWG",
+        "length": "178.8 mm"
       },
       {
-        "type": "1\" SW",
-        "length": "229.8 mm"
+        "type": "1/2\" SWG",
+        "length": "184.4 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "192.6 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "169 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "177 mm"
       }
     ],
     "massFlowSpecs": {
       "flowRange": {
-        "display": "100–1000 slpm",
-        "min": 100,
-        "max": 1000,
+        "display": "0.01–70 slpm",
+        "min": 0.01,
+        "max": 70,
         "unit": "slpm",
         "referenceGas": "N2"
       },
       "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
+        "display": "±1% of FS",
+        "value": 1,
         "unit": "%FS"
       },
       "repeatability": {
@@ -4984,11 +4371,17 @@
       },
       "ioSignal": {
         "display": "0–5 Vdc or 4–20 mA",
-        "outputs": ["0-5Vdc", "4-20mA"]
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
       },
       "supplyPower": {
         "display": "+15 or +24 Vdc, 350 mA",
-        "voltages": [15, 24],
+        "voltages": [
+          15,
+          24
+        ],
         "currentMA": 350
       },
       "tempRange": {
@@ -5007,7 +4400,421 @@
         "min": 3,
         "max": 100,
         "unit": "%"
+      },
+      "responseTime": {
+        "display": "<2 seconds",
+        "value": 2,
+        "unit": "s",
+        "comparator": "lt"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
       }
-    }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
+  },
+  {
+    "model": "LEPC",
+    "slug": {
+      "current": "lepc"
+    },
+    "series": "specialized",
+    "function": "MFC",
+    "productLabel": {
+      "en": "Mass Flow Controller",
+      "ko": "질량 유량 제어기 (MFC)",
+      "zh": "质量流量控制器 (MFC)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Accurate at Low Flow",
+        "ko": "저유량에서도 정밀한 측정",
+        "zh": "低流量下精准测量"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      },
+      {
+        "en": "Compact Connection",
+        "ko": "컴팩트한 연결부",
+        "zh": "紧凑型连接结构"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/8\" SWG",
+        "length": "122.9 mm"
+      },
+      {
+        "type": "1/4\" SWG",
+        "length": "127.5 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "130.5 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "123.9 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "0.01–30 slpm",
+        "min": 0.01,
+        "max": 30,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±0.5% of FS",
+        "value": 0.5,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "6 barA",
+        "value": 6,
+        "unit": "barA",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
+  },
+  {
+    "model": "EX1000M",
+    "slug": {
+      "current": "ex1000m"
+    },
+    "series": "specialized",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Explosion-Proof for Hazardous Environments",
+        "ko": "위험 지역용 방폭 설계",
+        "zh": "适用于危险场所的防爆设计"
+      },
+      {
+        "en": "Ex ec IIC T4 Gc Certified",
+        "ko": "Ex ec IIC T4 Gc 방폭 인증",
+        "zh": "Ex ec IIC T4 Gc 防爆认证"
+      },
+      {
+        "en": "IP 65 Rated",
+        "ko": "IP 65 보호 등급",
+        "zh": "IP 65 防护等级"
+      },
+      {
+        "en": "Robust Industrial Construction",
+        "ko": "견고한 산업용 구조",
+        "zh": "坚固的工业级结构"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/2\" SWG",
+        "length": "221 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "221 mm"
+      },
+      {
+        "type": "1 Inch\" SWG",
+        "length": "229.7 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "199 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "210.2 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "70–1000 slpm",
+        "min": 70,
+        "max": 1000,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<13 bar",
+        "value": 13,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
+  },
+  {
+    "model": "EX70M",
+    "slug": {
+      "current": "ex70m"
+    },
+    "series": "specialized",
+    "function": "MFM",
+    "productLabel": {
+      "en": "Mass Flow Meter",
+      "ko": "질량 유량 측정기 (MFM)",
+      "zh": "质量流量计 (MFM)"
+    },
+    "tags": [],
+    "features": [
+      {
+        "en": "Explosion-Proof for Hazardous Environments",
+        "ko": "위험 지역용 방폭 설계",
+        "zh": "适用于危险场所的防爆设计"
+      },
+      {
+        "en": "Ex ec IIC T4 Gc Certified",
+        "ko": "Ex ec IIC T4 Gc 방폭 인증",
+        "zh": "Ex ec IIC T4 Gc 防爆认证"
+      },
+      {
+        "en": "IP 65 Rated",
+        "ko": "IP 65 보호 등급",
+        "zh": "IP 65 防护等级"
+      },
+      {
+        "en": "Robust Industrial Construction",
+        "ko": "견고한 산업용 구조",
+        "zh": "坚固的工业级结构"
+      },
+      {
+        "en": "Wide Pressure Range Compatibility",
+        "ko": "넓은 압력 범위 대응",
+        "zh": "宽压力范围适用"
+      },
+      {
+        "en": "Excellent Linearity",
+        "ko": "우수한 선형성",
+        "zh": "优异的线性度"
+      },
+      {
+        "en": "Long-Term Stability",
+        "ko": "장기 안정성",
+        "zh": "长期稳定性"
+      },
+      {
+        "en": "High Corrosion Resistance",
+        "ko": "강한 내부식성",
+        "zh": "高耐腐蚀性"
+      }
+    ],
+    "connections": [
+      {
+        "type": "1/4\" SWG",
+        "length": "175.8 mm"
+      },
+      {
+        "type": "3/8\" SWG",
+        "length": "178.8 mm"
+      },
+      {
+        "type": "1/2\" SWG",
+        "length": "184.4 mm"
+      },
+      {
+        "type": "3/4\" SWG",
+        "length": "192.6 mm"
+      },
+      {
+        "type": "1/4\" VCR",
+        "length": "169 mm"
+      },
+      {
+        "type": "1/2\" VCR",
+        "length": "177 mm"
+      }
+    ],
+    "massFlowSpecs": {
+      "flowRange": {
+        "display": "70–1000 slpm",
+        "min": 70,
+        "max": 1000,
+        "unit": "slpm",
+        "referenceGas": "N2"
+      },
+      "accuracy": {
+        "display": "±2% of FS",
+        "value": 2,
+        "unit": "%FS"
+      },
+      "repeatability": {
+        "display": "±0.25% of FS",
+        "value": 0.25,
+        "unit": "%FS"
+      },
+      "ioSignal": {
+        "display": "0–5 Vdc or 4–20 mA",
+        "outputs": [
+          "0-5Vdc",
+          "4-20mA"
+        ]
+      },
+      "supplyPower": {
+        "display": "+15 or +24 Vdc, 350 mA",
+        "voltages": [
+          15,
+          24
+        ],
+        "currentMA": 350
+      },
+      "tempRange": {
+        "display": "0–50 °C",
+        "min": 0,
+        "max": 50,
+        "unit": "°C"
+      },
+      "leakRate": {
+        "display": "1×10⁻⁹ atm·cc/sec",
+        "value": 1e-9,
+        "unit": "atm·cc/sec"
+      },
+      "controlRange": {
+        "display": "3–100%",
+        "min": 3,
+        "max": 100,
+        "unit": "%"
+      },
+      "maxPressure": {
+        "display": "<90 bar",
+        "value": 90,
+        "unit": "bar",
+        "comparator": "lt"
+      }
+    },
+    "datasheets": [],
+    "manuals": [],
+    "drawings": []
   }
 ]

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -113,7 +113,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -254,7 +254,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -395,7 +395,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -536,7 +536,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -673,7 +673,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -810,7 +810,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -943,7 +943,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1076,7 +1076,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1217,7 +1217,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1352,7 +1352,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1487,7 +1487,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1621,7 +1621,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1752,7 +1752,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -1883,7 +1883,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2010,7 +2010,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2137,7 +2137,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2272,7 +2272,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2419,7 +2419,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2566,7 +2566,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2709,7 +2709,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2852,7 +2852,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -2991,7 +2991,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3130,7 +3130,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3277,7 +3277,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3418,7 +3418,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3559,7 +3559,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3696,7 +3696,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3833,7 +3833,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -3966,7 +3966,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4099,7 +4099,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4244,7 +4244,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4392,7 +4392,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4517,7 +4517,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4655,7 +4655,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {
@@ -4758,15 +4758,15 @@
     ],
     "massFlowSpecs": {
       "flowRange": {
-        "display": "70–1000 slpm",
-        "min": 70,
-        "max": 1000,
+        "display": "0.01–70 slpm",
+        "min": 0.01,
+        "max": 70,
         "unit": "slpm",
         "referenceGas": "N2"
       },
       "accuracy": {
-        "display": "±2% of FS",
-        "value": 2,
+        "display": "±1% of FS",
+        "value": 1,
         "unit": "%FS"
       },
       "repeatability": {
@@ -4797,7 +4797,7 @@
       },
       "leakRate": {
         "display": "1×10⁻⁹ atm·cc/sec",
-        "value": 1e-9,
+        "value": 1e-09,
         "unit": "atm·cc/sec"
       },
       "controlRange": {

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -138,7 +138,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "15-Pin D-Connector"
+    "connectorType": "15-Pin D-Connector",
+    "tagSlugs": [
+      "ultra-low-flow"
+    ]
   },
   {
     "model": "M3200VA",
@@ -279,7 +282,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "mid-flow"
+    ]
   },
   {
     "model": "MS3150VA",
@@ -420,7 +426,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "mid-flow"
+    ]
   },
   {
     "model": "MS3400VA",
@@ -561,7 +570,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow"
+    ]
   },
   {
     "model": "MS3500VA",
@@ -698,7 +710,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow"
+    ]
   },
   {
     "model": "MS3600VA",
@@ -835,7 +850,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow"
+    ]
   },
   {
     "model": "MS3700VA",
@@ -968,7 +986,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow"
+    ]
   },
   {
     "model": "MS3800VA",
@@ -1101,7 +1122,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow"
+    ]
   },
   {
     "model": "M2030VA",
@@ -1236,7 +1260,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "15-Pin D-Connector"
+    "connectorType": "15-Pin D-Connector",
+    "tagSlugs": [
+      "ultra-low-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "M2200VA",
@@ -1371,7 +1399,10 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "meter-only"
+    ]
   },
   {
     "model": "MS2150VA",
@@ -1505,7 +1536,10 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "meter-only"
+    ]
   },
   {
     "model": "MS2400VA",
@@ -1640,7 +1674,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MS2500VA",
@@ -1771,7 +1809,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MS2600VA",
@@ -1902,7 +1944,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MS2700VA",
@@ -2029,7 +2075,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MS2800VA",
@@ -2156,7 +2206,11 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "connectorType": "9-Pin D-Connector"
+    "connectorType": "9-Pin D-Connector",
+    "tagSlugs": [
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MD150C",
@@ -2303,7 +2357,10 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital"
+    ]
   },
   {
     "model": "MD30C",
@@ -2450,7 +2507,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "ultra-low-flow"
+    ]
   },
   {
     "model": "MD400C",
@@ -2597,7 +2658,10 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital"
+    ]
   },
   {
     "model": "MD500C",
@@ -2740,7 +2804,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow"
+    ]
   },
   {
     "model": "MD600C",
@@ -2883,7 +2951,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow"
+    ]
   },
   {
     "model": "MD700C",
@@ -3022,7 +3094,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow"
+    ]
   },
   {
     "model": "MD800C",
@@ -3161,7 +3237,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow"
+    ]
   },
   {
     "model": "MD150M",
@@ -3302,7 +3382,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "meter-only"
+    ]
   },
   {
     "model": "MD30M",
@@ -3443,7 +3527,12 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "ultra-low-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MD400M",
@@ -3584,7 +3673,11 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "meter-only"
+    ]
   },
   {
     "model": "MD500M",
@@ -3721,7 +3814,12 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MD600M",
@@ -3858,7 +3956,12 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MD700M",
@@ -3991,7 +4094,12 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "MD800M",
@@ -4124,7 +4232,12 @@
       "dataBits": 8,
       "stopBits": 1,
       "parity": "None"
-    }
+    },
+    "tagSlugs": [
+      "digital",
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "EX1000C",
@@ -4268,7 +4381,12 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "explosion-proof",
+      "hazardous-environment",
+      "high-flow"
+    ]
   },
   {
     "model": "EX70C",
@@ -4416,7 +4534,11 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "explosion-proof",
+      "hazardous-environment"
+    ]
   },
   {
     "model": "LEPC",
@@ -4535,7 +4657,11 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "low-pressure",
+      "ultra-low-flow"
+    ]
   },
   {
     "model": "EX1000M",
@@ -4673,7 +4799,13 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "explosion-proof",
+      "hazardous-environment",
+      "high-flow",
+      "meter-only"
+    ]
   },
   {
     "model": "EX70M",
@@ -4815,6 +4947,11 @@
     },
     "datasheets": [],
     "manuals": [],
-    "drawings": []
+    "drawings": [],
+    "tagSlugs": [
+      "explosion-proof",
+      "hazardous-environment",
+      "meter-only"
+    ]
   }
 ]

--- a/src/lib/products/slug-redirects.test.ts
+++ b/src/lib/products/slug-redirects.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import nextConfig from "../../../next.config";
+
+describe("next.config redirects (#175)", () => {
+  it("emits 3 locale × N renamed-slug redirects, all permanent", async () => {
+    const redirects = await nextConfig.redirects?.();
+    expect(redirects).toBeDefined();
+    expect(redirects!.length).toBeGreaterThan(0);
+    expect(redirects!.length % 3).toBe(0);
+
+    for (const r of redirects!) {
+      expect(r.permanent).toBe(true);
+      expect(r.source.startsWith("/")).toBe(true);
+      expect(r.destination.startsWith("/")).toBe(true);
+      expect(r.source).not.toBe(r.destination);
+      expect(r.source).toMatch(/^\/(ko|en|zh)\/products\//);
+      expect(r.destination).toMatch(/^\/(ko|en|zh)\/products\//);
+    }
+  });
+
+  it("retains the locale prefix between source and destination", async () => {
+    const redirects = await nextConfig.redirects?.();
+    for (const r of redirects!) {
+      const sourceLocale = r.source.split("/")[1];
+      const destLocale = r.destination.split("/")[1];
+      expect(sourceLocale).toBe(destLocale);
+    }
+  });
+
+  it("covers the 4 known 2020 → 2026 slug renames in each locale", async () => {
+    const redirects = await nextConfig.redirects?.();
+    const renames = [
+      ["specialized/ex070c", "specialized/ex70c"],
+      ["specialized/ex070m", "specialized/ex70m"],
+      ["digital/md100c", "digital/md150c"],
+      ["digital/md100m", "digital/md150m"],
+    ] as const;
+    for (const locale of ["ko", "en", "zh"]) {
+      for (const [from, to] of renames) {
+        const match = redirects!.find(
+          (r) =>
+            r.source === `/${locale}/products/${from}` &&
+            r.destination === `/${locale}/products/${to}`,
+        );
+        expect(
+          match,
+          `expected redirect for /${locale}/products/${from} → /${to}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+});

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -134,6 +134,7 @@ export const SanityProductSchema = z.object({
     .nullable()
     .optional(),
   cutout: SanityImageSchema.nullable().optional(),
+  connectorType: z.string().nullable().optional(),
   dimensionDrawing: SanityImageSchema.nullable().optional(),
   datasheets: z
     .array(

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -99,6 +99,7 @@ export const SanityProductSchema = z.object({
       }),
     )
     .default([]),
+  tagSlugs: z.array(z.string()).optional(),
   description: z
     .object({ ko: z.string(), en: z.string(), zh: z.string() })
     .nullable()

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -34,6 +34,7 @@ const PRODUCT_LIST_PROJECTION = `
 const PRODUCT_DETAIL_PROJECTION = `
   ${PRODUCT_BASE_PROJECTION},
   digitalCommunication,
+  connectorType,
   images,
   dimensionDrawing,
   "datasheets": *[_type == "datasheet" && lower(model) == lower(^.model)]


### PR DESCRIPTION
## Summary
- Regenerates `products.json` from the 2026 catalog: 35 products (down from 40) — retires M2100VA, M3100VA, LD030C/M, LM030C/M; renames EX070C/M → EX70C/M and MD100C/M → MD150C/M; adds LEPC
- Adds `connectorType` field throughout (product type, Sanity schema, parser, seed script) — captures electrical connector from spec tables (15-Pin / 9-Pin D-Connector)
- Adds 301 redirects in `next.config.ts` for all four renamed slugs across all three locales
- Updates `parse-catalog.ts` to default to `product-catalog-2026.md` with full 2026 format support (no page numbers, EX model parenthesis notation, `"A" Dimension (mm)` column, `Supply Power` key, LEPC pressure range)
- All Sanity data synced: 35 products patched, 6 retired docs deleted (with showcase ref cleanup), 17 cutouts uploaded (13 updated 2026 PNGs + 4 renamed-slug new uploads)

## Test plan
- [ ] Verify `/en/products/specialized/ex070c` redirects to `/en/products/specialized/ex70c`
- [ ] Verify `/en/products/digital/md100c` redirects to `/en/products/digital/md150c`
- [ ] Check LEPC product page renders without errors (no responseTime)
- [ ] Confirm retired products (e.g. M2100VA) no longer appear in the catalogue
- [ ] Spot-check MD150C and EX70C product pages show updated cutouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)