### PR TITLE
feat(home): credentials cards with scope + view-all link

### DIFF
--- a/src/components/home/Credentials/Credentials.css
+++ b/src/components/home/Credentials/Credentials.css
@@ -36,6 +36,7 @@
 }
 .ho-credentials__name {
   font: 600 var(--lt-fs-sm) var(--lt-sans);
+  line-height: 1.3;
   color: var(--pd-fg-strong);
   letter-spacing: -0.005em;
 }
@@ -62,7 +63,7 @@
     gap 160ms ease;
 }
 .ho-credentials__link:hover {
-  color: var(--pd-primary-dark, var(--pd-primary));
+  color: var(--pd-primary-dark);
   gap: 12px;
 }
 

--- a/src/components/home/Credentials/Credentials.css
+++ b/src/components/home/Credentials/Credentials.css
@@ -2,23 +2,76 @@
 .ho-credentials {
   display: flex;
   flex-wrap: wrap;
-  gap: 28px;
+  gap: 16px;
   padding: 8px 0;
 }
 .ho-credentials__item {
   display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 20px;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 22px;
   border: 1px solid var(--pd-border-strong);
   border-radius: var(--pd-r-md);
-  font: 500 var(--lt-fs-sm) var(--lt-sans);
+  background: var(--pd-surface);
   color: var(--pd-fg);
+  min-width: 200px;
+  transition: border-color 160ms ease;
+}
+.ho-credentials__item:hover {
+  border-color: var(--pd-primary);
 }
 .ho-credentials__dot {
   display: inline-block;
+  flex: none;
   width: 6px;
   height: 6px;
+  margin-top: 8px;
   border-radius: 50%;
   background: var(--pd-primary);
+}
+.ho-credentials__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ho-credentials__name {
+  font: 600 var(--lt-fs-sm) var(--lt-sans);
+  color: var(--pd-fg-strong);
+  letter-spacing: -0.005em;
+}
+.ho-credentials__scope {
+  font: 400 var(--lt-fs-xs) var(--lt-sans);
+  color: var(--pd-muted);
+  line-height: 1.4;
+}
+
+.ho-credentials__cta {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+.ho-credentials__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 var(--lt-fs-sm) var(--lt-sans);
+  color: var(--pd-primary);
+  text-decoration: none;
+  transition:
+    color 160ms ease,
+    gap 160ms ease;
+}
+.ho-credentials__link:hover {
+  color: var(--pd-primary-dark, var(--pd-primary));
+  gap: 12px;
+}
+
+@media (max-width: 640px) {
+  .ho-credentials__item {
+    min-width: 0;
+    flex: 1 1 calc(50% - 16px);
+  }
+  .ho-credentials__cta {
+    justify-content: flex-start;
+  }
 }

--- a/src/components/home/Credentials/Credentials.tsx
+++ b/src/components/home/Credentials/Credentials.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@/i18n/navigation";
 import { SectionHead } from "../SectionHead";
 import type { HomeContent } from "@/lib/content/home";
 import "./Credentials.css";
@@ -15,12 +16,21 @@ export function Credentials({ h }: Props) {
       />
       <ul className="ho-credentials">
         {credentials.items.map((it) => (
-          <li key={it} className="ho-credentials__item">
+          <li key={it.name} className="ho-credentials__item">
             <span className="ho-credentials__dot" aria-hidden="true" />
-            <span>{it}</span>
+            <div className="ho-credentials__text">
+              <span className="ho-credentials__name">{it.name}</span>
+              <span className="ho-credentials__scope">{it.scope}</span>
+            </div>
           </li>
         ))}
       </ul>
+      <div className="ho-credentials__cta">
+        <Link href="/resources/certifications" className="ho-credentials__link">
+          {credentials.viewAll}
+          <span aria-hidden="true">→</span>
+        </Link>
+      </div>
     </section>
   );
 }

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -47,7 +47,13 @@ export type HomeContent = {
     bulletLabels: FeatureBulletLabels;
     slides: FeatureSlide[];
   };
-  credentials: { kicker: string; title: string; sub: string; items: string[] };
+  credentials: {
+    kicker: string;
+    title: string;
+    sub: string;
+    items: { name: string; scope: string }[];
+    viewAll: string;
+  };
   contact: { title: string; sub: string; primary: string; secondary: string };
 };
 
@@ -157,12 +163,13 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       title: "검증된 국제 인증",
       sub: "ISO 9001, CE 인증을 포함한 국제 기준을 충족합니다.",
       items: [
-        "ISO 9001",
-        "CE",
-        "INNOBIZ 인증",
-        "RoHS / REACH",
-        "KAIST 공동 R&D",
+        { name: "ISO 9001", scope: "품질경영시스템" },
+        { name: "CE", scope: "EU 안전·전자파 적합성" },
+        { name: "INNOBIZ 인증", scope: "기술혁신형 중소기업" },
+        { name: "RoHS / REACH", scope: "유해물질·화학물질 규제 적합" },
+        { name: "KAIST 공동 R&D", scope: "산학 협력" },
       ],
+      viewAll: "전체 인증 보기",
     },
     contact: {
       title: "도입 검토 중이십니까?",
@@ -284,7 +291,14 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       kicker: "04 — Certifications",
       title: "International certifications.",
       sub: "ISO 9001, CE, RoHS — recognized standards across global process industries.",
-      items: ["ISO 9001", "CE", "INNOBIZ", "RoHS / REACH"],
+      items: [
+        { name: "ISO 9001", scope: "Quality management system" },
+        { name: "CE", scope: "EU safety & EMC compliance" },
+        { name: "INNOBIZ", scope: "Korean tech-innovation SME" },
+        { name: "RoHS / REACH", scope: "Hazardous substances & chemicals" },
+        { name: "KAIST R&D", scope: "Research collaboration" },
+      ],
+      viewAll: "View all certifications",
     },
     contact: {
       title: "Evaluating a line?",
@@ -394,7 +408,14 @@ export const LT_HOME: Record<Locale, HomeContent> = {
       kicker: "04 — 认证",
       title: "经验证的国际认证",
       sub: "满足 ISO 9001、CE 等国际认证标准。",
-      items: ["ISO 9001", "CE", "INNOBIZ", "RoHS / REACH", "KAIST 联合研发"],
+      items: [
+        { name: "ISO 9001", scope: "质量管理体系" },
+        { name: "CE", scope: "欧盟安全与电磁兼容性" },
+        { name: "INNOBIZ", scope: "韩国技术革新型中小企业" },
+        { name: "RoHS / REACH", scope: "有害物质与化学品合规" },
+        { name: "KAIST 联合研发", scope: "产学研合作" },
+      ],
+      viewAll: "查看全部认证",
     },
     contact: {
       title: "正在评估方案?",

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -290,7 +290,7 @@ export const LT_HOME: Record<Locale, HomeContent> = {
     credentials: {
       kicker: "04 — Certifications",
       title: "International certifications.",
-      sub: "ISO 9001, CE, RoHS — recognized standards across global process industries.",
+      sub: "Certified to international quality, safety, and compliance standards.",
       items: [
         { name: "ISO 9001", scope: "Quality management system" },
         { name: "CE", scope: "EU safety & EMC compliance" },


### PR DESCRIPTION
## Summary

- Each cert pill on the homepage now carries a one-line scope under the name (ISO 9001 → "Quality management system", etc.) — fully translated for ko/en/zh
- Adds a locale-aware "View all certifications →" link below the pills, pointing at `/[locale]/resources/certifications`
- Pill aesthetic preserved (border + dot accent), padding eased so cards breathe; subtle hover on each pill (border → primary)
- KAIST partnership stays at the end of the list as a credibility item

Closes #146

## Test plan

- [ ] `/`, `/en`, `/zh` — Credentials section renders 5 cards with name + scope
- [ ] "View all" link points at `/{locale}/resources/certifications`
- [ ] Mobile (≤ 640px) — cards reflow to 2-up grid, CTA aligns left
- [ ] Hover on a card — border tints primary blue
- [ ] `pnpm i18n:check` passes (verified)
- [ ] `pnpm typecheck` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)