### PR TITLE
feat(products): localize spec values for ko/zh

### DIFF
--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -35,6 +35,7 @@ import type { MassFlowSpecs, Product } from "@/lib/types/product";
 import { buildProductMetadata, siteUrl } from "@/lib/seo";
 import { safeJsonLd } from "@/lib/seo/jsonLd";
 import { LT_APPLICATIONS } from "@/lib/content/applications";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
 import "./product-detail.css";
 
 export const revalidate = 3600;
@@ -153,24 +154,33 @@ export default async function ProductPage({ params }: Props) {
     label: tPdp(`specGroups.${g.id}`),
     rows: g.keys.flatMap<SpecRow>((k) => {
       const spec = product.massFlowSpecs[k];
-      return spec ? [{ key: k, label: tSpecs(k), value: spec.display }] : [];
+      return spec
+        ? [
+            {
+              key: k,
+              label: tSpecs(k),
+              value: localizeSpecValue(spec.display, locale),
+            },
+          ]
+        : [];
     }),
   }));
 
-  const features = product.features.map((f) => f[locale]);
+  const features = product.features.map((f) => f[locale] || f.en);
   const specs = product.massFlowSpecs;
+  const loc = (s: string) => localizeSpecValue(s, locale);
   const overviewRows = [
     {
       feature: features[0] ?? "",
-      values: [specs.flowRange.display, specs.accuracy.display],
+      values: [loc(specs.flowRange.display), loc(specs.accuracy.display)],
     },
     {
       feature: features[1] ?? "",
-      values: specs.responseTime ? [specs.responseTime.display] : [],
+      values: specs.responseTime ? [loc(specs.responseTime.display)] : [],
     },
     {
       feature: features[2] ?? "",
-      values: specs.maxPressure ? [specs.maxPressure.display] : [],
+      values: specs.maxPressure ? [loc(specs.maxPressure.display)] : [],
     },
   ].filter((r) => r.feature);
 

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -16,6 +16,7 @@ import { CategoryShowcaseSchema } from "@/lib/types/showcase";
 import { urlFor } from "@/sanity/imageUrl";
 import { z } from "zod";
 import { buildCategoryMetadata } from "@/lib/seo";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
 
 export const revalidate = 3600;
 
@@ -59,8 +60,8 @@ export default async function CategoryPage({ params }: Props) {
     model: e.model,
     caption: e.caption,
     function: e.function,
-    flowRange: e.flowRange,
-    accuracy: e.accuracy,
+    flowRange: e.flowRange ? localizeSpecValue(e.flowRange, locale) : null,
+    accuracy: e.accuracy ? localizeSpecValue(e.accuracy, locale) : null,
     image: e.cutout?.asset
       ? urlFor(e.cutout).width(960).url()
       : e.image?.asset

--- a/src/components/products/ProductHero/ProductHero.tsx
+++ b/src/components/products/ProductHero/ProductHero.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
 import type { Product } from "@/lib/types/product";
 import type { Locale } from "@/i18n/routing";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
 import "./ProductHero.css";
 
 type Props = {
@@ -25,7 +26,8 @@ export function ProductHero({
   const name = product.productLabel[locale];
   const tagline = product.features
     .slice(0, 3)
-    .map((f) => f[locale])
+    .map((f) => f[locale] || f.en)
+    .filter(Boolean)
     .join(" · ");
 
   return (
@@ -88,7 +90,8 @@ export function ProductHero({
             LINE TECH
           </div>
           <div className="lt-pdp-hero__stamp lt-pdp-hero__stamp--br">
-            N₂ · {product.massFlowSpecs.flowRange.display}
+            N₂ ·{" "}
+            {localizeSpecValue(product.massFlowSpecs.flowRange.display, locale)}
           </div>
         </div>
       </div>

--- a/src/components/products/ProductRow/ProductRow.tsx
+++ b/src/components/products/ProductRow/ProductRow.tsx
@@ -7,6 +7,7 @@ import { Chip } from "@/components/ui/Chip/Chip";
 import type { Product } from "@/lib/types/product";
 import type { CategorySlug } from "@/lib/categories";
 import type { Locale } from "@/i18n/routing";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
 import "./ProductRow.css";
 
 type Props = {
@@ -31,9 +32,17 @@ function fittingSummary(connections: Product["connections"]): string {
 export function ProductRow({ product, imageSrc, category, locale }: Props) {
   const href = `/products/${category}/${product.slug.current}`;
   const label = product.description?.[locale] ?? product.productLabel[locale];
-  const range = product.massFlowSpecs.flowRange.display;
-  const accuracy = product.massFlowSpecs.accuracy.display;
-  const response = product.massFlowSpecs.responseTime?.display ?? "—";
+  const range = localizeSpecValue(
+    product.massFlowSpecs.flowRange.display,
+    locale,
+  );
+  const accuracy = localizeSpecValue(
+    product.massFlowSpecs.accuracy.display,
+    locale,
+  );
+  const response = product.massFlowSpecs.responseTime
+    ? localizeSpecValue(product.massFlowSpecs.responseTime.display, locale)
+    : "—";
   const fitting = fittingSummary(product.connections);
   const visibleTags = product.tags
     .filter((t) => VISIBLE_TAG_KINDS.has(t.kind))

--- a/src/lib/products/localizeSpecValue.test.ts
+++ b/src/lib/products/localizeSpecValue.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { localizeSpecValue } from "./localizeSpecValue";
+
+describe("localizeSpecValue", () => {
+  it("passes English values through unchanged", () => {
+    expect(localizeSpecValue("<2 seconds", "en")).toBe("<2 seconds");
+    expect(localizeSpecValue("0–5 Vdc or 4–20 mA", "en")).toBe(
+      "0–5 Vdc or 4–20 mA",
+    );
+    expect(localizeSpecValue("±1% of FS", "en")).toBe("±1% of FS");
+  });
+
+  it("translates English prose words to Korean", () => {
+    expect(localizeSpecValue("<2 seconds", "ko")).toBe("<2 초");
+    expect(localizeSpecValue("<1 second", "ko")).toBe("<1 초");
+    expect(localizeSpecValue("0–5 Vdc or 4–20 mA", "ko")).toBe(
+      "0–5 Vdc 또는 4–20 mA",
+    );
+    expect(localizeSpecValue("±1% of FS", "ko")).toBe("±1% F.S.");
+    expect(localizeSpecValue("+15 or +24 Vdc, 350 mA", "ko")).toBe(
+      "+15 또는 +24 Vdc, 350 mA",
+    );
+  });
+
+  it("translates English prose words to Chinese", () => {
+    expect(localizeSpecValue("<2 seconds", "zh")).toBe("<2 秒");
+    expect(localizeSpecValue("0–5 Vdc or 4–20 mA", "zh")).toBe(
+      "0–5 Vdc 或 4–20 mA",
+    );
+    expect(localizeSpecValue("±0.25% of FS", "zh")).toBe("±0.25% F.S.");
+  });
+
+  it("leaves pure technical strings untouched in all locales", () => {
+    for (const loc of ["en", "ko", "zh"] as const) {
+      expect(localizeSpecValue("0.01–100 slpm", loc)).toBe("0.01–100 slpm");
+      expect(localizeSpecValue("0–50 °C", loc)).toBe("0–50 °C");
+      expect(localizeSpecValue("<90 bar", loc)).toBe("<90 bar");
+      expect(localizeSpecValue("1×10⁻⁹ atm·cc/sec", loc)).toBe(
+        "1×10⁻⁹ atm·cc/sec",
+      );
+    }
+  });
+});

--- a/src/lib/products/localizeSpecValue.test.ts
+++ b/src/lib/products/localizeSpecValue.test.ts
@@ -17,6 +17,7 @@ describe("localizeSpecValue", () => {
       "0–5 Vdc 또는 4–20 mA",
     );
     expect(localizeSpecValue("±1% of FS", "ko")).toBe("±1% F.S.");
+    expect(localizeSpecValue("±1% of fs", "ko")).toBe("±1% F.S.");
     expect(localizeSpecValue("+15 or +24 Vdc, 350 mA", "ko")).toBe(
       "+15 또는 +24 Vdc, 350 mA",
     );
@@ -38,6 +39,15 @@ describe("localizeSpecValue", () => {
       expect(localizeSpecValue("1×10⁻⁹ atm·cc/sec", loc)).toBe(
         "1×10⁻⁹ atm·cc/sec",
       );
+    }
+  });
+
+  it("is idempotent", () => {
+    for (const loc of ["ko", "zh"] as const) {
+      const once = localizeSpecValue("±1% of FS", loc);
+      expect(localizeSpecValue(once, loc)).toBe(once);
+      const once2 = localizeSpecValue("<2 seconds", loc);
+      expect(localizeSpecValue(once2, loc)).toBe(once2);
     }
   });
 });

--- a/src/lib/products/localizeSpecValue.ts
+++ b/src/lib/products/localizeSpecValue.ts
@@ -1,0 +1,23 @@
+import type { Locale } from "@/i18n/routing";
+
+const RULES: Record<Locale, Array<[RegExp, string]>> = {
+  en: [],
+  ko: [
+    [/\bseconds?\b/gi, "초"],
+    [/\bor\b/gi, "또는"],
+    [/\bof FS\b/g, "F.S."],
+  ],
+  zh: [
+    [/\bseconds?\b/gi, "秒"],
+    [/\bor\b/gi, "或"],
+    [/\bof FS\b/g, "F.S."],
+  ],
+};
+
+export function localizeSpecValue(value: string, locale: Locale): string {
+  let result = value;
+  for (const [pattern, replacement] of RULES[locale]) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}

--- a/src/lib/products/localizeSpecValue.ts
+++ b/src/lib/products/localizeSpecValue.ts
@@ -4,13 +4,13 @@ const RULES: Record<Locale, Array<[RegExp, string]>> = {
   en: [],
   ko: [
     [/\bseconds?\b/gi, "초"],
-    [/\bor\b/gi, "또는"],
-    [/\bof FS\b/g, "F.S."],
+    [/(\s)or(\s)/gi, "$1또는$2"],
+    [/\bof FS\b/gi, "F.S."],
   ],
   zh: [
     [/\bseconds?\b/gi, "秒"],
-    [/\bor\b/gi, "或"],
-    [/\bof FS\b/g, "F.S."],
+    [/(\s)or(\s)/gi, "$1或$2"],
+    [/\bof FS\b/gi, "F.S."],
   ],
 };
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -3,6 +3,7 @@ import type { Locale } from "@/lib/content/home";
 import type { CategorySlug } from "@/lib/categories";
 import type { Product } from "@/lib/types/product";
 import { routing } from "@/i18n/routing";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
 
 function resolveSiteUrl(): string {
   const fromEnv = process.env.NEXT_PUBLIC_SITE_URL;
@@ -241,8 +242,14 @@ export function buildProductMetadata(
 ): Metadata {
   const label = product.productLabel[locale];
   const fn = product.function;
-  const flowRange = product.massFlowSpecs.flowRange.display;
-  const accuracy = product.massFlowSpecs.accuracy.display;
+  const flowRange = localizeSpecValue(
+    product.massFlowSpecs.flowRange.display,
+    locale,
+  );
+  const accuracy = localizeSpecValue(
+    product.massFlowSpecs.accuracy.display,
+    locale,
+  );
   const application = SERIES_APPLICATION[product.series][locale];
 
   const titles: Record<Locale, string> = {


### PR DESCRIPTION
## Summary

- Adds a small `localizeSpecValue` helper that swaps the English prose words found inside Sanity `display` strings — `seconds`/`second` → `초`/`秒`, `or` → `또는`/`或`, `of FS` → `F.S.` — when the locale isn't `en`.
- Routes every user-facing spec render through the helper: PDP spec table + overview, product hero stamp, category catalog table, category showcase, and per-locale meta description.
- Adds a defensive `f[locale] || f.en` fallback for product features so a missing translation degrades to English instead of blank.
- JSON-LD `additionalProperty` values, the `/en/` `llms.txt` manifest, and the spec-sheet markdown generator keep raw English on purpose (those consumers are language-agnostic).

## Why

Pure technical strings like `0.01–100 slpm` or `<90 bar` are language-agnostic, but a handful of `display` strings carry English connector words that leaked onto Korean/Chinese product pages — for example a Korean PDP showing `<2 seconds` or `±1% of FS`.

## Translation choices

Drafted these without verifying with a native speaker yet — happy to adjust:

| en | ko | zh |
|---|---|---|
| seconds / second | 초 | 秒 |
| or | 또는 | 或 |
| of FS | F.S. | F.S. |

## Test plan

- [x] `vitest` unit tests for the formatter (en passthrough, ko/zh substitutions, untouched pure-numeric strings)
- [x] Full suite `pnpm test` (61 passed)
- [x] `pnpm typecheck`
- [ ] Manual: visit `/ko/products/digital/md30c` and `/zh/...` — confirm spec table values use Korean/Chinese connector words

🤖 Generated with [Claude Code](https://claude.com/claude-code)