### PR TITLE
test: backfill coverage for #161, #163, #158 + CI coverage artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,15 @@ jobs:
         run: pnpm typecheck
 
       - name: Test
-        run: pnpm test:run
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: vitest-coverage
+          path: coverage/
+          retention-days: 7
 
       - name: Build
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ Build the full Tailwind color scale (50–950) around these anchors. Neutrals, s
 - Company history timeline (1997–2020) — strong credibility asset
 - Certifications (13 total, need real text labels — old site had unlabeled JPGs only)
 
+## Testing expectations
+
+- New `src/` modules with logic ship with vitest coverage (component or unit).
+- New dynamic routes (`src/app/[locale]/.../[param]/page.tsx`) ship with a Playwright spec covering the happy path and the `notFound()` path.
+- Run locally with Node 22 (`nvm use 22`) — vitest 4 + std-env requires `require(esm)` support.
+
 ## Reference
 
 - `docs/current-site-audit.md` — full audit of the legacy site with product inventory, color extraction, sitemap, and open questions

--- a/e2e/contact-network.spec.ts
+++ b/e2e/contact-network.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Contact distributor region pages (#163)", () => {
+  test("known region renders heading + coming-soon panel + back link", async ({
+    page,
+  }) => {
+    await page.goto("/en/contact/network/kr");
+
+    await expect(page.locator("h1.ct-region__title")).toBeVisible();
+    await expect(page.locator(".ct-region__panel h2")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /back to contact/i }),
+    ).toBeVisible();
+  });
+
+  test("Korean locale renders Korean region copy", async ({ page }) => {
+    await page.goto("/ko/contact/network/cn");
+
+    const title = page.locator("h1.ct-region__title");
+    await expect(title).toBeVisible();
+    // The KR fixture uses "중국" for cn — assert it's the Korean string.
+    await expect(title).toHaveText("중국");
+  });
+
+  test("unknown region returns 404", async ({ page }) => {
+    const res = await page.goto("/en/contact/network/zz-not-a-region");
+    expect(res?.status()).toBe(404);
+  });
+
+  test("region card on /contact links to /contact/network/{id} (#152)", async ({
+    page,
+  }) => {
+    await page.goto("/en/contact");
+
+    const krLink = page.locator('a[href*="/contact/network/kr"]').first();
+    await expect(krLink).toBeVisible();
+    await krLink.click();
+    await page.waitForURL(/\/en\/contact\/network\/kr/);
+    await expect(page.locator("h1.ct-region__title")).toBeVisible();
+  });
+});

--- a/src/components/home/Feature/FeatureSection.test.tsx
+++ b/src/components/home/Feature/FeatureSection.test.tsx
@@ -1,0 +1,118 @@
+import "@/test/mocks/i18n";
+
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { FeatureSection } from "./FeatureSection";
+import { FLAGSHIP_IMAGE_PLACEHOLDER } from "@/lib/products/flagship";
+
+const BULLET_LABELS = {
+  flow: "Flow",
+  accuracy: "Accuracy",
+  response: "Response",
+  io: "I/O",
+};
+
+const SLIDES = [
+  { model: "M3030VA", sub: "Analogue MFC" },
+  { model: "MD800C", sub: "Digital MFC" },
+  { model: "LD030C", sub: "Specialized MFC" },
+];
+
+const CUTOUT_M3030VA = "https://cdn.sanity.io/m3030va.jpg";
+const CUTOUT_MD800C = "https://cdn.sanity.io/md800c.jpg";
+
+function renderSection(
+  overrides: Partial<Parameters<typeof FeatureSection>[0]> = {},
+) {
+  return render(
+    <FeatureSection
+      kicker="Flagship"
+      cta="Explore the {model}"
+      bulletLabels={BULLET_LABELS}
+      slides={SLIDES}
+      cutoutByModel={{
+        M3030VA: CUTOUT_M3030VA,
+        MD800C: CUTOUT_MD800C,
+      }}
+      {...overrides}
+    />,
+  );
+}
+
+describe("FeatureSection", () => {
+  it("renders kicker, active model, sub, and four bullets", () => {
+    const { container, getByText } = renderSection();
+
+    expect(getByText("Flagship")).toBeInTheDocument();
+    expect(container.querySelector("h2")?.textContent).toBe("M3030VA");
+    expect(getByText("Analogue MFC")).toBeInTheDocument();
+
+    const bullets = container.querySelectorAll(".ho-feature__bullet");
+    expect(bullets).toHaveLength(4);
+    expect(getByText("Flow")).toBeInTheDocument();
+    expect(getByText("Accuracy")).toBeInTheDocument();
+    expect(getByText("Response")).toBeInTheDocument();
+    expect(getByText("I/O")).toBeInTheDocument();
+  });
+
+  it("interpolates the active model into the CTA (#158)", () => {
+    const { container } = renderSection();
+    const cta = container.querySelector(".lt-btn") as HTMLAnchorElement;
+    expect(cta.textContent).toContain("Explore the M3030VA");
+  });
+
+  it("CTA href points to /products/{category}/{slug} for the active model", () => {
+    const { container } = renderSection();
+    const cta = container.querySelector(".lt-btn") as HTMLAnchorElement;
+    expect(cta.getAttribute("href")).toBe("/products/analogue/m3030va");
+  });
+
+  it("renders one dot per slide and clicking switches the active slide", () => {
+    const { container } = renderSection();
+    const dots = container.querySelectorAll(".ho-feature__dot");
+    expect(dots).toHaveLength(SLIDES.length);
+
+    fireEvent.click(dots[1] as Element);
+
+    expect(container.querySelector("h2")?.textContent).toBe("MD800C");
+    const cta = container.querySelector(".lt-btn") as HTMLAnchorElement;
+    expect(cta.getAttribute("href")).toBe("/products/digital/md800c");
+    expect(cta.textContent).toContain("MD800C");
+  });
+
+  it("uses cutoutByModel URL as the chip image src for each slide", () => {
+    const { container } = renderSection();
+    const slides = container.querySelectorAll(".ho-feature__chip-slide");
+    const m3030 = slides[0]!.querySelector("img") as HTMLImageElement;
+    const md800 = slides[1]!.querySelector("img") as HTMLImageElement;
+    expect(m3030.src).toContain("m3030va.jpg");
+    expect(md800.src).toContain("md800c.jpg");
+  });
+
+  it("falls back to the placeholder when a model has no cutout", () => {
+    const { container } = renderSection({
+      cutoutByModel: { M3030VA: CUTOUT_M3030VA },
+    });
+    const slides = container.querySelectorAll(".ho-feature__chip-slide");
+    const ld030 = slides[2]!.querySelector("img") as HTMLImageElement;
+    expect(ld030.src).toContain(FLAGSHIP_IMAGE_PLACEHOLDER);
+  });
+
+  it("returns null when the active model has no SLIDE_SPECS entry", () => {
+    const { container } = renderSection({
+      slides: [{ model: "ZZZ_UNKNOWN", sub: "Mystery" }],
+    });
+    expect(container.querySelector(".ho-feature")).toBeNull();
+  });
+
+  it("aria-current and data-active reflect the active slide after dot click", () => {
+    const { container } = renderSection();
+    const dots = container.querySelectorAll(".ho-feature__dot");
+
+    fireEvent.click(dots[1] as Element);
+
+    expect(dots[0]!.getAttribute("aria-current")).toBe("false");
+    expect(dots[1]!.getAttribute("aria-current")).toBe("true");
+    expect(dots[1]!.getAttribute("data-active")).toBe("true");
+  });
+});

--- a/src/lib/products/flagship.test.ts
+++ b/src/lib/products/flagship.test.ts
@@ -4,6 +4,7 @@ import {
   FLAGSHIP_IMAGE_PLACEHOLDER,
   pickFlagship,
   flagshipImageUrl,
+  flagshipCutoutUrl,
 } from "./flagship";
 import { CATEGORY_SLUGS, type CategorySlug } from "@/lib/categories";
 import type { Product } from "@/lib/types/product";
@@ -135,6 +136,57 @@ describe("flagshipImageUrl", () => {
       vi.mocked(console.warn).mockClear();
       flagshipImageUrl(p);
       expect(console.warn).toHaveBeenCalled();
+    }
+  });
+});
+
+describe("flagshipCutoutUrl", () => {
+  const cutoutRef = {
+    _type: "image",
+    asset: { _type: "reference", _ref: "image-abc-jpg" },
+  } as Parameters<typeof flagshipCutoutUrl>[1];
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the Sanity CDN URL when a cutout is provided", () => {
+    expect(flagshipCutoutUrl("M3030VA", cutoutRef)).toBe(
+      "https://cdn.sanity.io/mock.jpg",
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns the placeholder for null/undefined cutouts", () => {
+    expect(flagshipCutoutUrl("MD800C", null)).toBe(FLAGSHIP_IMAGE_PLACEHOLDER);
+    expect(flagshipCutoutUrl("LD030C", undefined)).toBe(
+      FLAGSHIP_IMAGE_PLACEHOLDER,
+    );
+  });
+
+  it("warns in non-production when the cutout is missing", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    try {
+      flagshipCutoutUrl("MD800C", null);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("MD800C"),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("does not warn in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    try {
+      flagshipCutoutUrl("MD800C", null);
+      expect(console.warn).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,23 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
 
 // Stub Sanity env so modules that instantiate the client at import-time don't crash.
 // Real network calls are blocked via vi.mock("@/sanity/fetch", ...) in src/test/mocks/sanity.ts.
 process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ??= "test-project";
 process.env.NEXT_PUBLIC_SANITY_DATASET ??= "test";
 process.env.NEXT_PUBLIC_SITE_URL ??= "https://test.example.com";
+
+// jsdom doesn't implement matchMedia. Components using prefers-reduced-motion
+// (e.g. FeatureSection) crash without this stub.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}


### PR DESCRIPTION
## Summary

- **#161 / #158** Component test for `FeatureSection` (rotation via dot click, CTA model interpolation + href, cutout fallback to placeholder, null on missing `SLIDE_SPECS`).
- **#161** Unit tests for `flagshipCutoutUrl` (CDN URL when ref present, placeholder + dev-only warn when missing).
- **#163** Playwright spec for `/contact/network/[region]` (happy path, KO copy, 404 on unknown region, click-through from #152's contact-network cards).
- **Setup** `vitest.setup.ts` stubs `window.matchMedia` so jsdom doesn't crash on `prefers-reduced-motion` subscribers.
- **CI** swaps `pnpm test:run` for `pnpm test:coverage` and uploads the v8 HTML report as an artifact (no threshold yet — gathering signal first).
- **Docs** Adds a "Testing expectations" section to `CLAUDE.md`.

## Why

5 PRs landed in the last few hours and behavior was getting hard to predict. This locks down the bits that already shipped; tests for the open PRs (#175, #174, #162) will be pushed into those branches separately.

## Test plan

- [x] `pnpm test:run` — 9 files / 69 tests green (was 57)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings pre-existing)
- [x] `pnpm e2e --project=chromium e2e/contact-network.spec.ts` — 4/4 pass
- [ ] CI runs `pnpm test:coverage` and uploads `vitest-coverage` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)