### PR TITLE
refactor: /simplify pass — extract shared components, dedupe GROQ + i18n

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -107,8 +107,7 @@
       "range": "Flow range",
       "accuracy": "Accuracy",
       "response": "Response",
-      "fitting": "Fitting",
-      "view": "View"
+      "fitting": "Fitting"
     },
     "emptyStack": "No products in this category yet.",
     "showcase": {
@@ -244,8 +243,7 @@
     "certCard": {
       "issuer": "Issuing body",
       "scope": "Scope",
-      "validThrough": "Valid through",
-      "ongoing": "Ongoing"
+      "validThrough": "Valid through"
     },
     "empty": "No files available yet. Check back soon.",
     "emptyStateCta": "Contact us",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -107,8 +107,7 @@
       "range": "유량 범위",
       "accuracy": "정확도",
       "response": "응답",
-      "fitting": "연결",
-      "view": "보기"
+      "fitting": "연결"
     },
     "emptyStack": "이 카테고리에는 아직 등록된 제품이 없습니다.",
     "showcase": {
@@ -244,8 +243,7 @@
     "certCard": {
       "issuer": "발급 기관",
       "scope": "인증 범위",
-      "validThrough": "유효 기간",
-      "ongoing": "계속 유효"
+      "validThrough": "유효 기간"
     },
     "empty": "아직 등록된 파일이 없습니다. 곧 업데이트될 예정입니다.",
     "emptyStateCta": "문의하기",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -107,8 +107,7 @@
       "range": "流量范围",
       "accuracy": "精度",
       "response": "响应",
-      "fitting": "接口",
-      "view": "查看"
+      "fitting": "接口"
     },
     "emptyStack": "该类别下暂无产品。",
     "showcase": {
@@ -244,8 +243,7 @@
     "certCard": {
       "issuer": "颁发机构",
       "scope": "认证范围",
-      "validThrough": "有效期至",
-      "ongoing": "持续有效"
+      "validThrough": "有效期至"
     },
     "empty": "暂无可用文件，敬请期待。",
     "emptyStateCta": "联系我们",

--- a/src/app/[locale]/resources/catalogues/page.tsx
+++ b/src/app/[locale]/resources/catalogues/page.tsx
@@ -3,6 +3,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { EmptyState } from "@/components/shared/EmptyState";
+import { DocRow } from "@/components/resources/DocRow";
 import { formatISODate } from "@/lib/i18n/dates";
 import { sanityClient } from "@/sanity/client";
 import { allCataloguesQuery } from "@/sanity/queries";
@@ -67,41 +68,31 @@ export default async function CataloguesPage({ params }: Props) {
       ) : (
         <ul className="dr-list" role="list">
           {catalogues.map((item) => (
-            <li key={item._id} className="dr-list__row">
-              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
-              <div>
-                <div className="dr-list__label">{item.title}</div>
-                {(item.series || item.publishedAt) && (
-                  <div className="dr-list__meta">
-                    {item.series && (
-                      <span>
-                        {tRes(
-                          `seriesLabel.${item.series as "all" | "analogue" | "digital" | "specialized"}`,
-                        )}
-                      </span>
-                    )}
-                    {item.series && item.publishedAt && (
-                      <span className="dr-list__sep">·</span>
-                    )}
-                    {item.publishedAt && (
-                      <span>{formatISODate(item.publishedAt, locale)}</span>
-                    )}
-                  </div>
-                )}
-              </div>
-              {item.fileUrl ? (
-                <a href={item.fileUrl} download className="dr-list__btn">
-                  {tRes("download")}
-                </a>
-              ) : (
-                <Link
-                  href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
-                  className="dr-list__btn dr-list__btn--request"
-                >
-                  {tRes("requestFile")}
-                </Link>
-              )}
-            </li>
+            <DocRow
+              key={item._id}
+              label={item.title}
+              meta={[
+                item.series &&
+                  tRes(
+                    `seriesLabel.${item.series as "all" | "analogue" | "digital" | "specialized"}`,
+                  ),
+                item.publishedAt && formatISODate(item.publishedAt, locale),
+              ]}
+              action={
+                item.fileUrl ? (
+                  <a href={item.fileUrl} download className="dr-list__btn">
+                    {tRes("download")}
+                  </a>
+                ) : (
+                  <Link
+                    href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+                    className="dr-list__btn dr-list__btn--request"
+                  >
+                    {tRes("requestFile")}
+                  </Link>
+                )
+              }
+            />
           ))}
         </ul>
       )}

--- a/src/app/[locale]/resources/datasheets/page.tsx
+++ b/src/app/[locale]/resources/datasheets/page.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { DocRow } from "@/components/resources/DocRow";
 import { sanityClient } from "@/sanity/client";
 import { allDatasheetsQuery } from "@/sanity/queries";
 import { routing } from "@/i18n/routing";
@@ -69,6 +70,25 @@ export default async function DatasheetsPage({ params }: Props) {
 
   const ungrouped = datasheets.filter((d) => !d.series);
 
+  const renderRow = (item: DatasheetItem) => (
+    <DocRow
+      key={item._id}
+      label={item.title}
+      meta={[modelLabel(item), item.rev, item.publishedAt]}
+      action={
+        item.fileUrl ? (
+          <a href={item.fileUrl} download className="dr-list__btn">
+            {tRes("download")}
+          </a>
+        ) : (
+          <span className="dr-list__btn dr-list__btn--disabled">
+            {tRes("comingSoon")}
+          </span>
+        )
+      }
+    />
+  );
+
   return (
     <main className="lt-wrap dr-sub">
       <Breadcrumbs items={breadcrumbs} />
@@ -89,70 +109,10 @@ export default async function DatasheetsPage({ params }: Props) {
                   {tRes(`seriesLabel.${s}`)}
                 </h2>
               </li>
-              {grouped[s].map((item) => (
-                <li key={item._id} className="dr-list__row">
-                  <span className="dr-list__badge dr-list__badge--pdf">
-                    PDF
-                  </span>
-                  <div>
-                    <div className="dr-list__label">{item.title}</div>
-                    {(modelLabel(item) || item.rev || item.publishedAt) && (
-                      <div className="dr-list__meta">
-                        {modelLabel(item) && <span>{modelLabel(item)}</span>}
-                        {modelLabel(item) && (item.rev || item.publishedAt) && (
-                          <span className="dr-list__sep">·</span>
-                        )}
-                        {item.rev && <span>{item.rev}</span>}
-                        {item.rev && item.publishedAt && (
-                          <span className="dr-list__sep">·</span>
-                        )}
-                        {item.publishedAt && <span>{item.publishedAt}</span>}
-                      </div>
-                    )}
-                  </div>
-                  {item.fileUrl ? (
-                    <a href={item.fileUrl} download className="dr-list__btn">
-                      {tRes("download")}
-                    </a>
-                  ) : (
-                    <span className="dr-list__btn dr-list__btn--disabled">
-                      {tRes("comingSoon")}
-                    </span>
-                  )}
-                </li>
-              ))}
+              {grouped[s].map(renderRow)}
             </Fragment>
           ))}
-          {ungrouped.map((item) => (
-            <li key={item._id} className="dr-list__row">
-              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
-              <div>
-                <div className="dr-list__label">{item.title}</div>
-                {(modelLabel(item) || item.rev || item.publishedAt) && (
-                  <div className="dr-list__meta">
-                    {modelLabel(item) && <span>{modelLabel(item)}</span>}
-                    {modelLabel(item) && (item.rev || item.publishedAt) && (
-                      <span className="dr-list__sep">·</span>
-                    )}
-                    {item.rev && <span>{item.rev}</span>}
-                    {item.rev && item.publishedAt && (
-                      <span className="dr-list__sep">·</span>
-                    )}
-                    {item.publishedAt && <span>{item.publishedAt}</span>}
-                  </div>
-                )}
-              </div>
-              {item.fileUrl ? (
-                <a href={item.fileUrl} download className="dr-list__btn">
-                  {tRes("download")}
-                </a>
-              ) : (
-                <span className="dr-list__btn dr-list__btn--disabled">
-                  {tRes("comingSoon")}
-                </span>
-              )}
-            </li>
-          ))}
+          {ungrouped.map(renderRow)}
         </ul>
       )}
     </main>

--- a/src/app/[locale]/resources/manuals/page.tsx
+++ b/src/app/[locale]/resources/manuals/page.tsx
@@ -4,6 +4,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { EmptyState } from "@/components/shared/EmptyState";
+import { DocRow } from "@/components/resources/DocRow";
 import { formatISODate } from "@/lib/i18n/dates";
 import { sanityClient } from "@/sanity/client";
 import { allManualsQuery } from "@/sanity/queries";
@@ -70,6 +71,32 @@ export default async function ManualsPage({ params }: Props) {
 
   const ungrouped = manuals.filter((m) => !m.series);
 
+  const renderRow = (item: ManualItem) => (
+    <DocRow
+      key={item._id}
+      label={item.title}
+      meta={[
+        modelLabel(item),
+        item.rev,
+        item.publishedAt && formatISODate(item.publishedAt, locale),
+      ]}
+      action={
+        item.fileUrl ? (
+          <a href={item.fileUrl} download className="dr-list__btn">
+            {tRes("download")}
+          </a>
+        ) : (
+          <Link
+            href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
+            className="dr-list__btn dr-list__btn--request"
+          >
+            {tRes("requestFile")}
+          </Link>
+        )
+      }
+    />
+  );
+
   return (
     <main className="lt-wrap dr-sub">
       <Breadcrumbs items={breadcrumbs} />
@@ -94,80 +121,10 @@ export default async function ManualsPage({ params }: Props) {
                   {tRes(`seriesLabel.${s}`)}
                 </h2>
               </li>
-              {grouped[s].map((item) => (
-                <li key={item._id} className="dr-list__row">
-                  <span className="dr-list__badge dr-list__badge--pdf">
-                    PDF
-                  </span>
-                  <div>
-                    <div className="dr-list__label">{item.title}</div>
-                    {(modelLabel(item) || item.rev || item.publishedAt) && (
-                      <div className="dr-list__meta">
-                        {modelLabel(item) && <span>{modelLabel(item)}</span>}
-                        {modelLabel(item) && (item.rev || item.publishedAt) && (
-                          <span className="dr-list__sep">·</span>
-                        )}
-                        {item.rev && <span>{item.rev}</span>}
-                        {item.rev && item.publishedAt && (
-                          <span className="dr-list__sep">·</span>
-                        )}
-                        {item.publishedAt && (
-                          <span>{formatISODate(item.publishedAt, locale)}</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  {item.fileUrl ? (
-                    <a href={item.fileUrl} download className="dr-list__btn">
-                      {tRes("download")}
-                    </a>
-                  ) : (
-                    <Link
-                      href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
-                      className="dr-list__btn dr-list__btn--request"
-                    >
-                      {tRes("requestFile")}
-                    </Link>
-                  )}
-                </li>
-              ))}
+              {grouped[s].map(renderRow)}
             </Fragment>
           ))}
-          {ungrouped.map((item) => (
-            <li key={item._id} className="dr-list__row">
-              <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
-              <div>
-                <div className="dr-list__label">{item.title}</div>
-                {(modelLabel(item) || item.rev || item.publishedAt) && (
-                  <div className="dr-list__meta">
-                    {modelLabel(item) && <span>{modelLabel(item)}</span>}
-                    {modelLabel(item) && (item.rev || item.publishedAt) && (
-                      <span className="dr-list__sep">·</span>
-                    )}
-                    {item.rev && <span>{item.rev}</span>}
-                    {item.rev && item.publishedAt && (
-                      <span className="dr-list__sep">·</span>
-                    )}
-                    {item.publishedAt && (
-                      <span>{formatISODate(item.publishedAt, locale)}</span>
-                    )}
-                  </div>
-                )}
-              </div>
-              {item.fileUrl ? (
-                <a href={item.fileUrl} download className="dr-list__btn">
-                  {tRes("download")}
-                </a>
-              ) : (
-                <Link
-                  href={`/contact?topic=request&file=${encodeURIComponent(item.title)}`}
-                  className="dr-list__btn dr-list__btn--request"
-                >
-                  {tRes("requestFile")}
-                </Link>
-              )}
-            </li>
-          ))}
+          {ungrouped.map(renderRow)}
         </ul>
       )}
     </main>

--- a/src/components/home/Feature/FeatureSection.tsx
+++ b/src/components/home/Feature/FeatureSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useState } from "react";
 import Image from "next/image";
+import { useCarousel } from "@/lib/hooks/useCarousel";
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
 import { FLAGSHIP_IMAGE_PLACEHOLDER } from "@/lib/products/flagship";
@@ -74,16 +75,6 @@ const SLIDE_SPECS: Record<string, SlideSpec> = {
 };
 
 const INTERVAL_MS = 5500;
-const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
-
-const subscribeReducedMotion = (cb: () => void) => {
-  if (typeof window === "undefined") return () => {};
-  const mql = window.matchMedia(REDUCED_MOTION_QUERY);
-  mql.addEventListener("change", cb);
-  return () => mql.removeEventListener("change", cb);
-};
-const getRMSnapshot = () => window.matchMedia(REDUCED_MOTION_QUERY).matches;
-const getRMServerSnapshot = () => false;
 
 export function FeatureSection({
   kicker,
@@ -92,23 +83,12 @@ export function FeatureSection({
   slides,
   cutoutByModel,
 }: Props) {
-  const [active, setActive] = useState(0);
   const [mouseInside, setMouseInside] = useState(false);
   const [focusInside, setFocusInside] = useState(false);
-  const reducedMotion = useSyncExternalStore(
-    subscribeReducedMotion,
-    getRMSnapshot,
-    getRMServerSnapshot,
-  );
-
-  useEffect(() => {
-    if (slides.length <= 1 || reducedMotion) return;
-    if (mouseInside || focusInside) return;
-    const id = window.setInterval(() => {
-      setActive((n) => (n + 1) % slides.length);
-    }, INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [mouseInside, focusInside, reducedMotion, slides.length]);
+  const { active, setActive } = useCarousel(slides.length, {
+    intervalMs: INTERVAL_MS,
+    paused: mouseInside || focusInside,
+  });
 
   const current = slides[active];
   const spec = SLIDE_SPECS[current.model];

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useCarousel } from "@/lib/hooks/useCarousel";
@@ -60,7 +60,7 @@ export function CategoryShowcase({
     paused: hovered,
   });
 
-  const selectSlide = useCallback((i: number) => setActive(i), [setActive]);
+  const selectSlide = (i: number) => setActive(i);
 
   return (
     <div

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useCarousel } from "@/lib/hooks/useCarousel";
 import "./CategoryShowcase.css";
 
 export type ShowcaseProduct = {
@@ -53,19 +54,13 @@ export function CategoryShowcase({
   heroCode,
   heroLede,
 }: Props) {
-  const [active, setActive] = useState(0);
-  const isPaused = useRef(false);
-  const len = products.length;
+  const [hovered, setHovered] = useState(false);
+  const { active, setActive } = useCarousel(products.length, {
+    intervalMs: INTERVAL_MS,
+    paused: hovered,
+  });
 
-  useEffect(() => {
-    if (len < 2) return;
-    const id = setInterval(() => {
-      if (!isPaused.current) setActive((n) => (n + 1) % len);
-    }, INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [len]);
-
-  const selectSlide = useCallback((i: number) => setActive(i), []);
+  const selectSlide = useCallback((i: number) => setActive(i), [setActive]);
 
   return (
     <div
@@ -73,8 +68,8 @@ export function CategoryShowcase({
       role="region"
       aria-roledescription="carousel"
       aria-label={slidesAriaLabel}
-      onMouseEnter={() => (isPaused.current = true)}
-      onMouseLeave={() => (isPaused.current = false)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <span
         className="lt-showcase__bracket lt-showcase__bracket--tl"
@@ -157,7 +152,7 @@ export function CategoryShowcase({
         <div className="lt-showcase__nav">
           <span className="lt-showcase__nav-label">{slidesLabel}</span>
           <span className="lt-showcase__nav-spacer" />
-          {Array.from({ length: len }, (_, i) => (
+          {Array.from({ length: products.length }, (_, i) => (
             <button
               key={i}
               type="button"

--- a/src/components/products/DimensionDrawing/DimensionDrawing.tsx
+++ b/src/components/products/DimensionDrawing/DimensionDrawing.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { M3030VAOutline } from "./M3030VAOutline";
+import { SectionHeader } from "../SectionHeader/SectionHeader";
 import "./DimensionDrawing.css";
 
 export type Callout = { id: string; label: string; value: string };
@@ -32,13 +33,7 @@ export function DimensionDrawing({
 
   return (
     <section id="dimensions" className="lt-pdp-dim">
-      <header className="lt-pdp-section-hd">
-        <div>
-          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
-          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
-          <p className="lt-pdp-section-hd__sub">{sub}</p>
-        </div>
-      </header>
+      <SectionHeader kicker={kicker} title={heading} sub={sub} />
 
       <div className="lt-pdp-dim__frame">
         <div className="lt-pdp-dim__canvas">

--- a/src/components/products/DownloadsList/DownloadsList.tsx
+++ b/src/components/products/DownloadsList/DownloadsList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
+import { SectionHeader } from "../SectionHeader/SectionHeader";
 import "./DownloadsList.css";
 
 export type DownloadItem = {
@@ -49,13 +50,7 @@ export function DownloadsList({
 
   return (
     <section id="downloads" className="lt-pdp-dl">
-      <header className="lt-pdp-section-hd">
-        <div>
-          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
-          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
-          <p className="lt-pdp-section-hd__sub">{sub}</p>
-        </div>
-      </header>
+      <SectionHeader kicker={kicker} title={heading} sub={sub} />
 
       <ul className="lt-pdp-dl__list" role="list">
         {items.map((it, i) => {

--- a/src/components/products/Overview/Overview.css
+++ b/src/components/products/Overview/Overview.css
@@ -2,40 +2,6 @@
   margin-bottom: 64px;
   scroll-margin-top: 72px;
 }
-.lt-pdp-section-hd {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 24px;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--pd-rule);
-}
-.lt-pdp-section-hd__kicker {
-  font: 500 var(--lt-fs-xs) var(--lt-mono);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--pd-primary);
-  margin-bottom: 8px;
-}
-:lang(ko) .lt-pdp-section-hd__kicker,
-:lang(zh) .lt-pdp-section-hd__kicker {
-  font-family: var(--lt-sans);
-  letter-spacing: 0;
-  text-transform: none;
-}
-.lt-pdp-section-hd__title {
-  font: 500 var(--lt-fs-xl) / 1.1 var(--lt-sans);
-  letter-spacing: -0.015em;
-  color: var(--pd-fg-strong);
-  margin: 0 0 6px;
-}
-.lt-pdp-section-hd__sub {
-  margin: 0;
-  color: var(--pd-muted);
-  font-size: var(--lt-fs-sm);
-  max-width: 560px;
-}
 
 .lt-pdp-over__list {
   list-style: none;

--- a/src/components/products/Overview/Overview.tsx
+++ b/src/components/products/Overview/Overview.tsx
@@ -1,3 +1,4 @@
+import { SectionHeader } from "../SectionHeader/SectionHeader";
 import "./Overview.css";
 
 export type OverviewRow = {
@@ -30,13 +31,7 @@ export function Overview({
 }: Props) {
   return (
     <section id="overview" className={`lt-pdp-over lt-pdp-over--${tone}`}>
-      <header className="lt-pdp-section-hd">
-        <div>
-          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
-          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
-          <p className="lt-pdp-section-hd__sub">{sub}</p>
-        </div>
-      </header>
+      <SectionHeader kicker={kicker} title={heading} sub={sub} />
 
       <ol className="lt-pdp-over__list">
         {rows.map((r, i) => (

--- a/src/components/products/RequestDocs/RequestDocs.tsx
+++ b/src/components/products/RequestDocs/RequestDocs.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
+import { SectionHeader } from "../SectionHeader/SectionHeader";
 import "./RequestDocs.css";
 
 type Props = {
@@ -19,13 +20,7 @@ export function RequestDocs({
 }: Props) {
   return (
     <section id="downloads" className="lt-pdp-rd">
-      <header className="lt-pdp-section-hd">
-        <div>
-          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
-          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
-          <p className="lt-pdp-section-hd__sub">{body}</p>
-        </div>
-      </header>
+      <SectionHeader kicker={kicker} title={heading} sub={body} />
       <div className="lt-pdp-rd__cta">
         <Button
           variant="primary"

--- a/src/components/products/SectionHeader/SectionHeader.css
+++ b/src/components/products/SectionHeader/SectionHeader.css
@@ -1,0 +1,34 @@
+.lt-pdp-section-hd {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--pd-rule);
+}
+.lt-pdp-section-hd__kicker {
+  font: 500 var(--lt-fs-xs) var(--lt-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pd-primary);
+  margin-bottom: 8px;
+}
+:lang(ko) .lt-pdp-section-hd__kicker,
+:lang(zh) .lt-pdp-section-hd__kicker {
+  font-family: var(--lt-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.lt-pdp-section-hd__title {
+  font: 500 var(--lt-fs-xl) / 1.1 var(--lt-sans);
+  letter-spacing: -0.015em;
+  color: var(--pd-fg-strong);
+  margin: 0 0 6px;
+}
+.lt-pdp-section-hd__sub {
+  margin: 0;
+  color: var(--pd-muted);
+  font-size: var(--lt-fs-sm);
+  max-width: 560px;
+}

--- a/src/components/products/SectionHeader/SectionHeader.tsx
+++ b/src/components/products/SectionHeader/SectionHeader.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import "./SectionHeader.css";
+
+type Props = {
+  kicker: string;
+  title: string;
+  sub: string;
+  /** Optional right-aligned content (e.g. action button). */
+  children?: ReactNode;
+};
+
+export function SectionHeader({ kicker, title, sub, children }: Props) {
+  return (
+    <header className="lt-pdp-section-hd">
+      <div>
+        <div className="lt-pdp-section-hd__kicker">{kicker}</div>
+        <h2 className="lt-pdp-section-hd__title">{title}</h2>
+        <p className="lt-pdp-section-hd__sub">{sub}</p>
+      </div>
+      {children}
+    </header>
+  );
+}

--- a/src/components/products/SpecTable/SpecTable.tsx
+++ b/src/components/products/SpecTable/SpecTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Glyph } from "@/components/ui/Glyph";
+import { SectionHeader } from "../SectionHeader/SectionHeader";
 import "./SpecTable.css";
 
 type Row = { key: string; label: string; value: string };
@@ -44,12 +45,7 @@ export function SpecTable({
 
   return (
     <section id="specs" className="lt-pdp-specs">
-      <header className="lt-pdp-section-hd">
-        <div>
-          <div className="lt-pdp-section-hd__kicker">{kicker}</div>
-          <h2 className="lt-pdp-section-hd__title">{heading}</h2>
-          <p className="lt-pdp-section-hd__sub">{sub}</p>
-        </div>
+      <SectionHeader kicker={kicker} title={heading} sub={sub}>
         <Button
           variant="ghost"
           size="sm"
@@ -58,7 +54,7 @@ export function SpecTable({
         >
           {copied ? copiedLabel : copyLabel}
         </Button>
-      </header>
+      </SectionHeader>
 
       <div className="lt-pdp-spec">
         {groups.map((g) => (

--- a/src/components/resources/DocRow.tsx
+++ b/src/components/resources/DocRow.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 
 type Props = {
   /** Document title shown as the row's primary label. */
@@ -24,10 +24,10 @@ export function DocRow({ label, meta, action }: Props) {
         {parts.length > 0 && (
           <div className="dr-list__meta">
             {parts.map((part, i) => (
-              <span key={i}>
+              <Fragment key={i}>
                 {i > 0 && <span className="dr-list__sep">·</span>}
                 <span>{part}</span>
-              </span>
+              </Fragment>
             ))}
           </div>
         )}

--- a/src/components/resources/DocRow.tsx
+++ b/src/components/resources/DocRow.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  /** Document title shown as the row's primary label. */
+  label: string;
+  /** Meta parts (model, rev, date, …). Falsy entries are dropped; rendered with `·` separators. */
+  meta?: Array<string | null | undefined>;
+  /** Action element — typically a download `<a>` or a request `<Link>`/badge. */
+  action: ReactNode;
+};
+
+/**
+ * One row in the data-room list views (catalogues / manuals / datasheets).
+ * Layout: `[PDF badge] [label + meta] [action]`. CSS lives in
+ * resources-subpage.css and is shared by every consumer.
+ */
+export function DocRow({ label, meta, action }: Props) {
+  const parts = (meta ?? []).filter((p): p is string => Boolean(p));
+  return (
+    <li className="dr-list__row">
+      <span className="dr-list__badge dr-list__badge--pdf">PDF</span>
+      <div>
+        <div className="dr-list__label">{label}</div>
+        {parts.length > 0 && (
+          <div className="dr-list__meta">
+            {parts.map((part, i) => (
+              <span key={i}>
+                {i > 0 && <span className="dr-list__sep">·</span>}
+                <span>{part}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      {action}
+    </li>
+  );
+}

--- a/src/lib/hooks/useCarousel.ts
+++ b/src/lib/hooks/useCarousel.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+const subscribeReducedMotion = (cb: () => void) => {
+  if (typeof window === "undefined") return () => {};
+  const mql = window.matchMedia(REDUCED_MOTION_QUERY);
+  mql.addEventListener("change", cb);
+  return () => mql.removeEventListener("change", cb);
+};
+const getRMSnapshot = () => window.matchMedia(REDUCED_MOTION_QUERY).matches;
+const getRMServerSnapshot = () => false;
+
+type Options = {
+  intervalMs: number;
+  /** Caller-provided pause flag (e.g. hover/focus inside the carousel). */
+  paused?: boolean;
+};
+
+/**
+ * Auto-advancing index hook for carousels. Skips ticks when:
+ *   - length <= 1
+ *   - the user has prefers-reduced-motion set
+ *   - `paused` is true (hover, focus, etc. — caller decides)
+ */
+export function useCarousel(
+  length: number,
+  { intervalMs, paused = false }: Options,
+) {
+  const [active, setActive] = useState(0);
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getRMSnapshot,
+    getRMServerSnapshot,
+  );
+
+  useEffect(() => {
+    if (length <= 1 || reducedMotion || paused) return;
+    const id = window.setInterval(() => {
+      setActive((n) => (n + 1) % length);
+    }, intervalMs);
+    return () => window.clearInterval(id);
+  }, [length, intervalMs, paused, reducedMotion]);
+
+  return { active, setActive };
+}

--- a/src/lib/seo/llmsManifest.ts
+++ b/src/lib/seo/llmsManifest.ts
@@ -79,11 +79,12 @@ export async function buildLlmsManifest(siteUrl: string): Promise<string> {
     })
     .filter((p): p is Product => p !== null);
 
-  const byCategory = {
-    analogue: products.filter((p) => p.series === "analogue"),
-    digital: products.filter((p) => p.series === "digital"),
-    specialized: products.filter((p) => p.series === "specialized"),
+  const byCategory: Record<Product["series"], Product[]> = {
+    analogue: [],
+    digital: [],
+    specialized: [],
   };
+  for (const p of products) byCategory[p.series].push(p);
 
   const lines: string[] = [
     "# Line Tech",

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -1,23 +1,41 @@
 import { defineQuery } from "next-sanity";
 
+/**
+ * Localized-field projection helpers.
+ *
+ * The CMS stores localized text as `[{ language, value }]` arrays. Every query
+ * needs to project a `{ ko, en, zh }` object with locale fallbacks. There are
+ * two fallback shapes in use:
+ *
+ *   - localized(field):     ko↔en↔ko, zh→en→zh   (most fields)
+ *   - localizedFull(field): full circular fallback through all 3 locales
+ *                           (used where every locale must produce a value, e.g.
+ *                           product tag labels surfaced in the UI)
+ *
+ * Helpers return a GROQ object literal — embed inside a projection with `:`.
+ */
+const localized = (field: string) => `{
+    "ko": coalesce(${field}[language == "ko"][0].value, ${field}[language == "en"][0].value),
+    "en": coalesce(${field}[language == "en"][0].value, ${field}[language == "ko"][0].value),
+    "zh": coalesce(${field}[language == "zh"][0].value, ${field}[language == "en"][0].value)
+  }`;
+
+const localizedFull = (field: string) => `{
+    "ko": coalesce(${field}[language == "ko"][0].value, ${field}[language == "en"][0].value, ${field}[language == "zh"][0].value),
+    "en": coalesce(${field}[language == "en"][0].value, ${field}[language == "ko"][0].value, ${field}[language == "zh"][0].value),
+    "zh": coalesce(${field}[language == "zh"][0].value, ${field}[language == "en"][0].value, ${field}[language == "ko"][0].value)
+  }`;
+
 const PRODUCT_BASE_PROJECTION = `
   model,
   slug,
   series,
   "function": function,
-  "productLabel": {
-    "ko": coalesce(productLabel[language == "ko"][0].value, productLabel[language == "en"][0].value),
-    "en": coalesce(productLabel[language == "en"][0].value, productLabel[language == "ko"][0].value),
-    "zh": coalesce(productLabel[language == "zh"][0].value, productLabel[language == "en"][0].value)
-  },
+  "productLabel": ${localized("productLabel")},
   "tags": coalesce(tags[]->{
     "slug": slug,
     kind,
-    "label": {
-      "ko": coalesce(label[language == "ko"][0].value, label[language == "en"][0].value, label[language == "zh"][0].value),
-      "en": coalesce(label[language == "en"][0].value, label[language == "ko"][0].value, label[language == "zh"][0].value),
-      "zh": coalesce(label[language == "zh"][0].value, label[language == "en"][0].value, label[language == "ko"][0].value)
-    }
+    "label": ${localizedFull("label")}
   }, []),
   description,
   features,
@@ -211,44 +229,20 @@ export const allDrawingsQuery = defineQuery(`
 export const allFaqGroupsQuery = defineQuery(`
   *[_type == "faqGroup"] | order(coalesce(order, 99) asc) {
     "id": id.current,
-    "heading": {
-      "ko": coalesce(heading[language == "ko"][0].value, heading[language == "en"][0].value),
-      "en": coalesce(heading[language == "en"][0].value, heading[language == "ko"][0].value),
-      "zh": coalesce(heading[language == "zh"][0].value, heading[language == "en"][0].value)
-    },
+    "heading": ${localized("heading")},
     "questions": questions[] {
       id,
-      "q": {
-        "ko": coalesce(q[language == "ko"][0].value, q[language == "en"][0].value),
-        "en": coalesce(q[language == "en"][0].value, q[language == "ko"][0].value),
-        "zh": coalesce(q[language == "zh"][0].value, q[language == "en"][0].value)
-      },
-      "a": {
-        "ko": coalesce(a[language == "ko"][0].value, a[language == "en"][0].value),
-        "en": coalesce(a[language == "en"][0].value, a[language == "ko"][0].value),
-        "zh": coalesce(a[language == "zh"][0].value, a[language == "en"][0].value)
-      }
+      "q": ${localized("q")},
+      "a": ${localized("a")}
     }
   }
 `);
 
 const APPLICATION_PROJECTION = `
   "slug": slug.current,
-  "title": {
-    "ko": coalesce(title[language == "ko"][0].value, title[language == "en"][0].value),
-    "en": coalesce(title[language == "en"][0].value, title[language == "ko"][0].value),
-    "zh": coalesce(title[language == "zh"][0].value, title[language == "en"][0].value)
-  },
-  "lede": {
-    "ko": coalesce(lede[language == "ko"][0].value, lede[language == "en"][0].value),
-    "en": coalesce(lede[language == "en"][0].value, lede[language == "ko"][0].value),
-    "zh": coalesce(lede[language == "zh"][0].value, lede[language == "en"][0].value)
-  },
-  "body": {
-    "ko": coalesce(body[language == "ko"][0].value, body[language == "en"][0].value),
-    "en": coalesce(body[language == "en"][0].value, body[language == "ko"][0].value),
-    "zh": coalesce(body[language == "zh"][0].value, body[language == "en"][0].value)
-  },
+  "title": ${localized("title")},
+  "lede": ${localized("lede")},
+  "body": ${localized("body")},
   recommendedSeries,
   relatedCategories
 `;
@@ -285,16 +279,8 @@ export const allCertificationsQuery = defineQuery(`
   *[_type == "certification"] | order(coalesce(order, 99) asc) {
     _id,
     name,
-    "issuer": {
-      "ko": coalesce(issuer[language == "ko"][0].value, issuer[language == "en"][0].value),
-      "en": coalesce(issuer[language == "en"][0].value, issuer[language == "ko"][0].value),
-      "zh": coalesce(issuer[language == "zh"][0].value, issuer[language == "en"][0].value)
-    },
-    "scope": {
-      "ko": coalesce(scope[language == "ko"][0].value, scope[language == "en"][0].value),
-      "en": coalesce(scope[language == "en"][0].value, scope[language == "ko"][0].value),
-      "zh": coalesce(scope[language == "zh"][0].value, scope[language == "en"][0].value)
-    },
+    "issuer": ${localized("issuer")},
+    "scope": ${localized("scope")},
     validThrough,
     "fileUrl": file.asset->url
   }


### PR DESCRIPTION
## Summary

A focused /simplify pass over the codebase. Started from a 3-agent audit (components, libs/hooks/sanity, config/infra) that surfaced 30+ candidates. Most didn't survive contact with the actual code — agents tend to count lines without reading them. The 6 commits here are the survivors that genuinely improve reuse, quality, or efficiency without scope creep.

### What changed
- **`<SectionHeader>` for PDP sections** — DRYed the `lt-pdp-section-hd` markup duplicated across Overview, DownloadsList, SpecTable, DimensionDrawing, RequestDocs. Moved the cross-component CSS out of `Overview.css` so it lives with the component that owns it.
- **`useCarousel` hook** — extracted the auto-advance loop shared between `CategoryShowcase` and `FeatureSection`. CategoryShowcase now respects `prefers-reduced-motion` (a11y improvement that came along for free — FeatureSection already did).
- **GROQ `localized()` helpers** — replaced ~10 inlined 5-line `coalesce(field[language=="ko"][0].value, …)` blocks across `queries.ts` with two helpers covering the 2-locale and 3-locale fallback shapes. Output GROQ is byte-identical.
- **`<DocRow>` for data-room lists** — extracted the PDF-badge + label + dot-meta + action row pattern shared by catalogues, manuals, and datasheets. Net **−94 lines** across the 3 pages.
- **`llmsManifest` partition** — replaced 3 sequential `.filter()` calls with one explicit-partition loop.
- **i18n key sweep** — dropped 2 confirmed-dead keys (`products.table.view`, `resources.certCard.ongoing`) from all 3 locale files.

### What was rejected (and why)
~12 of the audit candidates were rejected after reading the code. The big ones, briefly:
- **Inline single-use SVGs as static assets** — `M3030VAOutline` is interactive (hover/setH props); `IntroVisual` embeds CSS-var refs that don't resolve in static `.svg` files.
- **Drop the `@theme inline` block in `globals.css`** — that block is what maps `--lt-*`/`--pd-*` tokens into Tailwind v4's `--color-*` namespace; removing it kills every brand utility (`bg-primary-500`, `text-h2`, `bg-surface`, …).
- **Remove `fetchSanity` wrapper** — 16 callers, provides structured `[sanity] <name> failed` logs Next.js can't reproduce. Earns its keep.
- **Simplify middleware locale detection** — the country-IP routing is a deliberate feature (#142); next-intl handles Accept-Language but not `x-vercel-ip-country`. Removing it would silently delete a shipped feature.
- **Split `useDialogPanel` into 4 hooks** — the bundle ("scroll lock + escape + focus trap + focus restore") is the contract; splitting moves complexity to call sites.
- **Consolidate SEO builders into a factory / split HeaderShell contexts / extract useSearch / useAccordion / useAsyncButtonState** — agent flags that don't survive scrutiny: single consumers, intentionally-different patterns, or already-decomposed code.

Detail in the commit messages.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (2 pre-existing warnings unrelated to this branch)
- [x] `pnpm test:run` — 77/77 passing on Node 22
- [ ] Smoke: home, one PDP, /resources/catalogues, /resources/datasheets, /resources/manuals, mobile nav, search panel
- [ ] Confirm dialog focus-restore + carousel autoplay still behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)