### PR TITLE
fix(types): accept "EPC" as a product function

### DIFF
--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -744,7 +744,7 @@ function validate(p: Product): void {
   if (!p.slug.current) throw new Error(`${p.model}: missing slug`);
   if (!["analogue", "digital", "specialized"].includes(p.series))
     throw new Error(`${p.model}: bad series "${p.series}"`);
-  if (!["MFC", "MFM"].includes(p.function))
+  if (!["MFC", "MFM", "EPC"].includes(p.function))
     throw new Error(`${p.model}: bad function "${p.function}"`);
   if (p.connections.length === 0)
     throw new Error(`${p.model}: no connections parsed`);

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -10,7 +10,7 @@ export type ShowcaseProduct = {
   slug: string;
   model: string;
   caption: string | null;
-  function: "MFC" | "MFM" | null;
+  function: "MFC" | "MFM" | "EPC" | null;
   flowRange: string | null;
   accuracy: string | null;
   image: string;

--- a/src/lib/seo/llmsManifest.ts
+++ b/src/lib/seo/llmsManifest.ts
@@ -37,7 +37,11 @@ function productLine(product: Product, siteUrl: string): string {
   const mdUrl = `${siteUrl}/products/${slug}/spec.md`;
 
   const fnLabel =
-    product.function === "MFC" ? "Mass Flow Controller" : "Mass Flow Meter";
+    product.function === "MFC"
+      ? "Mass Flow Controller"
+      : product.function === "MFM"
+        ? "Mass Flow Meter"
+        : "Electronic Pressure Controller";
   const flowRange = product.massFlowSpecs.flowRange?.display;
   const accuracy = product.massFlowSpecs.accuracy?.display;
 
@@ -112,6 +116,7 @@ export async function buildLlmsManifest(siteUrl: string): Promise<string> {
 
     const mfcs = list.filter((p) => p.function === "MFC");
     const mfms = list.filter((p) => p.function === "MFM");
+    const epcs = list.filter((p) => p.function === "EPC");
 
     if (mfcs.length > 0) {
       lines.push("**Mass Flow Controllers**", "");
@@ -121,6 +126,11 @@ export async function buildLlmsManifest(siteUrl: string): Promise<string> {
     if (mfms.length > 0) {
       lines.push("**Mass Flow Meters**", "");
       for (const p of mfms) lines.push(productLine(p, siteUrl));
+      lines.push("");
+    }
+    if (epcs.length > 0) {
+      lines.push("**Electronic Pressure Controllers**", "");
+      for (const p of epcs) lines.push(productLine(p, siteUrl));
       lines.push("");
     }
   }

--- a/src/lib/seo/specSheet.ts
+++ b/src/lib/seo/specSheet.ts
@@ -33,6 +33,18 @@ const SERIES_LABELS: Record<Product["series"], string> = {
   specialized: "Specialized",
 };
 
+const FUNCTION_LABELS: Record<
+  Product["function"],
+  { short: string; long: string }
+> = {
+  MFC: { short: "Mass Flow Controller", long: "Mass Flow Controller (MFC)" },
+  MFM: { short: "Mass Flow Meter", long: "Mass Flow Meter (MFM)" },
+  EPC: {
+    short: "Electronic Pressure Controller",
+    long: "Electronic Pressure Controller (EPC)",
+  },
+};
+
 export type SpecJsonPayload = {
   model: string;
   slug: string;
@@ -97,10 +109,12 @@ export function buildSpecMarkdown(product: Product, siteUrl: string): string {
   const koUrl = `${siteUrl}/ko/products/${category}/${slug}`;
   const zhUrl = `${siteUrl}/zh/products/${category}/${slug}`;
 
+  const fn = FUNCTION_LABELS[product.function];
+
   const lines: string[] = [
-    `# ${product.model} — ${seriesLabel} Mass Flow ${product.function === "MFC" ? "Controller" : "Meter"}`,
+    `# ${product.model} — ${seriesLabel} ${fn.short}`,
     "",
-    `**Series:** ${seriesLabel} · **Function:** ${product.function === "MFC" ? "Mass Flow Controller (MFC)" : "Mass Flow Meter (MFM)"}`,
+    `**Series:** ${seriesLabel} · **Function:** ${fn.long}`,
     `**Product name:** ${product.productLabel.en}`,
     `**Canonical page:** ${canonicalUrl}`,
     "",

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -80,7 +80,7 @@ export const SanityProductSchema = z.object({
   model: z.string(),
   slug: z.object({ current: z.string() }),
   series: z.enum(["analogue", "digital", "specialized"]),
-  function: z.enum(["MFC", "MFM"]),
+  function: z.enum(["MFC", "MFM", "EPC"]),
   productLabel: z.object({
     ko: z.string(),
     en: z.string(),

--- a/src/lib/types/showcase.ts
+++ b/src/lib/types/showcase.ts
@@ -5,7 +5,7 @@ const ShowcaseEntrySchema = z.object({
   model: z.string(),
   slug: z.string(),
   caption: z.string().nullable(),
-  function: z.enum(["MFC", "MFM"]).nullable(),
+  function: z.enum(["MFC", "MFM", "EPC"]).nullable(),
   flowRange: z.string().nullable(),
   accuracy: z.string().nullable(),
   image: SanityImageSchema.nullable().optional(),


### PR DESCRIPTION
## Why

The LEPC product is configured in Sanity with `function: "EPC"` (Electronic Pressure Controller — neither MFC nor MFM). The Zod schema only allowed `"MFC" | "MFM"`, so every CI build crashed when prerendering `/en/products/specialized/lepc`:

```
Error [ZodError]: Invalid option: expected one of "MFC"|"MFM"
  path: [ "function" ]
Export encountered an error on /[locale]/products/[category]/[product]/page: /en/products/specialized/lepc
```

Main has been red on this for several runs. Unblocks #184 (drawings) and any other in-flight PR.

## Changes

- `src/lib/types/product.ts` — widen `function` enum to `"MFC" | "MFM" | "EPC"`
- `src/lib/types/showcase.ts` — same widening on the showcase entry schema
- `src/components/products/CategoryShowcase/CategoryShowcase.tsx` — TS union match
- `src/lib/seo/specSheet.ts` — replace binary `=== "MFC"` ternary with a `FUNCTION_LABELS` map so EPC products render as "Electronic Pressure Controller" in the spec sheet markdown, not silently as "Mass Flow Meter"
- `src/lib/seo/llmsManifest.ts` — same; adds an "Electronic Pressure Controllers" subsection to the manifest
- `scripts/parse-catalog.ts` — accept `"EPC"` in runtime validation

## Test plan

- [ ] CI green
- [ ] Visit `/en/products/specialized/lepc` — page renders
- [ ] Visit `/en/products/specialized/lepc/spec.md` — markdown header reads "Specialized Electronic Pressure Controller"