### PR TITLE
fix(drawings): deterministic _key for stpFiles in import script

### DIFF
--- a/scripts/upload-cad-drawings.ts
+++ b/scripts/upload-cad-drawings.ts
@@ -264,7 +264,7 @@ async function uploadDrawing(plan: DrawingPlan): Promise<{ uploaded: number }> {
     );
     stpFiles.push({
       _type: "stpVariant",
-      _key: asset._id,
+      _key: stp.fitting.replace(/[^a-z0-9]/gi, "-").toLowerCase(),
       fitting: stp.fitting,
       sortKey: stp.sortKey,
       file: {


### PR DESCRIPTION
## Summary
- Replaces `_key: asset._id` (changes on every upload) with a slug derived from the fitting label so `createOrReplace` stays idempotent across re-runs
- Prevents orphaned assets in Sanity when the import script is re-run
- Closes #191

## Test plan
- Script is not under automated test; verify by reading the change: `stp.fitting.replace(/[^a-z0-9]/gi, "-").toLowerCase()` produces a stable, lowercase, hyphen-separated key for any fitting label

🤖 Generated with [Claude Code](https://claude.com/claude-code)