### PR TITLE
fix(catalogue): show em-dash for empty fitting cell

### DIFF
--- a/src/components/products/ProductRow/ProductRow.tsx
+++ b/src/components/products/ProductRow/ProductRow.tsx
@@ -26,6 +26,7 @@ function fittingSummary(connections: Product["connections"]): string {
     const last = c.type.split(/\s+/).at(-1);
     if (last) types.add(last);
   }
+  if (types.size === 0) return "—";
   return [...types].join(" · ");
 }
 


### PR DESCRIPTION
## Summary
- DO400's fitting cell on the analogue catalogue page rendered as a fully blank `<td>` because its `connections` array is empty in the fixture (the 2026 source materials genuinely lack fitting data for this special-order SKU — no brochure CAD, no row in `docs/product-catalog-2026.md` §8).
- `fittingSummary` in `ProductRow.tsx` now returns `"—"` when no connection types are present, matching the existing response-time fallback on the same row (`response` at `ProductRow.tsx:43-45`).

No invented spec data; if real DO400 fittings surface later, just populate `connections` in `src/lib/fixtures/products.json`.

## Test plan
- [ ] `pnpm dev` and visit `/en/products/analogue` — DO400 row shows `—` in the fitting column; M3030VA and others unchanged
- [ ] Repeat for `/ko/products/analogue` and `/zh/products/analogue`
- [ ] Spot-check one digital and one specialized product for regression
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)