### PR TITLE
Spec table: swap mono to IBM Plex, drop sticky group label

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Inter, IBM_Plex_Mono } from "next/font/google";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -19,7 +19,7 @@ const fontSans = Inter({
   display: "swap",
 });
 
-const fontMono = JetBrains_Mono({
+const fontMono = IBM_Plex_Mono({
   subsets: ["latin"],
   weight: ["400", "500", "600"],
   variable: "--font-mono",

--- a/src/components/products/SpecTable/SpecTable.css
+++ b/src/components/products/SpecTable/SpecTable.css
@@ -35,7 +35,7 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
-  font: 600 var(--lt-fs-lg) var(--lt-sans);
+  font: 600 var(--lt-fs-md) var(--lt-sans);
   color: var(--pd-fg-strong);
   height: fit-content;
   margin: 0;

--- a/src/components/products/SpecTable/SpecTable.css
+++ b/src/components/products/SpecTable/SpecTable.css
@@ -32,8 +32,6 @@
   border-bottom: 1px solid var(--pd-border-strong);
 }
 .lt-pdp-spec__grouplbl {
-  position: sticky;
-  top: 120px;
   display: flex;
   align-items: baseline;
   gap: 10px;
@@ -41,6 +39,7 @@
   color: var(--pd-fg-strong);
   height: fit-content;
   margin: 0;
+  padding-top: 14px;
 }
 .lt-pdp-spec__groupnum {
   font: 500 var(--lt-fs-micro) var(--lt-mono);
@@ -87,7 +86,7 @@
     gap: 8px;
   }
   .lt-pdp-spec__grouplbl {
-    position: static;
+    padding-top: 0;
   }
 }
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- Swap global \`--lt-mono\` (Inter's mono pair) from JetBrains Mono → IBM Plex Mono. JetBrains is a coder font that felt out of place against Inter in the spec layout, and its weak coverage of ±, ×, superscript digits, and middle dot pulled in mismatched fallback glyphs inside single value cells.
- Drop the sticky positioning on the spec group label — it floated mid-scroll and looked detached from its rows. Now sits at the top of each group, aligned with the first row's text.
- Side effect: every other small mono accent on the site (404 hero, eyebrow labels on resources / faq / applications / region pages) also gets the more neutral Plex Mono treatment.

## Test plan
- [ ] Open a product detail page (e.g. \`/en/products/analogue/m3030va\`) — Specifications section should render values in IBM Plex Mono with consistent glyphs across ±, ×, superscript, middle dot.
- [ ] Scroll the spec section — group labels (01 Performance / 02 Signal & power / 03 Environment) should NOT stick; they sit at the top of each group, aligned with row text.
- [ ] Spot-check pages that use \`--lt-mono\` for editorial accents: 404, /en/resources, /en/faq, /en/applications, /en/contact/network/* — eyebrow labels should look consistent (now Plex Mono).

🤖 Generated with [Claude Code](https://claude.com/claude-code)