### PR TITLE
fix(products): render LTI-2000 instrument specs (shape alignment)

### DIFF
--- a/e2e/products-lti-2000.spec.ts
+++ b/e2e/products-lti-2000.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("LTI-2000 read-out unit detail", () => {
+  for (const locale of ["en", "ko", "zh"] as const) {
+    test(`renders Specifications with instrumentSpecs rows (${locale})`, async ({
+      page,
+    }) => {
+      await page.goto(`/${locale}/products/specialized/lti-2000`);
+
+      const specs = page.locator("#specs");
+      await expect(specs).toBeVisible();
+
+      const rows = specs.locator(".lt-pdp-spec__row");
+      await expect(rows.first()).toBeVisible();
+      expect(await rows.count()).toBeGreaterThanOrEqual(10);
+
+      await expect(
+        specs.getByText("Input Power", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        specs.getByText('256×64 Dot 6" Wide OLED LCD'),
+      ).toBeVisible();
+    });
+  }
+
+  test("unknown specialized slug returns 404", async ({ page }) => {
+    const res = await page.goto("/en/products/specialized/does-not-exist-1234");
+    expect(res?.status()).toBe(404);
+  });
+});

--- a/scripts/parse-catalog.test.ts
+++ b/scripts/parse-catalog.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { buildInstrumentSpecs } from "./parse-catalog";
+
+describe("buildInstrumentSpecs", () => {
+  it("returns a flat row array parsed from a Spec/Value table", () => {
+    const body = [
+      "Some intro prose",
+      "",
+      "| Spec | Value |",
+      "|---|---|",
+      "| Input Power | 220VAC |",
+      "| Output Signal | 0–5 Vdc |",
+      "",
+      "Trailing notes",
+    ];
+
+    expect(buildInstrumentSpecs(body)).toEqual([
+      { label: "Input Power", value: "220VAC" },
+      { label: "Output Signal", value: "0–5 Vdc" },
+    ]);
+  });
+
+  it("returns an empty array when no Spec/Value table is present", () => {
+    expect(buildInstrumentSpecs(["just prose", "no table here"])).toEqual([]);
+  });
+
+  it("drops rows that are missing label or value", () => {
+    const body = [
+      "| Spec | Value |",
+      "|---|---|",
+      "| Good Row | yes |",
+      "|  | orphan-value |",
+      "| orphan-label |  |",
+    ];
+
+    expect(buildInstrumentSpecs(body)).toEqual([
+      { label: "Good Row", value: "yes" },
+    ]);
+  });
+});

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -579,7 +579,7 @@ type ProductSection = {
   body: string[];
 };
 
-function buildInstrumentSpecs(body: string[]): InstrumentSpecs {
+export function buildInstrumentSpecs(body: string[]): InstrumentSpecs {
   for (let i = 0; i < body.length; i++) {
     if (/^\s*\|\s*Spec\s*\|\s*Value\s*\|/.test(body[i])) {
       const { rows } = parseMarkdownTable(body, i);
@@ -588,7 +588,7 @@ function buildInstrumentSpecs(body: string[]): InstrumentSpecs {
           label: row["Spec"] ?? "",
           value: row["Value"] ?? "",
         }))
-        .filter((r) => r.label);
+        .filter((r) => r.label && r.value);
     }
   }
   return [];
@@ -866,7 +866,7 @@ function validate(p: Product): void {
 
   if (p.function === "ROU") {
     if (!p.instrumentSpecs || p.instrumentSpecs.length === 0)
-      throw new Error(`${p.model}: ROU missing instrumentSpecs rows`);
+      throw new Error(`${p.model}: ROU missing instrumentSpecs`);
   } else {
     const s = p.massFlowSpecs;
     if (!s) throw new Error(`${p.model}: missing massFlowSpecs`);
@@ -962,4 +962,6 @@ function main() {
   console.log(`\nWrote ${products.length} products → ${OUTPUT_PATH}`);
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -583,17 +583,15 @@ function buildInstrumentSpecs(body: string[]): InstrumentSpecs {
   for (let i = 0; i < body.length; i++) {
     if (/^\s*\|\s*Spec\s*\|\s*Value\s*\|/.test(body[i])) {
       const { rows } = parseMarkdownTable(body, i);
-      return {
-        rows: rows
-          .map((row) => ({
-            label: row["Spec"] ?? "",
-            value: row["Value"] ?? "",
-          }))
-          .filter((r) => r.label),
-      };
+      return rows
+        .map((row) => ({
+          label: row["Spec"] ?? "",
+          value: row["Value"] ?? "",
+        }))
+        .filter((r) => r.label);
     }
   }
-  return { rows: [] };
+  return [];
 }
 
 function extractProductSections(catalog: string): ProductSection[] {
@@ -867,7 +865,7 @@ function validate(p: Product): void {
     throw new Error(`${p.model}: no connections parsed`);
 
   if (p.function === "ROU") {
-    if (!p.instrumentSpecs || p.instrumentSpecs.rows.length === 0)
+    if (!p.instrumentSpecs || p.instrumentSpecs.length === 0)
       throw new Error(`${p.model}: ROU missing instrumentSpecs rows`);
   } else {
     const s = p.massFlowSpecs;

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -50,7 +50,7 @@ function productToSeedFields(p: Product) {
     ...(p.massFlowSpecs ? { massFlowSpecs: p.massFlowSpecs } : {}),
   };
   if (p.instrumentSpecs) {
-    fields.instrumentSpecs = p.instrumentSpecs.rows.map((r, i) => ({
+    fields.instrumentSpecs = p.instrumentSpecs.map((r, i) => ({
       ...r,
       _key: `spec-${i}`,
     }));

--- a/src/app/[locale]/products/[category]/[product]/page.tsx
+++ b/src/app/[locale]/products/[category]/[product]/page.tsx
@@ -159,7 +159,7 @@ export default async function ProductPage({ params }: Props) {
           id: "instrument",
           num: "01",
           label: tPdp("tabs.specs"),
-          rows: (product.instrumentSpecs?.rows ?? []).map((r) => ({
+          rows: (product.instrumentSpecs ?? []).map((r) => ({
             key: r.label,
             label: r.label,
             value: r.value,
@@ -190,7 +190,7 @@ export default async function ProductPage({ params }: Props) {
     product.massFlowSpecs?.flowRange ?? product.massFlowSpecs?.pressureRange;
 
   const overviewRows = isROU
-    ? (product.instrumentSpecs?.rows ?? []).slice(0, 3).map((r) => ({
+    ? (product.instrumentSpecs ?? []).slice(0, 3).map((r) => ({
         feature: r.label,
         values: [r.value],
       }))
@@ -311,7 +311,7 @@ export default async function ProductPage({ params }: Props) {
   const productLabel = product.productLabel[locale];
 
   const additionalProperties = isROU
-    ? (product.instrumentSpecs?.rows ?? []).map((r) => ({
+    ? (product.instrumentSpecs ?? []).map((r) => ({
         "@type": "PropertyValue",
         name: r.label,
         value: r.value,

--- a/src/app/products/[slug]/spec.json/route.test.ts
+++ b/src/app/products/[slug]/spec.json/route.test.ts
@@ -2,7 +2,11 @@ import { mockFetchSanity } from "@/test/mocks/sanity";
 
 import { describe, expect, it, beforeEach } from "vitest";
 import { GET } from "./route";
-import { productFixture, makeProduct } from "@/test/fixtures/products";
+import {
+  productFixture,
+  makeProduct,
+  rouProductFixture,
+} from "@/test/fixtures/products";
 
 describe("GET /products/[slug]/spec.json", () => {
   beforeEach(() => {
@@ -37,6 +41,25 @@ describe("GET /products/[slug]/spec.json", () => {
     });
 
     expect(res.status).toBe(404);
+  });
+
+  it("surfaces instrumentSpecs rows for ROU products", async () => {
+    mockFetchSanity({
+      specJson: () => rouProductFixture,
+    });
+
+    const res = await GET(new Request("http://test/products/rou-test"), {
+      params: Promise.resolve({ slug: "rou-test" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.function).toBe("ROU");
+    expect(body.instrumentSpecs).toEqual([
+      { label: "Input Power", value: "220VAC (50–60 Hz)" },
+      { label: "Output Signal", value: "0–5 Vdc or 4–20 mA" },
+      { label: "Communication", value: "RS-232, RS-485" },
+    ]);
   });
 
   it("propagates fixture overrides into the response", async () => {

--- a/src/app/products/[slug]/spec.md/route.test.ts
+++ b/src/app/products/[slug]/spec.md/route.test.ts
@@ -1,0 +1,54 @@
+import { mockFetchSanity } from "@/test/mocks/sanity";
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { GET } from "./route";
+import { productFixture, rouProductFixture } from "@/test/fixtures/products";
+
+describe("GET /products/[slug]/spec.md", () => {
+  beforeEach(() => {
+    mockFetchSanity({
+      specMd: () => productFixture,
+    });
+  });
+
+  it("returns markdown for a flow product", async () => {
+    const res = await GET(new Request("http://test/products/test-1000"), {
+      params: Promise.resolve({ slug: "test-1000" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/text\/markdown/);
+    const body = await res.text();
+    expect(body).toContain("# TEST-1000");
+    expect(body).toContain("| Flow range | 0–1000 sccm |");
+  });
+
+  it("returns 404 when the Sanity query yields nothing", async () => {
+    mockFetchSanity({
+      specMd: () => null,
+    });
+
+    const res = await GET(new Request("http://test/products/missing"), {
+      params: Promise.resolve({ slug: "missing" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("renders instrumentSpecs rows for a ROU product", async () => {
+    mockFetchSanity({
+      specMd: () => rouProductFixture,
+    });
+
+    const res = await GET(new Request("http://test/products/rou-test"), {
+      params: Promise.resolve({ slug: "rou-test" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("# ROU-TEST");
+    expect(body).toContain("| Input Power | 220VAC (50–60 Hz) |");
+    expect(body).toContain("| Communication | RS-232, RS-485 |");
+    expect(body).not.toContain("Flow range");
+  });
+});

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -4718,62 +4718,60 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "instrumentSpecs": {
-      "rows": [
-        {
-          "label": "Input Power",
-          "value": "220VAC (50–60 Hz)"
-        },
-        {
-          "label": "Output Power",
-          "value": "+15 or +24 Vdc @ 500 mA"
-        },
-        {
-          "label": "Display Window",
-          "value": "256×64 Dot 6\" Wide OLED LCD"
-        },
-        {
-          "label": "Display Repeatability",
-          "value": "≤±1.0% of Full Scale"
-        },
-        {
-          "label": "Output Signal",
-          "value": "0–5 Vdc or 4–20 mA"
-        },
-        {
-          "label": "Units of Display",
-          "value": "SCCM, SLPM, %"
-        },
-        {
-          "label": "Remote Control",
-          "value": "D-SUB 9-pin (Male)"
-        },
-        {
-          "label": "Setpoint",
-          "value": "0–5 Vdc for Full Scale"
-        },
-        {
-          "label": "Flow ON/OFF",
-          "value": "Input Signal (TTL)"
-        },
-        {
-          "label": "Flow Out Signal",
-          "value": "0–5 Vdc or 4–20 mA"
-        },
-        {
-          "label": "Relay Contact Rate",
-          "value": "1 Relay (Max 24 Vdc @ 1A)"
-        },
-        {
-          "label": "Communication",
-          "value": "RS-232 (9600 Baud, 8-N-1), RS-485"
-        },
-        {
-          "label": "External Setpoint",
-          "value": "Analogue In/Out 0–5 Vdc"
-        }
-      ]
-    }
+    "instrumentSpecs": [
+      {
+        "label": "Input Power",
+        "value": "220VAC (50–60 Hz)"
+      },
+      {
+        "label": "Output Power",
+        "value": "+15 or +24 Vdc @ 500 mA"
+      },
+      {
+        "label": "Display Window",
+        "value": "256×64 Dot 6\" Wide OLED LCD"
+      },
+      {
+        "label": "Display Repeatability",
+        "value": "≤±1.0% of Full Scale"
+      },
+      {
+        "label": "Output Signal",
+        "value": "0–5 Vdc or 4–20 mA"
+      },
+      {
+        "label": "Units of Display",
+        "value": "SCCM, SLPM, %"
+      },
+      {
+        "label": "Remote Control",
+        "value": "D-SUB 9-pin (Male)"
+      },
+      {
+        "label": "Setpoint",
+        "value": "0–5 Vdc for Full Scale"
+      },
+      {
+        "label": "Flow ON/OFF",
+        "value": "Input Signal (TTL)"
+      },
+      {
+        "label": "Flow Out Signal",
+        "value": "0–5 Vdc or 4–20 mA"
+      },
+      {
+        "label": "Relay Contact Rate",
+        "value": "1 Relay (Max 24 Vdc @ 1A)"
+      },
+      {
+        "label": "Communication",
+        "value": "RS-232 (9600 Baud, 8-N-1), RS-485"
+      },
+      {
+        "label": "External Setpoint",
+        "value": "Analogue In/Out 0–5 Vdc"
+      }
+    ]
   },
   {
     "model": "LTI-1000",
@@ -4819,57 +4817,55 @@
     "datasheets": [],
     "manuals": [],
     "drawings": [],
-    "instrumentSpecs": {
-      "rows": [
-        {
-          "label": "Input Power",
-          "value": "220VAC (50–60 Hz)"
-        },
-        {
-          "label": "Output Power",
-          "value": "+15 or +24 Vdc @ 500 mA"
-        },
-        {
-          "label": "Display Window",
-          "value": "4-Digit 7-Segment"
-        },
-        {
-          "label": "Display Repeatability",
-          "value": "≤±1.0% of Full Scale"
-        },
-        {
-          "label": "Output Signal",
-          "value": "0–5 Vdc or 4–20 mA"
-        },
-        {
-          "label": "Units of Display",
-          "value": "SCCM, SLPM, %"
-        },
-        {
-          "label": "Remote Control",
-          "value": "D-SUB 9-pin (Male)"
-        },
-        {
-          "label": "Setpoint",
-          "value": "0–5 Vdc for Full Scale"
-        },
-        {
-          "label": "Flow ON/OFF",
-          "value": "Input Signal (TTL)"
-        },
-        {
-          "label": "Flow Out Signal",
-          "value": "0–5 Vdc or 4–20 mA"
-        },
-        {
-          "label": "Relay Contact Rate",
-          "value": "1 Relay (Max 24 Vdc @ 1A)"
-        },
-        {
-          "label": "Communication",
-          "value": "RS-232 (9600 Baud, 8-N-1)"
-        }
-      ]
-    }
+    "instrumentSpecs": [
+      {
+        "label": "Input Power",
+        "value": "220VAC (50–60 Hz)"
+      },
+      {
+        "label": "Output Power",
+        "value": "+15 or +24 Vdc @ 500 mA"
+      },
+      {
+        "label": "Display Window",
+        "value": "4-Digit 7-Segment"
+      },
+      {
+        "label": "Display Repeatability",
+        "value": "≤±1.0% of Full Scale"
+      },
+      {
+        "label": "Output Signal",
+        "value": "0–5 Vdc or 4–20 mA"
+      },
+      {
+        "label": "Units of Display",
+        "value": "SCCM, SLPM, %"
+      },
+      {
+        "label": "Remote Control",
+        "value": "D-SUB 9-pin (Male)"
+      },
+      {
+        "label": "Setpoint",
+        "value": "0–5 Vdc for Full Scale"
+      },
+      {
+        "label": "Flow ON/OFF",
+        "value": "Input Signal (TTL)"
+      },
+      {
+        "label": "Flow Out Signal",
+        "value": "0–5 Vdc or 4–20 mA"
+      },
+      {
+        "label": "Relay Contact Rate",
+        "value": "1 Relay (Max 24 Vdc @ 1A)"
+      },
+      {
+        "label": "Communication",
+        "value": "RS-232 (9600 Baud, 8-N-1)"
+      }
+    ]
   }
 ]

--- a/src/lib/seo/specSheet.ts
+++ b/src/lib/seo/specSheet.ts
@@ -96,8 +96,8 @@ export function buildSpecJson(
       length,
     })),
     specifications,
-    ...(product.instrumentSpecs?.rows.length
-      ? { instrumentSpecs: product.instrumentSpecs.rows }
+    ...(product.instrumentSpecs?.length
+      ? { instrumentSpecs: product.instrumentSpecs }
       : {}),
     digitalCommunication: product.digitalCommunication ?? undefined,
     canonicalUrl: `${siteUrl}/en/products/${category}/${slug}`,
@@ -139,8 +139,8 @@ export function buildSpecMarkdown(product: Product, siteUrl: string): string {
   lines.push("## Specifications", "");
   lines.push("| Spec | Value |");
   lines.push("|---|---|");
-  if (product.instrumentSpecs?.rows.length) {
-    for (const r of product.instrumentSpecs.rows) {
+  if (product.instrumentSpecs?.length) {
+    for (const r of product.instrumentSpecs) {
       lines.push(`| ${r.label} | ${r.value} |`);
     }
   } else {

--- a/src/lib/seo/specSheet.ts
+++ b/src/lib/seo/specSheet.ts
@@ -1,5 +1,9 @@
 import { categoryForSeries } from "@/lib/categories";
-import type { Product, MassFlowSpecs } from "@/lib/types/product";
+import type {
+  Product,
+  MassFlowSpecs,
+  InstrumentSpecs,
+} from "@/lib/types/product";
 
 const SPEC_LABELS: Record<keyof MassFlowSpecs, string> = {
   flowRange: "Flow range",
@@ -57,7 +61,7 @@ export type SpecJsonPayload = {
   features: { en?: string; ko?: string; zh?: string }[];
   connections: { type: string; length: string }[];
   specifications: Partial<Record<keyof MassFlowSpecs, Record<string, unknown>>>;
-  instrumentSpecs?: Array<{ label: string; value: string }>;
+  instrumentSpecs?: InstrumentSpecs | null;
   digitalCommunication?: Product["digitalCommunication"];
   canonicalUrl: string;
   alternates: { ko: string; zh: string };

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -58,9 +58,9 @@ const MassFlowSpecsSchema = z.object({
   }),
 });
 
-const InstrumentSpecsSchema = z.object({
-  rows: z.array(z.object({ label: z.string(), value: z.string() })),
-});
+const InstrumentSpecsSchema = z.array(
+  z.object({ label: z.string(), value: z.string() }),
+);
 
 const SanityImageRefSchema = z.object({
   _ref: z.string(),

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -41,6 +41,7 @@ const PRODUCT_BASE_PROJECTION = `
   features,
   connections,
   massFlowSpecs,
+  instrumentSpecs,
   cutout
 `;
 

--- a/src/test/fixtures/products.ts
+++ b/src/test/fixtures/products.ts
@@ -36,3 +36,27 @@ export const productFixture: Product = {
 export function makeProduct(overrides: Partial<Product> = {}): Product {
   return { ...productFixture, ...overrides };
 }
+
+export const rouProductFixture: Product = {
+  model: "ROU-TEST",
+  slug: { current: "rou-test" },
+  series: "specialized",
+  function: "ROU",
+  productLabel: {
+    ko: "테스트 리드아웃",
+    en: "Test Read-Out Unit",
+    zh: "测试读数单元",
+  },
+  tags: [],
+  features: [{ ko: "특징 1", en: "Feature 1", zh: "特征 1", _key: "f1" }],
+  connections: [],
+  instrumentSpecs: [
+    { label: "Input Power", value: "220VAC (50–60 Hz)" },
+    { label: "Output Signal", value: "0–5 Vdc or 4–20 mA" },
+    { label: "Communication", value: "RS-232, RS-485" },
+  ],
+  datasheets: [],
+  manuals: [],
+  drawings: [],
+  certifications: [],
+};


### PR DESCRIPTION
## Summary

LTI-2000's Specifications section was rendering empty in all three locales because the `instrumentSpecs` shape disagreed across layers — Sanity stored a flat array of rows (correct per its own schema), but the rest of the stack assumed a wrapped `{ rows: [...] }` object. The GROQ projection also didn't list `instrumentSpecs` at all, so even after the shape mismatch the data still wouldn't have reached the page.

Aligned every layer on the flat `Row[]` shape (matching Sanity reality):

- `InstrumentSpecsSchema` (Zod): `z.array(...)` instead of `z.object({ rows: z.array(...) })`
- `buildInstrumentSpecs()` in `scripts/parse-catalog.ts`: return the row array directly
- `scripts/seed-products.ts`: drop the `.rows` access when seeding
- `src/lib/fixtures/products.json`: LTI-2000 entry now uses the flat shape
- `PRODUCT_BASE_PROJECTION` in `src/sanity/queries.ts`: project `instrumentSpecs`
- `src/app/[locale]/products/[category]/[product]/page.tsx` (3 read sites) + `src/lib/seo/specSheet.ts` (2 read sites): read `instrumentSpecs` directly

**No Sanity migration needed** — production already stores the flat shape (verified via direct GROQ probe — 13 rows on `product-lti-2000`). This PR just stops the rest of the stack from disagreeing with it.

## Why flat array

The Sanity schema models `instrumentSpecs` as `type: "array"` with `preview: { select: { title: "label", subtitle: "value" } }` — Studio editors interact with rows directly. Wrapping in `{ rows: [...] }` would be dead weight in Studio and inconsistent with how `massFlowSpecs` is modeled (no wrapper either). Aligning on the array shape removes a latent footgun for any future ROU.

## Closes

Closes #179. Most of the LTI-2000 umbrella was already delivered (#199 code layer, #215 cutout + Sanity sync, #216 description sync). This PR fixes the last user-visible gap — the empty Specifications section — surfaced while verifying #179's end-to-end state.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:run` — 126/126 pass
- [ ] After `chore/product-photos-2026-batch` lands on main: `/en|ko|zh/products/specialized/lti-2000` renders all 13 spec rows under the "01 Specifications" group. (Cannot verify in isolation here — without the ROU/EPC validator fix from that branch the page returns 500 before reaching the renderer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)