### PR TITLE
chore(products): add readout capability tag

### DIFF
--- a/scripts/seed-tags.ts
+++ b/scripts/seed-tags.ts
@@ -99,6 +99,11 @@ const TAGS: TagDef[] = [
     kind: "capability",
     label: { ko: "저압", en: "Low pressure", zh: "低压" },
   },
+  {
+    slug: "readout",
+    kind: "capability",
+    label: { ko: "리드아웃", en: "Readout", zh: "读出器" },
+  },
 ];
 
 function tagDocFields(t: TagDef) {


### PR DESCRIPTION
## Summary
- Seeds a new `readout` capability tag (ko 리드아웃 / en Readout / zh 读出器) — closes the vocabulary gap for the LTI readout family, which had no applicable tag in the existing 10-tag set.
- Sanity production already patched (out-of-band): **DO400** ← `mid-flow`, **LTI-1000** ← `readout`, **LTI-2000** ← `readout`. These three products previously rendered plain-text descriptions instead of capability chips on `/products/specialized` because their `tags[]` arrays were empty.

## Test plan
- [x] `pnpm test:run` — 140/140 pass (pre-push hook)
- [ ] Visit `/ko/products/specialized` after ISR refresh (or revalidate) — confirm DO400 / LTI-1000 / LTI-2000 rows now show capability chips in the description column

🤖 Generated with [Claude Code](https://claude.com/claude-code)