### PR TITLE
feat(products): dedicated ReadoutStack for ROU listings (#223)

### DIFF
--- a/e2e/products.spec.ts
+++ b/e2e/products.spec.ts
@@ -61,6 +61,45 @@ test.describe("Product browsing", () => {
   });
 });
 
+test.describe("Specialized category — readout table", () => {
+  test("instruments stack renders readout columns, not flow columns", async ({
+    page,
+  }) => {
+    await page.goto("/en/products/specialized");
+
+    // The instruments stack is the ReadoutStack — find it by its title.
+    const readout = page
+      .getByRole("region")
+      .filter({ has: page.getByRole("heading", { name: /Read-Out Units/i }) });
+    await expect(readout).toBeVisible();
+
+    // Readout-specific column headers are present
+    await expect(
+      readout.getByRole("columnheader", { name: "Display" }),
+    ).toBeVisible();
+    await expect(
+      readout.getByRole("columnheader", { name: "Input power" }),
+    ).toBeVisible();
+
+    // Flow-device column headers are absent from the readout table
+    await expect(
+      readout.getByRole("columnheader", { name: "Flow range" }),
+    ).toHaveCount(0);
+    await expect(
+      readout.getByRole("columnheader", { name: "Accuracy" }),
+    ).toHaveCount(0);
+
+    // LTI-2000 row shows the OLED display value, not an em-dash
+    const lti2000Row = readout.locator(".lt-prod-row").filter({
+      has: page.getByRole("link", { name: "LTI-2000" }),
+    });
+    await expect(lti2000Row).toBeVisible();
+    await expect(
+      lti2000Row.locator(".lt-readout-row__cell--display"),
+    ).toContainText("OLED");
+  });
+});
+
 test.describe("Certifications hub", () => {
   test("renders company-wide and product-specific groups", async ({ page }) => {
     await page.goto("/en/resources/certifications");

--- a/e2e/products.spec.ts
+++ b/e2e/products.spec.ts
@@ -67,13 +67,12 @@ test.describe("Specialized category — readout table", () => {
   }) => {
     await page.goto("/en/products/specialized");
 
-    // The instruments stack is the ReadoutStack — find it by its title.
-    const readout = page
-      .getByRole("region")
-      .filter({ has: page.getByRole("heading", { name: /Read-Out Units/i }) });
+    // ReadoutStack labels its <section> via aria-labelledby on the title heading,
+    // so it resolves as a named region — locate it by accessible name.
+    const readout = page.getByRole("region", { name: /Read-Out Units/i });
     await expect(readout).toBeVisible();
 
-    // Readout-specific column headers are present
+    // Readout-specific column headers are present.
     await expect(
       readout.getByRole("columnheader", { name: "Display" }),
     ).toBeVisible();
@@ -81,7 +80,7 @@ test.describe("Specialized category — readout table", () => {
       readout.getByRole("columnheader", { name: "Input power" }),
     ).toBeVisible();
 
-    // Flow-device column headers are absent from the readout table
+    // Flow-device column headers are absent from the readout table.
     await expect(
       readout.getByRole("columnheader", { name: "Flow range" }),
     ).toHaveCount(0);
@@ -89,14 +88,12 @@ test.describe("Specialized category — readout table", () => {
       readout.getByRole("columnheader", { name: "Accuracy" }),
     ).toHaveCount(0);
 
-    // LTI-2000 row shows the OLED display value, not an em-dash
-    const lti2000Row = readout.locator(".lt-prod-row").filter({
-      has: page.getByRole("link", { name: "LTI-2000" }),
-    });
+    // LTI-2000 row shows the OLED display value, not an em-dash.
+    const lti2000Row = readout.getByRole("row", { name: /LTI-2000/ });
     await expect(lti2000Row).toBeVisible();
-    await expect(
-      lti2000Row.locator(".lt-readout-row__cell--display"),
-    ).toContainText("OLED");
+    await expect(lti2000Row).toContainText("OLED");
+    // No em-dash should appear in this row — every column has data.
+    await expect(lti2000Row).not.toContainText("—");
   });
 });
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -117,7 +117,11 @@
       "range": "Flow range",
       "accuracy": "Accuracy",
       "response": "Response",
-      "fitting": "Fitting"
+      "fitting": "Fitting",
+      "display": "Display",
+      "power": "Input power",
+      "communication": "Communication",
+      "connector": "Connector"
     },
     "emptyStack": "No products in this category yet.",
     "showcase": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -117,7 +117,11 @@
       "range": "유량 범위",
       "accuracy": "정확도",
       "response": "응답",
-      "fitting": "연결"
+      "fitting": "연결",
+      "display": "디스플레이",
+      "power": "입력 전원",
+      "communication": "통신",
+      "connector": "커넥터"
     },
     "emptyStack": "이 카테고리에는 아직 등록된 제품이 없습니다.",
     "showcase": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -117,7 +117,11 @@
       "range": "流量范围",
       "accuracy": "精度",
       "response": "响应",
-      "fitting": "接口"
+      "fitting": "接口",
+      "display": "显示",
+      "power": "输入电源",
+      "communication": "通信",
+      "connector": "连接器"
     },
     "emptyStack": "该类别下暂无产品。",
     "showcase": {

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -215,7 +215,7 @@ export const product = defineType({
       name: "instrumentSpecs",
       title: "Instrument specs",
       description:
-        "For non-flow instruments (ROU). Each row: label + value string.",
+        "For non-flow instruments (ROU). Each row: label + value string. Set 'slot' to surface the row as a column in the readout listing table.",
       type: "array",
       of: [
         {
@@ -230,6 +230,20 @@ export const product = defineType({
               name: "value",
               type: "string",
               validation: (r) => r.required(),
+            }),
+            defineField({
+              name: "slot",
+              title: "Readout column slot",
+              type: "string",
+              options: {
+                list: [
+                  { title: "Display", value: "display" },
+                  { title: "Input power", value: "power" },
+                  { title: "Communication", value: "communication" },
+                  { title: "Connector", value: "connector" },
+                ],
+                layout: "dropdown",
+              },
             }),
           ],
           preview: { select: { title: "label", subtitle: "value" } },

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -249,6 +249,20 @@ export const product = defineType({
           preview: { select: { title: "label", subtitle: "value" } },
         },
       ],
+      validation: (r) =>
+        r.custom((items?: Array<{ slot?: string | null }>) => {
+          if (!items) return true;
+          const seen = new Set<string>();
+          for (const item of items) {
+            const slot = item?.slot;
+            if (!slot) continue;
+            if (seen.has(slot)) {
+              return `Multiple instrumentSpec rows share slot "${slot}". Each readout column accepts only one row.`;
+            }
+            seen.add(slot);
+          }
+          return true;
+        }),
     }),
     defineField({
       name: "digitalCommunication",

--- a/scripts/sync-readout-slots.ts
+++ b/scripts/sync-readout-slots.ts
@@ -14,9 +14,15 @@ function loadEnv(p: string) {
   try {
     for (const l of readFileSync(p, "utf-8").split("\n")) {
       const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-      if (m) process.env[m[1]] ??= m[2].trimEnd();
+      if (m) {
+        const value = m[2].trimEnd().replace(/^['"]|['"]$/g, "");
+        process.env[m[1]] ??= value;
+      }
     }
-  } catch {}
+  } catch (err) {
+    // Missing .env.local is fine; surface anything else.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
 }
 loadEnv(".env.local");
 
@@ -44,7 +50,7 @@ const client = createClient({
 
 type Slot = "display" | "power" | "communication" | "connector";
 
-// Canonical English label → readout column slot. Keep keys lowercased for
+// Canonical English label → readout column slot. Keys are lowercased for
 // case-insensitive matching against existing Sanity data.
 const LABEL_TO_SLOT: Record<string, Slot> = {
   "display window": "display",
@@ -55,6 +61,24 @@ const LABEL_TO_SLOT: Record<string, Slot> = {
   "remote control": "connector",
   connector: "connector",
 };
+
+// Sanity-generated _keys are URL-safe nanoids. Anything else came from a
+// non-standard import path and we won't risk it in a query-path literal.
+const SAFE_KEY = /^[A-Za-z0-9_-]+$/;
+
+// Build the unmatched-warning keyword set from the map keys so adding a new
+// slot to LABEL_TO_SLOT automatically updates the warning heuristic.
+const SLOT_KEYWORDS = new Set(
+  Object.keys(LABEL_TO_SLOT).flatMap((k) => k.split(/\s+/)),
+);
+
+// Labels that share a slot keyword but legitimately aren't column candidates.
+// Suppresses noise on every ROU product. Update if a new label drifts in.
+const KNOWN_NON_SLOT_LABELS = new Set([
+  "output power",
+  "display repeatability",
+  "units of display",
+]);
 
 interface InstrumentSpec {
   _key: string;
@@ -67,6 +91,12 @@ interface RouProduct {
   _id: string;
   model: string;
   instrumentSpecs: InstrumentSpec[] | null;
+}
+
+interface PendingPatch {
+  key: string;
+  slot: Slot;
+  path: string;
 }
 
 async function main() {
@@ -82,10 +112,11 @@ async function main() {
   let patched = 0;
   let alreadyTagged = 0;
   let unmatched = 0;
+  let skippedBadKey = 0;
 
   for (const p of products) {
     const specs = p.instrumentSpecs ?? [];
-    const patch: Record<string, Slot> = {};
+    const pending: PendingPatch[] = [];
 
     for (const spec of specs) {
       if (spec.slot) {
@@ -93,21 +124,29 @@ async function main() {
         continue;
       }
       const slot = LABEL_TO_SLOT[spec.label.trim().toLowerCase()];
-      if (!slot) {
-        // Most rows legitimately don't map to a column slot (Output Signal,
-        // Setpoint, etc.). Only warn for labels that look like they should.
+      if (!slot) continue;
+      if (!spec._key || !SAFE_KEY.test(spec._key)) {
+        console.warn(
+          `  bad-key  ${p.model}  "${spec.label}" has _key=${JSON.stringify(spec._key)}; skipping`,
+        );
+        skippedBadKey++;
         continue;
       }
-      patch[`instrumentSpecs[_key=="${spec._key}"].slot`] = slot;
+      pending.push({
+        key: spec._key,
+        slot,
+        path: `instrumentSpecs[_key=="${spec._key}"].slot`,
+      });
     }
 
-    // Log labels that suggest a slot but didn't match a canonical key, in
-    // case prod data has drifted.
+    // Surface labels that look like they should map to a slot but don't.
     for (const spec of specs) {
       if (spec.slot) continue;
       const lower = spec.label.trim().toLowerCase();
       if (LABEL_TO_SLOT[lower]) continue;
-      if (/display|power|communication|connector|remote/.test(lower)) {
+      if (KNOWN_NON_SLOT_LABELS.has(lower)) continue;
+      const words = lower.split(/\s+/);
+      if (words.some((w) => SLOT_KEYWORDS.has(w))) {
         console.warn(
           `  unmatched candidate  ${p.model}  "${spec.label}" — add to LABEL_TO_SLOT if it should be a column`,
         );
@@ -115,37 +154,44 @@ async function main() {
       }
     }
 
-    const entries = Object.entries(patch);
-    if (entries.length === 0) {
+    if (pending.length === 0) {
       console.log(`  noop   ${p.model}  (already tagged or no matches)`);
       continue;
     }
 
-    const summary = entries
-      .map(([path, slot]) => `${path.split('"').slice(-2, -1)[0]?.slice(0, 8)}→${slot}`)
-      .join(", ");
+    const summary = pending.map((e) => `${e.key}→${e.slot}`).join(", ");
 
     if (!isApply) {
-      console.log(`  WOULD  ${p.model}  ${entries.length} slot(s)  ${summary}`);
-      patched += entries.length;
+      console.log(`  WOULD  ${p.model}  ${pending.length} slot(s)  ${summary}`);
+      patched += pending.length;
       continue;
     }
 
-    let txn = client.patch(p._id);
-    for (const [path, slot] of entries) {
-      txn = txn.set({ [path]: slot });
+    try {
+      const patchSet = Object.fromEntries(
+        pending.map((e) => [e.path, e.slot] as const),
+      );
+      await client.patch(p._id).set(patchSet).commit();
+      console.log(`  patch  ${p.model}  ${pending.length} slot(s)  ${summary}`);
+      patched += pending.length;
+    } catch (err) {
+      const e = err as Error & { response?: { statusCode?: number } };
+      console.error(
+        `  FAILED  ${p.model}  ${e.message} (status ${e.response?.statusCode ?? "?"})`,
+      );
+      throw err;
     }
-    await txn.commit();
-    console.log(`  patch  ${p.model}  ${entries.length} slot(s)`);
-    patched += entries.length;
   }
 
   console.log(
-    `\nDone. ${isApply ? "patched" : "would-patch"}=${patched}  alreadyTagged=${alreadyTagged}  unmatched=${unmatched}`,
+    `\nDone. ${isApply ? "patched" : "would-patch"}=${patched}  alreadyTagged=${alreadyTagged}  unmatched=${unmatched}  skippedBadKey=${skippedBadKey}`,
   );
 }
 
-main().catch((e) => {
-  console.error(e);
+main().catch((err) => {
+  const e = err as Error & { response?: { statusCode?: number } };
+  console.error(
+    `fatal: ${e.message} (status ${e.response?.statusCode ?? "?"})`,
+  );
   process.exit(1);
 });

--- a/scripts/sync-readout-slots.ts
+++ b/scripts/sync-readout-slots.ts
@@ -1,0 +1,151 @@
+/**
+ * Backfill `slot` on ROU `instrumentSpecs` items by canonical label match.
+ *
+ *   pnpm tsx scripts/sync-readout-slots.ts            # dry-run
+ *   pnpm tsx scripts/sync-readout-slots.ts --apply    # write
+ *
+ * Idempotent: rows that already carry a `slot` are left untouched.
+ * Unmatched labels are logged so we can spot label drift in prod.
+ */
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+
+function loadEnv(p: string) {
+  try {
+    for (const l of readFileSync(p, "utf-8").split("\n")) {
+      const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m) process.env[m[1]] ??= m[2].trimEnd();
+    }
+  } catch {}
+}
+loadEnv(".env.local");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+const isApply = process.argv.includes("--apply");
+
+if (!projectId || !dataset) {
+  console.error("Missing project/dataset env");
+  process.exit(1);
+}
+if (isApply && !token) {
+  console.error("--apply requires SANITY_WRITE_TOKEN");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+type Slot = "display" | "power" | "communication" | "connector";
+
+// Canonical English label → readout column slot. Keep keys lowercased for
+// case-insensitive matching against existing Sanity data.
+const LABEL_TO_SLOT: Record<string, Slot> = {
+  "display window": "display",
+  display: "display",
+  "input power": "power",
+  "power supply": "power",
+  communication: "communication",
+  "remote control": "connector",
+  connector: "connector",
+};
+
+interface InstrumentSpec {
+  _key: string;
+  label: string;
+  value: string;
+  slot?: Slot | null;
+}
+
+interface RouProduct {
+  _id: string;
+  model: string;
+  instrumentSpecs: InstrumentSpec[] | null;
+}
+
+async function main() {
+  console.log(`\nsync-readout-slots  [${isApply ? "APPLY" : "DRY RUN"}]\n`);
+
+  const products = await client.fetch<RouProduct[]>(
+    `*[_type == "product" && function == "ROU"]{
+      _id, model,
+      instrumentSpecs[]{ _key, label, value, slot }
+    }`,
+  );
+
+  let patched = 0;
+  let alreadyTagged = 0;
+  let unmatched = 0;
+
+  for (const p of products) {
+    const specs = p.instrumentSpecs ?? [];
+    const patch: Record<string, Slot> = {};
+
+    for (const spec of specs) {
+      if (spec.slot) {
+        alreadyTagged++;
+        continue;
+      }
+      const slot = LABEL_TO_SLOT[spec.label.trim().toLowerCase()];
+      if (!slot) {
+        // Most rows legitimately don't map to a column slot (Output Signal,
+        // Setpoint, etc.). Only warn for labels that look like they should.
+        continue;
+      }
+      patch[`instrumentSpecs[_key=="${spec._key}"].slot`] = slot;
+    }
+
+    // Log labels that suggest a slot but didn't match a canonical key, in
+    // case prod data has drifted.
+    for (const spec of specs) {
+      if (spec.slot) continue;
+      const lower = spec.label.trim().toLowerCase();
+      if (LABEL_TO_SLOT[lower]) continue;
+      if (/display|power|communication|connector|remote/.test(lower)) {
+        console.warn(
+          `  unmatched candidate  ${p.model}  "${spec.label}" — add to LABEL_TO_SLOT if it should be a column`,
+        );
+        unmatched++;
+      }
+    }
+
+    const entries = Object.entries(patch);
+    if (entries.length === 0) {
+      console.log(`  noop   ${p.model}  (already tagged or no matches)`);
+      continue;
+    }
+
+    const summary = entries
+      .map(([path, slot]) => `${path.split('"').slice(-2, -1)[0]?.slice(0, 8)}→${slot}`)
+      .join(", ");
+
+    if (!isApply) {
+      console.log(`  WOULD  ${p.model}  ${entries.length} slot(s)  ${summary}`);
+      patched += entries.length;
+      continue;
+    }
+
+    let txn = client.patch(p._id);
+    for (const [path, slot] of entries) {
+      txn = txn.set({ [path]: slot });
+    }
+    await txn.commit();
+    console.log(`  patch  ${p.model}  ${entries.length} slot(s)`);
+    patched += entries.length;
+  }
+
+  console.log(
+    `\nDone. ${isApply ? "patched" : "would-patch"}=${patched}  alreadyTagged=${alreadyTagged}  unmatched=${unmatched}`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import { CategoryHero } from "@/components/products/CategoryHero";
 import { CategoryShowcase } from "@/components/products/CategoryShowcase";
 import { ProductStack } from "@/components/products/ProductStack";
+import { ReadoutStack } from "@/components/products/ReadoutStack";
 import { sanityClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
 import { productsBySeriesQuery, categoryShowcaseQuery } from "@/sanity/queries";
@@ -99,6 +100,14 @@ export default async function CategoryPage({ params }: Props) {
     response: tProducts("table.response"),
     fitting: tProducts("table.fitting"),
   };
+  const readoutHeaders = {
+    model: tProducts("table.model"),
+    description: tProducts("table.description"),
+    display: tProducts("table.display"),
+    power: tProducts("table.power"),
+    communication: tProducts("table.communication"),
+    connector: tProducts("table.connector"),
+  };
   const emptyLabel = tProducts("emptyStack");
 
   return (
@@ -152,14 +161,14 @@ export default async function CategoryPage({ params }: Props) {
           headers={headers}
         />
         {instruments.length > 0 && (
-          <ProductStack
+          <ReadoutStack
             title={tProducts("stack.instruments.title")}
             subtitle={tProducts("stack.instruments.subtitle")}
             products={instruments}
             category={category}
             locale={locale}
             emptyLabel={emptyLabel}
-            headers={headers}
+            headers={readoutHeaders}
           />
         )}
       </main>

--- a/src/app/products/[slug]/spec.json/route.test.ts
+++ b/src/app/products/[slug]/spec.json/route.test.ts
@@ -56,9 +56,27 @@ describe("GET /products/[slug]/spec.json", () => {
     const body = await res.json();
     expect(body.function).toBe("ROU");
     expect(body.instrumentSpecs).toEqual([
-      { label: "Input Power", value: "220VAC (50–60 Hz)" },
+      {
+        label: "Input Power",
+        value: "220VAC (50–60 Hz)",
+        slot: "power",
+      },
       { label: "Output Signal", value: "0–5 Vdc or 4–20 mA" },
-      { label: "Communication", value: "RS-232, RS-485" },
+      {
+        label: "Display Window",
+        value: "256×64 OLED",
+        slot: "display",
+      },
+      {
+        label: "Communication",
+        value: "RS-232, RS-485",
+        slot: "communication",
+      },
+      {
+        label: "Remote Control",
+        value: "D-SUB 9-pin",
+        slot: "connector",
+      },
     ]);
   });
 

--- a/src/components/products/ReadoutRow/ReadoutRow.css
+++ b/src/components/products/ReadoutRow/ReadoutRow.css
@@ -1,19 +1,19 @@
 .lt-readout-row__cell--display,
 .lt-readout-row__cell--power,
-.lt-readout-row__cell--comm,
-.lt-readout-row__cell--conn {
+.lt-readout-row__cell--communication,
+.lt-readout-row__cell--connector {
   font-family: var(--lt-mono);
   font-variant-numeric: tabular-nums;
   color: var(--pd-fg-strong);
   font-size: var(--lt-fs-sm);
 }
-.lt-readout-row__cell--conn {
+.lt-readout-row__cell--connector {
   color: var(--pd-muted);
 }
 
 @media (max-width: 1024px) {
-  .lt-readout-row__cell--comm,
-  .lt-readout-row__cell--conn {
+  .lt-readout-row__cell--communication,
+  .lt-readout-row__cell--connector {
     display: none;
   }
 }

--- a/src/components/products/ReadoutRow/ReadoutRow.css
+++ b/src/components/products/ReadoutRow/ReadoutRow.css
@@ -1,0 +1,24 @@
+.lt-readout-row__cell--display,
+.lt-readout-row__cell--power,
+.lt-readout-row__cell--comm,
+.lt-readout-row__cell--conn {
+  font-family: var(--lt-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--pd-fg-strong);
+  font-size: var(--lt-fs-sm);
+}
+.lt-readout-row__cell--conn {
+  color: var(--pd-muted);
+}
+
+@media (max-width: 1024px) {
+  .lt-readout-row__cell--comm,
+  .lt-readout-row__cell--conn {
+    display: none;
+  }
+}
+@media (max-width: 500px) {
+  .lt-readout-row__cell--power {
+    display: none;
+  }
+}

--- a/src/components/products/ReadoutRow/ReadoutRow.test.tsx
+++ b/src/components/products/ReadoutRow/ReadoutRow.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+const pushSpy = vi.fn();
 
 vi.mock("@/i18n/navigation", () => ({
   Link: ({
@@ -16,11 +18,12 @@ vi.mock("@/i18n/navigation", () => ({
       { href: typeof href === "string" ? href : "#", ...rest },
       children,
     ),
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: pushSpy }),
 }));
 
 import { ReadoutRow } from "./ReadoutRow";
 import { rouProductFixture, makeProduct } from "@/test/fixtures/products";
+import type { Product } from "@/lib/types/product";
 
 function renderRow(product = rouProductFixture) {
   return render(
@@ -38,6 +41,10 @@ function renderRow(product = rouProductFixture) {
 }
 
 describe("ReadoutRow", () => {
+  beforeEach(() => {
+    pushSpy.mockReset();
+  });
+
   it("renders each slot value from instrumentSpecs", () => {
     const { container } = renderRow();
     expect(
@@ -47,10 +54,11 @@ describe("ReadoutRow", () => {
       container.querySelector(".lt-readout-row__cell--power")?.textContent,
     ).toBe("220VAC (50–60 Hz)");
     expect(
-      container.querySelector(".lt-readout-row__cell--comm")?.textContent,
+      container.querySelector(".lt-readout-row__cell--communication")
+        ?.textContent,
     ).toBe("RS-232, RS-485");
     expect(
-      container.querySelector(".lt-readout-row__cell--conn")?.textContent,
+      container.querySelector(".lt-readout-row__cell--connector")?.textContent,
     ).toBe("D-SUB 9-pin");
   });
 
@@ -70,10 +78,11 @@ describe("ReadoutRow", () => {
       container.querySelector(".lt-readout-row__cell--power")?.textContent,
     ).toBe("—");
     expect(
-      container.querySelector(".lt-readout-row__cell--comm")?.textContent,
+      container.querySelector(".lt-readout-row__cell--communication")
+        ?.textContent,
     ).toBe("—");
     expect(
-      container.querySelector(".lt-readout-row__cell--conn")?.textContent,
+      container.querySelector(".lt-readout-row__cell--connector")?.textContent,
     ).toBe("—");
   });
 
@@ -92,5 +101,116 @@ describe("ReadoutRow", () => {
     expect(
       container.querySelector(".lt-readout-row__cell--power")?.textContent,
     ).toBe("—");
+  });
+
+  describe("navigation", () => {
+    it("pushes to the product href when a plain cell is clicked", () => {
+      const { container } = renderRow();
+      const row = container.querySelector(".lt-readout-row") as HTMLElement;
+      const cell = row.querySelector(
+        ".lt-readout-row__cell--display",
+      ) as HTMLElement;
+      fireEvent.click(cell);
+      expect(pushSpy).toHaveBeenCalledWith("/products/specialized/rou-test");
+    });
+
+    it("does not navigate when a modifier key is held", () => {
+      const { container } = renderRow();
+      const row = container.querySelector(".lt-readout-row") as HTMLElement;
+      fireEvent.click(row, { metaKey: true });
+      fireEvent.click(row, { ctrlKey: true });
+      fireEvent.click(row, { shiftKey: true });
+      fireEvent.click(row, { altKey: true });
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate when an inner anchor is clicked", () => {
+      const { container } = renderRow();
+      const link = container.querySelector(
+        ".lt-prod-row__codelink",
+      ) as HTMLElement;
+      fireEvent.click(link);
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it("navigates on Enter and Space key presses", () => {
+      const { container } = renderRow();
+      const row = container.querySelector(".lt-readout-row") as HTMLElement;
+      fireEvent.keyDown(row, { key: "Enter" });
+      fireEvent.keyDown(row, { key: " " });
+      expect(pushSpy).toHaveBeenCalledTimes(2);
+      expect(pushSpy).toHaveBeenNthCalledWith(
+        1,
+        "/products/specialized/rou-test",
+      );
+    });
+  });
+
+  describe("description cell", () => {
+    it("renders chips for visible tag kinds, capped at three", () => {
+      const tags: Product["tags"] = [
+        {
+          slug: { current: "high-flow" },
+          kind: "capability",
+          label: { ko: "고유량", en: "High flow", zh: "大流量" },
+        },
+        {
+          slug: { current: "n2" },
+          kind: "gas",
+          label: { ko: "질소", en: "N2", zh: "氮气" },
+        },
+        {
+          slug: { current: "semicon" },
+          kind: "application",
+          label: { ko: "반도체", en: "Semicon", zh: "半导体" },
+        },
+        {
+          slug: { current: "fast-response" },
+          kind: "capability",
+          label: { ko: "빠른응답", en: "Fast response", zh: "快速响应" },
+        },
+        {
+          slug: { current: "ar" },
+          kind: "gas",
+          label: { ko: "아르곤", en: "Ar", zh: "氩气" },
+        },
+      ];
+      const product = makeProduct({
+        function: "ROU",
+        tags,
+        instrumentSpecs: rouProductFixture.instrumentSpecs,
+      });
+      const { container, queryByText } = renderRow(product);
+
+      const chips = container.querySelectorAll(".lt-prod-row__tags > *");
+      expect(chips.length).toBe(3);
+      // Non-allowed kind (application) is filtered out
+      expect(queryByText("Semicon")).toBeNull();
+      // The raw description label is hidden in favor of chips
+      expect(container.querySelector(".lt-prod-row__label")).toBeNull();
+    });
+
+    it("falls back to description label when no visible tags are present", () => {
+      const product = makeProduct({
+        function: "ROU",
+        tags: [
+          {
+            slug: { current: "semicon" },
+            kind: "application",
+            label: { ko: "반도체", en: "Semicon", zh: "半导体" },
+          },
+        ],
+        description: {
+          ko: "리드아웃",
+          en: "Read-out unit",
+          zh: "读数单元",
+        },
+        instrumentSpecs: rouProductFixture.instrumentSpecs,
+      });
+      const { container, getByText } = renderRow(product);
+
+      expect(container.querySelector(".lt-prod-row__tags")).toBeNull();
+      expect(getByText("Read-out unit")).toBeTruthy();
+    });
   });
 });

--- a/src/components/products/ReadoutRow/ReadoutRow.test.tsx
+++ b/src/components/products/ReadoutRow/ReadoutRow.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: unknown;
+    children: React.ReactNode;
+  } & Record<string, unknown>) =>
+    React.createElement(
+      "a",
+      { href: typeof href === "string" ? href : "#", ...rest },
+      children,
+    ),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { ReadoutRow } from "./ReadoutRow";
+import { rouProductFixture, makeProduct } from "@/test/fixtures/products";
+
+function renderRow(product = rouProductFixture) {
+  return render(
+    <table>
+      <tbody>
+        <ReadoutRow
+          product={product}
+          imageSrc={null}
+          category="specialized"
+          locale="en"
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("ReadoutRow", () => {
+  it("renders each slot value from instrumentSpecs", () => {
+    const { container } = renderRow();
+    expect(
+      container.querySelector(".lt-readout-row__cell--display")?.textContent,
+    ).toBe("256×64 OLED");
+    expect(
+      container.querySelector(".lt-readout-row__cell--power")?.textContent,
+    ).toBe("220VAC (50–60 Hz)");
+    expect(
+      container.querySelector(".lt-readout-row__cell--comm")?.textContent,
+    ).toBe("RS-232, RS-485");
+    expect(
+      container.querySelector(".lt-readout-row__cell--conn")?.textContent,
+    ).toBe("D-SUB 9-pin");
+  });
+
+  it("falls back to em-dash when a slot is missing", () => {
+    const product = makeProduct({
+      function: "ROU",
+      instrumentSpecs: [
+        { label: "Display Window", value: "4-Digit", slot: "display" },
+        // power, comm, connector intentionally absent
+      ],
+    });
+    const { container } = renderRow(product);
+    expect(
+      container.querySelector(".lt-readout-row__cell--display")?.textContent,
+    ).toBe("4-Digit");
+    expect(
+      container.querySelector(".lt-readout-row__cell--power")?.textContent,
+    ).toBe("—");
+    expect(
+      container.querySelector(".lt-readout-row__cell--comm")?.textContent,
+    ).toBe("—");
+    expect(
+      container.querySelector(".lt-readout-row__cell--conn")?.textContent,
+    ).toBe("—");
+  });
+
+  it("ignores instrumentSpecs entries without a slot", () => {
+    const product = makeProduct({
+      function: "ROU",
+      instrumentSpecs: [
+        { label: "Output Signal", value: "0–5 Vdc" },
+        { label: "Display Window", value: "OLED", slot: "display" },
+      ],
+    });
+    const { container } = renderRow(product);
+    expect(
+      container.querySelector(".lt-readout-row__cell--display")?.textContent,
+    ).toBe("OLED");
+    expect(
+      container.querySelector(".lt-readout-row__cell--power")?.textContent,
+    ).toBe("—");
+  });
+});

--- a/src/components/products/ReadoutRow/ReadoutRow.tsx
+++ b/src/components/products/ReadoutRow/ReadoutRow.tsx
@@ -102,10 +102,10 @@ export function ReadoutRow({ product, imageSrc, category, locale }: Props) {
         {display}
       </td>
       <td className="lt-prod-row__cell lt-readout-row__cell--power">{power}</td>
-      <td className="lt-prod-row__cell lt-readout-row__cell--comm">
+      <td className="lt-prod-row__cell lt-readout-row__cell--communication">
         {communication}
       </td>
-      <td className="lt-prod-row__cell lt-readout-row__cell--conn">
+      <td className="lt-prod-row__cell lt-readout-row__cell--connector">
         {connector}
       </td>
     </tr>

--- a/src/components/products/ReadoutRow/ReadoutRow.tsx
+++ b/src/components/products/ReadoutRow/ReadoutRow.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Image from "next/image";
+import { Link, useRouter } from "@/i18n/navigation";
+import { ProductThumb } from "../ProductThumb";
+import { Chip } from "@/components/ui/Chip/Chip";
+import type { Product, ReadoutSlot } from "@/lib/types/product";
+import type { CategorySlug } from "@/lib/categories";
+import type { Locale } from "@/i18n/routing";
+import { localizeSpecValue } from "@/lib/products/localizeSpecValue";
+import "./ReadoutRow.css";
+
+type Props = {
+  product: Product;
+  imageSrc: string | null;
+  category: CategorySlug;
+  locale: Locale;
+};
+
+const VISIBLE_TAG_KINDS = new Set(["capability", "gas"]);
+const MAX_VISIBLE_TAGS = 3;
+
+function slotValue(
+  specs: Product["instrumentSpecs"],
+  slot: ReadoutSlot,
+  locale: Locale,
+): string {
+  const hit = specs?.find((s) => s.slot === slot);
+  return hit ? localizeSpecValue(hit.value, locale) : "—";
+}
+
+export function ReadoutRow({ product, imageSrc, category, locale }: Props) {
+  const href = `/products/${category}/${product.slug.current}`;
+  const label = product.description?.[locale] ?? product.productLabel[locale];
+  const display = slotValue(product.instrumentSpecs, "display", locale);
+  const power = slotValue(product.instrumentSpecs, "power", locale);
+  const communication = slotValue(
+    product.instrumentSpecs,
+    "communication",
+    locale,
+  );
+  const connector = slotValue(product.instrumentSpecs, "connector", locale);
+  const visibleTags = product.tags
+    .filter((t) => VISIBLE_TAG_KINDS.has(t.kind))
+    .slice(0, MAX_VISIBLE_TAGS);
+  const router = useRouter();
+
+  return (
+    <tr
+      className="lt-prod-row lt-readout-row"
+      tabIndex={0}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("a")) return;
+        if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+        router.push(href);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") router.push(href);
+      }}
+    >
+      <td
+        className="lt-prod-row__cell lt-prod-row__cell--thumb"
+        aria-hidden="true"
+      >
+        <div className="lt-prod-row__thumb">
+          {imageSrc ? (
+            <Image
+              src={imageSrc}
+              alt=""
+              fill
+              sizes="56px"
+              className="lt-prod-row__thumb-img"
+            />
+          ) : (
+            <ProductThumb />
+          )}
+        </div>
+      </td>
+      <th scope="row" className="lt-prod-row__cell lt-prod-row__cell--code">
+        <Link href={href} className="lt-prod-row__codelink">
+          {product.model}
+        </Link>
+      </th>
+      <td className="lt-prod-row__cell lt-prod-row__cell--label">
+        {visibleTags.length > 0 ? (
+          <span className="lt-prod-row__tags">
+            {visibleTags.map((t) => (
+              <Chip
+                key={`${t.kind}:${t.slug.current}`}
+                small
+                tone={t.kind === "gas" ? "accent" : "neutral"}
+              >
+                {t.label[locale]}
+              </Chip>
+            ))}
+          </span>
+        ) : (
+          <span className="lt-prod-row__label">{label}</span>
+        )}
+      </td>
+      <td className="lt-prod-row__cell lt-readout-row__cell--display">
+        {display}
+      </td>
+      <td className="lt-prod-row__cell lt-readout-row__cell--power">{power}</td>
+      <td className="lt-prod-row__cell lt-readout-row__cell--comm">
+        {communication}
+      </td>
+      <td className="lt-prod-row__cell lt-readout-row__cell--conn">
+        {connector}
+      </td>
+    </tr>
+  );
+}

--- a/src/components/products/ReadoutRow/index.ts
+++ b/src/components/products/ReadoutRow/index.ts
@@ -1,0 +1,1 @@
+export { ReadoutRow } from "./ReadoutRow";

--- a/src/components/products/ReadoutStack/ReadoutStack.css
+++ b/src/components/products/ReadoutStack/ReadoutStack.css
@@ -6,8 +6,8 @@
   .lt-readout-stack__table {
     grid-template-columns: 48px 88px 2fr 2.5fr 2fr;
   }
-  .lt-readout-stack__head-cell--comm,
-  .lt-readout-stack__head-cell--conn {
+  .lt-readout-stack__head-cell--communication,
+  .lt-readout-stack__head-cell--connector {
     display: none;
   }
 }

--- a/src/components/products/ReadoutStack/ReadoutStack.css
+++ b/src/components/products/ReadoutStack/ReadoutStack.css
@@ -1,0 +1,26 @@
+.lt-readout-stack__table {
+  grid-template-columns: 56px 96px 2fr 2.5fr 2fr 2fr 2fr;
+}
+
+@media (max-width: 1024px) {
+  .lt-readout-stack__table {
+    grid-template-columns: 48px 88px 2fr 2.5fr 2fr;
+  }
+  .lt-readout-stack__head-cell--comm,
+  .lt-readout-stack__head-cell--conn {
+    display: none;
+  }
+}
+@media (max-width: 640px) {
+  .lt-readout-stack__table {
+    grid-template-columns: 88px 2fr 2.5fr 2fr;
+  }
+}
+@media (max-width: 500px) {
+  .lt-readout-stack__table {
+    grid-template-columns: 72px 1fr 2fr;
+  }
+  .lt-readout-stack__head-cell--power {
+    display: none;
+  }
+}

--- a/src/components/products/ReadoutStack/ReadoutStack.test.tsx
+++ b/src/components/products/ReadoutStack/ReadoutStack.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: unknown;
+    children: React.ReactNode;
+  } & Record<string, unknown>) =>
+    React.createElement(
+      "a",
+      { href: typeof href === "string" ? href : "#", ...rest },
+      children,
+    ),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/sanity/imageUrl", () => ({
+  urlFor: () => ({ width: () => ({ url: () => "" }) }),
+}));
+
+import { ReadoutStack } from "./ReadoutStack";
+import { rouProductFixture } from "@/test/fixtures/products";
+
+const headers = {
+  model: "Model",
+  description: "Features",
+  display: "Display",
+  power: "Input power",
+  communication: "Communication",
+  connector: "Connector",
+};
+
+describe("ReadoutStack", () => {
+  it("renders readout column headers and a row per product", () => {
+    const { container, getByText } = render(
+      <ReadoutStack
+        title="Read-Out Units"
+        subtitle="Instruments"
+        products={[rouProductFixture]}
+        category="specialized"
+        locale="en"
+        emptyLabel="No products"
+        headers={headers}
+      />,
+    );
+    expect(getByText("Display")).toBeTruthy();
+    expect(getByText("Input power")).toBeTruthy();
+    expect(getByText("Communication")).toBeTruthy();
+    expect(getByText("Connector")).toBeTruthy();
+    expect(container.querySelectorAll("tbody tr").length).toBe(1);
+    // Verifies the row pulled the display slot, not an em-dash.
+    expect(
+      container.querySelector(".lt-readout-row__cell--display")?.textContent,
+    ).toBe("256×64 OLED");
+  });
+
+  it("renders the empty state when products is empty", () => {
+    const { queryByRole, getByText } = render(
+      <ReadoutStack
+        title="Read-Out Units"
+        subtitle="Instruments"
+        products={[]}
+        category="specialized"
+        locale="en"
+        emptyLabel="No products yet"
+        headers={headers}
+      />,
+    );
+    expect(queryByRole("table")).toBeNull();
+    expect(getByText("No products yet")).toBeTruthy();
+  });
+});

--- a/src/components/products/ReadoutStack/ReadoutStack.test.tsx
+++ b/src/components/products/ReadoutStack/ReadoutStack.test.tsx
@@ -60,7 +60,7 @@ describe("ReadoutStack", () => {
   });
 
   it("renders the empty state when products is empty", () => {
-    const { queryByRole, getByText } = render(
+    const { container, getByText } = render(
       <ReadoutStack
         title="Read-Out Units"
         subtitle="Instruments"
@@ -71,7 +71,8 @@ describe("ReadoutStack", () => {
         headers={headers}
       />,
     );
-    expect(queryByRole("table")).toBeNull();
+    expect(container.querySelector("tbody")).toBeNull();
+    expect(container.querySelector(".lt-prod-row")).toBeNull();
     expect(getByText("No products yet")).toBeTruthy();
   });
 });

--- a/src/components/products/ReadoutStack/ReadoutStack.tsx
+++ b/src/components/products/ReadoutStack/ReadoutStack.tsx
@@ -1,0 +1,119 @@
+import { ReadoutRow } from "../ReadoutRow";
+import type { Product } from "@/lib/types/product";
+import type { CategorySlug } from "@/lib/categories";
+import type { Locale } from "@/i18n/routing";
+import { urlFor } from "@/sanity/imageUrl";
+import { EmptyState } from "@/components/shared/EmptyState";
+import "./ReadoutStack.css";
+
+type Props = {
+  title: string;
+  subtitle: string;
+  products: Product[];
+  category: CategorySlug;
+  locale: Locale;
+  emptyLabel: string;
+  headers: {
+    model: string;
+    description: string;
+    display: string;
+    power: string;
+    communication: string;
+    connector: string;
+  };
+};
+
+export function ReadoutStack({
+  title,
+  subtitle,
+  products,
+  category,
+  locale,
+  emptyLabel,
+  headers,
+}: Props) {
+  return (
+    <section className="lt-prod-stack lt-readout-stack">
+      <header className="lt-prod-stack__hd">
+        <div className="lt-prod-stack__kicker">{subtitle}</div>
+        <h2 className="lt-prod-stack__title">
+          {title}{" "}
+          <span className="lt-prod-stack__count">{products.length}</span>
+        </h2>
+      </header>
+
+      {products.length === 0 ? (
+        <EmptyState message={emptyLabel} />
+      ) : (
+        <table className="lt-prod-stack__table lt-readout-stack__table">
+          <caption className="lt-prod-stack__sr-caption">{title}</caption>
+          <thead>
+            <tr className="lt-prod-stack__head">
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-prod-stack__head-cell--thumb"
+                aria-hidden="true"
+              />
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-prod-stack__head-cell--code"
+              >
+                {headers.model}
+              </th>
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-prod-stack__head-cell--label"
+              >
+                {headers.description}
+              </th>
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--display"
+              >
+                {headers.display}
+              </th>
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--power"
+              >
+                {headers.power}
+              </th>
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--comm"
+              >
+                {headers.communication}
+              </th>
+              <th
+                scope="col"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--conn"
+              >
+                {headers.connector}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {products.map((p) => {
+              const fallback = p.images?.[0];
+              const source = p.cutout?.asset
+                ? p.cutout
+                : fallback?.asset
+                  ? fallback
+                  : null;
+              const imageSrc = source ? urlFor(source).width(128).url() : null;
+              return (
+                <ReadoutRow
+                  key={p.slug.current}
+                  product={p}
+                  imageSrc={imageSrc}
+                  category={category}
+                  locale={locale}
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/src/components/products/ReadoutStack/ReadoutStack.tsx
+++ b/src/components/products/ReadoutStack/ReadoutStack.tsx
@@ -32,11 +32,15 @@ export function ReadoutStack({
   emptyLabel,
   headers,
 }: Props) {
+  const titleId = `readout-stack-${category}`;
   return (
-    <section className="lt-prod-stack lt-readout-stack">
+    <section
+      className="lt-prod-stack lt-readout-stack"
+      aria-labelledby={titleId}
+    >
       <header className="lt-prod-stack__hd">
         <div className="lt-prod-stack__kicker">{subtitle}</div>
-        <h2 className="lt-prod-stack__title">
+        <h2 id={titleId} className="lt-prod-stack__title">
           {title}{" "}
           <span className="lt-prod-stack__count">{products.length}</span>
         </h2>
@@ -80,13 +84,13 @@ export function ReadoutStack({
               </th>
               <th
                 scope="col"
-                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--comm"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--communication"
               >
                 {headers.communication}
               </th>
               <th
                 scope="col"
-                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--conn"
+                className="lt-prod-stack__head-cell lt-readout-stack__head-cell--connector"
               >
                 {headers.connector}
               </th>

--- a/src/components/products/ReadoutStack/index.ts
+++ b/src/components/products/ReadoutStack/index.ts
@@ -1,0 +1,1 @@
+export { ReadoutStack } from "./ReadoutStack";

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -4721,7 +4721,8 @@
     "instrumentSpecs": [
       {
         "label": "Input Power",
-        "value": "220VAC (50–60 Hz)"
+        "value": "220VAC (50–60 Hz)",
+        "slot": "power"
       },
       {
         "label": "Output Power",
@@ -4729,7 +4730,8 @@
       },
       {
         "label": "Display Window",
-        "value": "256×64 Dot 6\" Wide OLED LCD"
+        "value": "256×64 Dot 6\" Wide OLED LCD",
+        "slot": "display"
       },
       {
         "label": "Display Repeatability",
@@ -4745,7 +4747,8 @@
       },
       {
         "label": "Remote Control",
-        "value": "D-SUB 9-pin (Male)"
+        "value": "D-SUB 9-pin (Male)",
+        "slot": "connector"
       },
       {
         "label": "Setpoint",
@@ -4765,7 +4768,8 @@
       },
       {
         "label": "Communication",
-        "value": "RS-232 (9600 Baud, 8-N-1), RS-485"
+        "value": "RS-232 (9600 Baud, 8-N-1), RS-485",
+        "slot": "communication"
       },
       {
         "label": "External Setpoint",
@@ -4820,7 +4824,8 @@
     "instrumentSpecs": [
       {
         "label": "Input Power",
-        "value": "220VAC (50–60 Hz)"
+        "value": "220VAC (50–60 Hz)",
+        "slot": "power"
       },
       {
         "label": "Output Power",
@@ -4828,7 +4833,8 @@
       },
       {
         "label": "Display Window",
-        "value": "4-Digit 7-Segment"
+        "value": "4-Digit 7-Segment",
+        "slot": "display"
       },
       {
         "label": "Display Repeatability",
@@ -4844,7 +4850,8 @@
       },
       {
         "label": "Remote Control",
-        "value": "D-SUB 9-pin (Male)"
+        "value": "D-SUB 9-pin (Male)",
+        "slot": "connector"
       },
       {
         "label": "Setpoint",
@@ -4864,7 +4871,8 @@
       },
       {
         "label": "Communication",
-        "value": "RS-232 (9600 Baud, 8-N-1)"
+        "value": "RS-232 (9600 Baud, 8-N-1)",
+        "slot": "communication"
       }
     ]
   }

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -58,8 +58,21 @@ const MassFlowSpecsSchema = z.object({
   }),
 });
 
+export const READOUT_SLOTS = [
+  "display",
+  "power",
+  "communication",
+  "connector",
+] as const;
+
+export type ReadoutSlot = (typeof READOUT_SLOTS)[number];
+
 const InstrumentSpecsSchema = z.array(
-  z.object({ label: z.string(), value: z.string() }),
+  z.object({
+    label: z.string(),
+    value: z.string(),
+    slot: z.enum(READOUT_SLOTS).nullable().optional(),
+  }),
 );
 
 const SanityImageRefSchema = z.object({

--- a/src/test/fixtures/products.ts
+++ b/src/test/fixtures/products.ts
@@ -51,9 +51,27 @@ export const rouProductFixture: Product = {
   features: [{ ko: "특징 1", en: "Feature 1", zh: "特征 1", _key: "f1" }],
   connections: [],
   instrumentSpecs: [
-    { label: "Input Power", value: "220VAC (50–60 Hz)" },
+    {
+      label: "Input Power",
+      value: "220VAC (50–60 Hz)",
+      slot: "power",
+    },
     { label: "Output Signal", value: "0–5 Vdc or 4–20 mA" },
-    { label: "Communication", value: "RS-232, RS-485" },
+    {
+      label: "Display Window",
+      value: "256×64 OLED",
+      slot: "display",
+    },
+    {
+      label: "Communication",
+      value: "RS-232, RS-485",
+      slot: "communication",
+    },
+    {
+      label: "Remote Control",
+      value: "D-SUB 9-pin",
+      slot: "connector",
+    },
   ],
   datasheets: [],
   manuals: [],


### PR DESCRIPTION
Closes #223.

## Summary
- New `ReadoutStack` + `ReadoutRow` components replace the flow-device `ProductStack` for the instruments group on `/products/specialized`, swapping em-dashed Range/Accuracy/Response/Fitting cells for **Display / Input power / Communication / Connector**.
- Adds an optional `slot` discriminator (`display | power | communication | connector`) to `instrumentSpec` items in the Sanity schema + Zod type so the table can pull typed values from the existing free-form spec list without duplicating data.
- `scripts/sync-readout-slots.ts` is an idempotent backfill that tags existing LTI-1000 / LTI-2000 entries by canonical English label. **Already applied to the live dataset** (`patched=8, alreadyTagged=0`), so the page will go live populated.

## Why this approach
Considered a separate `readoutSpecs` typed object; rejected because it would duplicate data into two ROU spec mechanisms. The `slot` tag keeps `instrumentSpecs` as single source of truth; the detail page is unaffected (it iterates all entries regardless of slot).

The issue's proposed `channels` column was dropped — LTI-1000/2000 are single-unit readouts, so the data doesn't exist and a hardcoded "1" would be noise.

## Test plan
- [x] `pnpm test:run` — 299 tests pass (new `ReadoutStack.test.tsx` + `ReadoutRow.test.tsx`, plus updated `spec.json/route.test.ts` for the expanded `rouProductFixture`)
- [x] `tsc --noEmit` clean
- [x] Dev-server smoke on `/en/products/specialized` — confirmed all 8 readout cells populated with real values (4-Digit 7-Segment / 256×64 OLED / 220VAC / RS-232 / RS-485 / D-SUB 9-pin)
- [ ] Reviewer: spot-check `/ko/products/specialized` and `/zh/products/specialized` for translated column headers (디스플레이/입력 전원/통신/커넥터, 显示/输入电源/通信/连接器)
- [ ] Reviewer: confirm Controllers/Meters stacks on `/products/{analogue,digital}` are visually unchanged
- [ ] Reviewer: `e2e/products.spec.ts` "Specialized category — readout table" passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)