### PR TITLE
fix(products): MFC-only sliders + 4s rotation site-wide (#235, #234)

### DIFF
--- a/sanity/schemaTypes/categoryShowcase.ts
+++ b/sanity/schemaTypes/categoryShowcase.ts
@@ -18,6 +18,7 @@ export const categoryShowcase = defineType({
               title: "Product",
               type: "reference",
               to: [{ type: "product" }],
+              options: { filter: 'function != "MFM"' },
               validation: (r) => r.required(),
             }),
             defineField({
@@ -47,6 +48,7 @@ export const categoryShowcase = defineType({
               title: "Product",
               type: "reference",
               to: [{ type: "product" }],
+              options: { filter: 'function != "MFM"' },
               validation: (r) => r.required(),
             }),
             defineField({
@@ -75,6 +77,7 @@ export const categoryShowcase = defineType({
               title: "Product",
               type: "reference",
               to: [{ type: "product" }],
+              options: { filter: 'function != "MFM"' },
               validation: (r) => r.required(),
             }),
             defineField({

--- a/scripts/seed-showcase.ts
+++ b/scripts/seed-showcase.ts
@@ -31,7 +31,7 @@ const FEATURED: Record<string, { model: string; caption: string }[]> = {
   analogue: [
     { model: "M3030VA", caption: "±0.5% F.S. accuracy" },
     { model: "MS3700VA", caption: "5–3,000 sccm flow range" },
-    { model: "M2030VA", caption: "Sub-200 ms response time" },
+    { model: "MS3800VA", caption: "2,500–5,000 slpm high-flow control" },
   ],
   digital: [
     { model: "MD30C", caption: "8-point linearization, RS-485 / Modbus RTU" },
@@ -47,6 +47,10 @@ const FEATURED: Record<string, { model: string; caption: string }[]> = {
       model: "LEPC",
       caption:
         "Electronic pressure controller with OLED display and RS-485 / Modbus",
+    },
+    {
+      model: "DO400",
+      caption: "New for 2026 — ≤1 s response, 100–400 slpm",
     },
   ],
 };

--- a/scripts/seed-showcase.ts
+++ b/scripts/seed-showcase.ts
@@ -50,7 +50,7 @@ const FEATURED: Record<string, { model: string; caption: string }[]> = {
     },
     {
       model: "DO400",
-      caption: "New for 2026 — ≤1 s response, 100–400 slpm",
+      caption: "≤1 s response, 100–400 slpm",
     },
   ],
 };

--- a/src/app/[locale]/products/RotatingFeatured.tsx
+++ b/src/app/[locale]/products/RotatingFeatured.tsx
@@ -38,11 +38,9 @@ type Props = {
 export function RotatingFeatured({
   slides,
   slidesLabel,
-  intervalMs = 5500,
+  intervalMs = 4000,
 }: Props) {
   const [active, setActive] = useState(0);
-  const [mouseInside, setMouseInside] = useState(false);
-  const [focusInside, setFocusInside] = useState(false);
   const touchStartX = useRef<number | null>(null);
   const reducedMotion = useSyncExternalStore(
     subscribeReducedMotion,
@@ -52,23 +50,18 @@ export function RotatingFeatured({
 
   useEffect(() => {
     if (slides.length <= 1 || reducedMotion) return;
-    if (mouseInside || focusInside) return;
     if (typeof window === "undefined") return;
     const id = window.setInterval(() => {
       setActive((n) => (n + 1) % slides.length);
     }, intervalMs);
     return () => window.clearInterval(id);
-  }, [mouseInside, focusInside, reducedMotion, slides.length, intervalMs]);
+  }, [reducedMotion, slides.length, intervalMs]);
 
   if (slides.length === 0) return null;
 
   return (
     <div
       className="lt-products-side__rot"
-      onMouseEnter={() => setMouseInside(true)}
-      onMouseLeave={() => setMouseInside(false)}
-      onFocusCapture={() => setFocusInside(true)}
-      onBlurCapture={() => setFocusInside(false)}
       onTouchStart={(e) => {
         touchStartX.current = e.touches[0].clientX;
       }}

--- a/src/components/home/Feature/FeatureSection.tsx
+++ b/src/components/home/Feature/FeatureSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import Image from "next/image";
 import { useCarousel } from "@/lib/hooks/useCarousel";
 import { Button } from "@/components/ui/Button";
@@ -74,7 +73,7 @@ const SLIDE_SPECS: Record<string, SlideSpec> = {
   },
 };
 
-const INTERVAL_MS = 5500;
+const INTERVAL_MS = 4000;
 
 export function FeatureSection({
   kicker,
@@ -83,11 +82,8 @@ export function FeatureSection({
   slides,
   cutoutByModel,
 }: Props) {
-  const [mouseInside, setMouseInside] = useState(false);
-  const [focusInside, setFocusInside] = useState(false);
   const { active, setActive } = useCarousel(slides.length, {
     intervalMs: INTERVAL_MS,
-    paused: mouseInside || focusInside,
   });
 
   const current = slides[active];
@@ -95,13 +91,7 @@ export function FeatureSection({
   if (!spec) return null;
 
   return (
-    <section
-      className="ho-sec ho-feature"
-      onMouseEnter={() => setMouseInside(true)}
-      onMouseLeave={() => setMouseInside(false)}
-      onFocusCapture={() => setFocusInside(true)}
-      onBlurCapture={() => setFocusInside(false)}
-    >
+    <section className="ho-sec ho-feature">
       <div>
         <div className="ho-feature__kicker">{kicker}</div>
         <h2 className="ho-feature__title">{current.model}</h2>

--- a/src/components/products/CategoryShowcase/CategoryShowcase.tsx
+++ b/src/components/products/CategoryShowcase/CategoryShowcase.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useCarousel } from "@/lib/hooks/useCarousel";
@@ -35,7 +34,7 @@ type Props = {
   heroLede: string;
 };
 
-const INTERVAL_MS = 4500;
+const INTERVAL_MS = 4000;
 
 export function CategoryShowcase({
   products,
@@ -54,10 +53,8 @@ export function CategoryShowcase({
   heroCode,
   heroLede,
 }: Props) {
-  const [hovered, setHovered] = useState(false);
   const { active, setActive } = useCarousel(products.length, {
     intervalMs: INTERVAL_MS,
-    paused: hovered,
   });
 
   const selectSlide = (i: number) => setActive(i);
@@ -68,8 +65,6 @@ export function CategoryShowcase({
       role="region"
       aria-roledescription="carousel"
       aria-label={slidesAriaLabel}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
     >
       <span
         className="lt-showcase__bracket lt-showcase__bracket--tl"

--- a/src/lib/hooks/useCarousel.test.ts
+++ b/src/lib/hooks/useCarousel.test.ts
@@ -83,16 +83,6 @@ describe("useCarousel", () => {
     expect(result.current.active).toBe(0);
   });
 
-  it("does not advance while paused", () => {
-    const { result } = renderHook(() =>
-      useCarousel(3, { intervalMs: 1000, paused: true }),
-    );
-    act(() => {
-      vi.advanceTimersByTime(5000);
-    });
-    expect(result.current.active).toBe(0);
-  });
-
   it("does not advance when prefers-reduced-motion is set", () => {
     prefersReducedMotion = true;
     const { result } = renderHook(() => useCarousel(3, { intervalMs: 1000 }));

--- a/src/lib/hooks/useCarousel.ts
+++ b/src/lib/hooks/useCarousel.ts
@@ -13,20 +13,14 @@ const getRMServerSnapshot = () => false;
 
 type Options = {
   intervalMs: number;
-  /** Caller-provided pause flag (e.g. hover/focus inside the carousel). */
-  paused?: boolean;
 };
 
 /**
  * Auto-advancing index hook for carousels. Skips ticks when:
  *   - length <= 1
  *   - the user has prefers-reduced-motion set
- *   - `paused` is true (hover, focus, etc. — caller decides)
  */
-export function useCarousel(
-  length: number,
-  { intervalMs, paused = false }: Options,
-) {
+export function useCarousel(length: number, { intervalMs }: Options) {
   const [active, setActive] = useState(0);
   const reducedMotion = useSyncExternalStore(
     subscribeReducedMotion,
@@ -35,12 +29,12 @@ export function useCarousel(
   );
 
   useEffect(() => {
-    if (length <= 1 || reducedMotion || paused) return;
+    if (length <= 1 || reducedMotion) return;
     const id = window.setInterval(() => {
       setActive((n) => (n + 1) % length);
     }, intervalMs);
     return () => window.clearInterval(id);
-  }, [length, intervalMs, paused, reducedMotion]);
+  }, [length, intervalMs, reducedMotion]);
 
   return { active, setActive };
 }

--- a/src/lib/products/flagship.test.ts
+++ b/src/lib/products/flagship.test.ts
@@ -99,6 +99,16 @@ describe("pickFlagship", () => {
     const products = ALL_PRODUCTS.filter((p) => p.series !== "specialized");
     expect(pickFlagship(products, "specialized")).toBeUndefined();
   });
+
+  it("excludes MFM meters from the fallback", () => {
+    const products: Product[] = [
+      makeProduct({ model: "MS3010MA", series: "analogue", function: "MFM" }),
+      makeProduct({ model: "M3010VA", series: "analogue" }),
+    ];
+    const result = pickFlagship(products, "analogue");
+    expect(result?.model).toBe("M3010VA");
+    expect(result?.function).not.toBe("MFM");
+  });
 });
 
 describe("flagshipImageUrl", () => {

--- a/src/lib/products/flagship.ts
+++ b/src/lib/products/flagship.ts
@@ -16,16 +16,17 @@ export function pickFlagship(
   products: Product[],
   slug: CategorySlug,
 ): Product | undefined {
+  const candidates = products.filter((p) => p.function !== "MFM");
   const preferred = FLAGSHIP_MODEL[slug];
   if (preferred) {
-    const match = products.find(
+    const match = candidates.find(
       (p) =>
         categoryForSeries(p.series) === slug &&
         p.model.toLowerCase() === preferred.toLowerCase(),
     );
     if (match) return match;
   }
-  return products.find((p) => categoryForSeries(p.series) === slug);
+  return candidates.find((p) => categoryForSeries(p.series) === slug);
 }
 
 export function flagshipImageUrl(flagship: Product): string {

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -150,7 +150,7 @@ export const productSlugsQuery = defineQuery(`
 
 export const categoryShowcaseQuery = defineQuery(`
   *[_type == "categoryShowcase" && _id == "category-showcases"][0]{
-    "analogue": analogue[]{
+    "analogue": analogue[product->function != "MFM"]{
       caption,
       "model": product->model,
       "slug": product->slug.current,
@@ -160,7 +160,7 @@ export const categoryShowcaseQuery = defineQuery(`
       "image": product->images[0],
       "cutout": product->cutout,
     },
-    "digital": digital[]{
+    "digital": digital[product->function != "MFM"]{
       caption,
       "model": product->model,
       "slug": product->slug.current,
@@ -170,7 +170,7 @@ export const categoryShowcaseQuery = defineQuery(`
       "image": product->images[0],
       "cutout": product->cutout,
     },
-    "specialized": specialized[]{
+    "specialized": specialized[product->function != "MFM"]{
       caption,
       "model": product->model,
       "slug": product->slug.current,


### PR DESCRIPTION
## Summary
- `pickFlagship()` filters MFMs from the candidate pool so the `/products` rotators only ever surface controllers (closes #235).
- `categoryShowcase` Sanity schema gains an editor-side filter (`function != "MFM"`) on each product reference so meters cannot be picked going forward.
- Reseeded showcase: dropped M2030VA (data-marked MFM) from analogue and added MS3800VA; added DO400 to specialized so every category features 3 products.
- All three rotating sliders share a 4000 ms interval and now keep advancing on hover/focus (closes #234). `prefers-reduced-motion` still pauses; touch swipe + dot clicks preserved.

## Test plan
- [x] `pnpm test` — full vitest suite (338 tests) green; new `pickFlagship` "excludes MFM from fallback" case added.
- [x] `pnpm typecheck` clean.
- [x] Manual: `/en`, `/en/products`, `/en/products/{analogue,digital,specialized}` — sliders rotate every ~4s, no pause on hover, no MFM appears.
- [ ] Verify the new MS3800VA and DO400 showcase slides render with real imagery (cutout/image asset present).
- [ ] Sanity Studio spot-check: editing a `categoryShowcase` array member only offers non-MFM products in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)