### PR TITLE
fix(contact): preserve typed inputs when validation fails (#251)

### DIFF
--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -251,4 +251,34 @@ test.describe("Contact form", () => {
       "true",
     );
   });
+
+  test("preserves typed inputs after a failed submission", async ({ page }) => {
+    // Regression guard for #251: React 19's <form action> auto-resets the form
+    // after every submit, wiping user input. Switching to onSubmit must keep
+    // every filled value in place when validation fails.
+    await page.locator("#ct-inquiry-type").selectOption("general");
+    await page.locator("#ct-name").fill("Preserved Tester");
+    await page.locator("#ct-company").fill("Acme Corp");
+    await page.locator("#ct-phone").fill("+82-10-0000-0000");
+    await page
+      .locator("#ct-message")
+      .fill("Values must survive a failed submit.");
+    // Leave email blank — schema rejects, server action returns errorKey "invalid".
+    await page.locator('input[name="consent"]').check();
+    await page.getByRole("button", { name: /send inquiry/i }).click();
+
+    await expect(page.locator("#ct-email")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+      { timeout: 10_000 },
+    );
+
+    await expect(page.locator("#ct-inquiry-type")).toHaveValue("general");
+    await expect(page.locator("#ct-name")).toHaveValue("Preserved Tester");
+    await expect(page.locator("#ct-company")).toHaveValue("Acme Corp");
+    await expect(page.locator("#ct-phone")).toHaveValue("+82-10-0000-0000");
+    await expect(page.locator("#ct-message")).toHaveValue(
+      "Values must survive a failed submit.",
+    );
+  });
 });

--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useState, useTransition, type FormEvent } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/Button";
 import { Link } from "@/i18n/navigation";
@@ -30,10 +30,19 @@ export function ContactForm({ form, defaults }: Props) {
   const extra = selected?.extraField;
 
   const t = useTranslations("contactForm");
-  const [state, formAction, isPending] = useActionState(
-    submitContact,
-    INITIAL_STATE,
-  );
+  // Manual submit (not <form action>) so React 19 doesn't auto-reset the form
+  // after the action runs — preserves typed values when validation fails.
+  const [state, setState] = useState<ContactFormState>(INITIAL_STATE);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    startTransition(async () => {
+      const result = await submitContact(state, formData);
+      setState(result);
+    });
+  };
 
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
   const turnstileRequired = process.env.NODE_ENV === "production";
@@ -66,7 +75,7 @@ export function ContactForm({ form, defaults }: Props) {
   }
 
   return (
-    <form action={formAction} noValidate>
+    <form onSubmit={handleSubmit} noValidate>
       {/* Honeypot — visually hidden, ignored by users, populated by bots.
           The submit handler rejects any submission with a non-empty value. */}
       <div


### PR DESCRIPTION
## Summary
- Closes #251 — failed contact-form submissions no longer wipe the user's typed inputs.
- Root cause: React 19's `<form action={formAction}>` auto-resets the form after every submit. Swap to a manual `onSubmit` handler that calls the server action via `useTransition`, so uncontrolled inputs keep their DOM values on the re-render that surfaces validation errors.
- No changes to the server contract (`submit.ts`/`schema.ts`) or to `QuoteFields` (its controlled state already survived a parent re-render).

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test:run` (389 passed)
- [ ] `pnpm exec playwright test e2e/contact-form.spec.ts` — includes new \`preserves typed inputs after a failed submission\` regression case
- [ ] Manual: `/en/contact`, fill name/company/phone/message, leave email blank, submit, confirm error appears and every filled field is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)