### PR TITLE
fix(do400): restore connections + correct maxPressure from PDF p.34

### DIFF
--- a/scripts/lib/sanity-mutate.ts
+++ b/scripts/lib/sanity-mutate.ts
@@ -15,6 +15,8 @@ export interface SanityEnv {
 export interface PatchMutation {
   patch: {
     id: string;
+    // `unknown` because set values include arrays and objects
+    // (e.g. `connections: [{ _key, type, length }, …]`), not just primitives.
     set?: Record<string, unknown>;
     unset?: string[];
   };

--- a/scripts/lib/sanity-mutate.ts
+++ b/scripts/lib/sanity-mutate.ts
@@ -15,7 +15,7 @@ export interface SanityEnv {
 export interface PatchMutation {
   patch: {
     id: string;
-    set?: Record<string, string | number | boolean | null>;
+    set?: Record<string, unknown>;
     unset?: string[];
   };
 }

--- a/scripts/parse-catalog.test.ts
+++ b/scripts/parse-catalog.test.ts
@@ -1,5 +1,63 @@
 import { describe, it, expect } from "vitest";
-import { buildInstrumentSpecs } from "./parse-catalog";
+import { buildInstrumentSpecs, validate } from "./parse-catalog";
+import { makeProduct, rouProductFixture } from "../src/test/fixtures/products";
+
+describe("validate", () => {
+  const baseMfc = () =>
+    makeProduct({
+      connections: [{ type: "1/4 inch VCR", length: "60 mm", _key: "c1" }],
+      massFlowSpecs: {
+        flowRange: { display: "0–1000 sccm", min: 0, max: 1000, unit: "sccm" },
+        accuracy: { display: "±1% F.S.", value: 1, unit: "% F.S." },
+        repeatability: { display: "±0.2% F.S.", value: 0.2, unit: "% F.S." },
+        ioSignal: { display: "0–5 VDC", outputs: ["0-5VDC"] },
+        supplyPower: { display: "±15 VDC", voltages: [15, -15] },
+        tempRange: { display: "0–50 °C", min: 0, max: 50, unit: "°C" },
+        leakRate: {
+          display: "1 × 10⁻⁹ atm·cc/sec He",
+          value: 1e-9,
+          unit: "atm·cc/sec",
+        },
+        controlRange: {
+          display: "2–100% F.S.",
+          min: 2,
+          max: 100,
+          unit: "% F.S.",
+        },
+        responseTime: {
+          display: "<1 sec",
+          value: 1,
+          unit: "sec",
+          comparator: "lt",
+        },
+      },
+    });
+
+  it("passes a normal MFC product with at least one connection", () => {
+    expect(() => validate(baseMfc())).not.toThrow();
+  });
+
+  it("throws when a non-ROU product has empty connections", () => {
+    const empty = makeProduct({ connections: [] });
+    expect(() => validate(empty)).toThrowError(/no connections parsed/);
+  });
+
+  it("throws on DO400 too — no allow-list any more", () => {
+    // Regression guard: a stale comment in this file used to skip DO400.
+    // After 2026-06-03 the allow-list was removed; DO400's connection
+    // table now comes from patch-eng-corrections.ts.
+    const do400 = makeProduct({
+      model: "DO400",
+      slug: { current: "do400" },
+      connections: [],
+    });
+    expect(() => validate(do400)).toThrowError(/DO400: no connections parsed/);
+  });
+
+  it("skips the connections check for ROU instruments", () => {
+    expect(() => validate(rouProductFixture)).not.toThrow();
+  });
+});
 
 describe("buildInstrumentSpecs", () => {
   it("returns a flat row array parsed from a Spec/Value table", () => {

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -855,12 +855,11 @@ function validate(p: Product): void {
     throw new Error(`${p.model}: bad series "${p.series}"`);
   if (!["MFC", "MFM", "EPC", "ROU"].includes(p.function))
     throw new Error(`${p.model}: bad function "${p.function}"`);
-  // DO400 and ROU instruments have no fluid connection table in the catalog.
-  if (
-    (p.connections?.length ?? 0) === 0 &&
-    p.function !== "ROU" &&
-    p.model !== "DO400"
-  )
+  // ROU instruments have no fluid connection table in the catalog.
+  // DO400's connections + corrected maxPressure are hand-applied via
+  // scripts/patch-eng-corrections.ts + products.json until the markdown
+  // source in company-docs-private adds the connection table (PDF p.34).
+  if ((p.connections?.length ?? 0) === 0 && p.function !== "ROU")
     throw new Error(`${p.model}: no connections parsed`);
 
   if (p.function === "ROU") {

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -848,7 +848,7 @@ function buildProduct(
 
 // --- Validation ---
 
-function validate(p: Product): void {
+export function validate(p: Product): void {
   if (!p.model) throw new Error("Missing model");
   if (!p.slug.current) throw new Error(`${p.model}: missing slug`);
   if (!["analogue", "digital", "specialized"].includes(p.series))
@@ -859,6 +859,8 @@ function validate(p: Product): void {
   // DO400's connections + corrected maxPressure are hand-applied via
   // scripts/patch-eng-corrections.ts + products.json until the markdown
   // source in company-docs-private adds the connection table (PDF p.34).
+  // Once it does, drop the DO400 entry from patch-eng-corrections.ts and
+  // let the parser populate the field naturally.
   if ((p.connections?.length ?? 0) === 0 && p.function !== "ROU")
     throw new Error(`${p.model}: no connections parsed`);
 

--- a/scripts/patch-eng-corrections.ts
+++ b/scripts/patch-eng-corrections.ts
@@ -3,12 +3,12 @@
  *
  *   1. EX70C / EX70M  — flow range  0.01–70 slpm  →  0.01–100 slpm
  *   2. MS2150VA / MS3150VA  — flow range  0.01–100 slpm  →  30–100 slpm
- *   3. DO400  — series  analogue  →  specialized
+ *   3. DO400  — series analogue → specialized, plus connections (3 SW
+ *      fittings) and maxPressure <30 bar → <13 bar (source: 2026 final
+ *      catalogue PDF p.34; the markdown in company-docs-private still
+ *      lacks the connection table)
  *   4. High-flow models (22 slugs)  — maxPressure.display  →  "inquiry"
  *      (numeric value/unit/comparator unset, since "inquiry" is not a number)
- *   5. DO400  — connections (3 SW fittings) + maxPressure  <30 bar → <13 bar
- *      (source: 2026 final catalogue PDF p.34; the markdown source in
- *      company-docs-private still lacks the connection table)
  *
  * Mirrors the corrections already applied to src/lib/fixtures/products.json.
  *
@@ -81,24 +81,11 @@ const PATCHES: Patch[] = [
   { id: "product-ms2150va", set: FLOW_30_TO_100 },
   { id: "product-ms3150va", set: FLOW_30_TO_100 },
 
-  // 3. DO400 series
-  { id: "product-do400", set: { series: "specialized" } },
-
-  // 4. "inquiry" maxPressure for high-flow models
-  ...INQUIRY_SLUGS.map<Patch>((slug) => ({
-    id: `product-${slug}`,
-    set: { "massFlowSpecs.maxPressure.display": "inquiry" },
-    unset: [
-      "massFlowSpecs.maxPressure.value",
-      "massFlowSpecs.maxPressure.unit",
-      "massFlowSpecs.maxPressure.comparator",
-    ],
-  })),
-
-  // 5. DO400 connections + corrected maxPressure (PDF p.34)
+  // 3. DO400 — series + connections + corrected maxPressure (PDF p.34)
   {
     id: "product-do400",
     set: {
+      series: "specialized",
       connections: [
         { _key: "conn-0", type: '1/2" SW', length: "208.5 mm" },
         { _key: "conn-1", type: '3/4" SW', length: "208.5 mm" },
@@ -110,6 +97,17 @@ const PATCHES: Patch[] = [
       "massFlowSpecs.maxPressure.comparator": "lt",
     },
   },
+
+  // 4. "inquiry" maxPressure for high-flow models
+  ...INQUIRY_SLUGS.map<Patch>((slug) => ({
+    id: `product-${slug}`,
+    set: { "massFlowSpecs.maxPressure.display": "inquiry" },
+    unset: [
+      "massFlowSpecs.maxPressure.value",
+      "massFlowSpecs.maxPressure.unit",
+      "massFlowSpecs.maxPressure.comparator",
+    ],
+  })),
 ];
 
 function printPlan(apply: boolean) {

--- a/scripts/patch-eng-corrections.ts
+++ b/scripts/patch-eng-corrections.ts
@@ -6,6 +6,9 @@
  *   3. DO400  — series  analogue  →  specialized
  *   4. High-flow models (22 slugs)  — maxPressure.display  →  "inquiry"
  *      (numeric value/unit/comparator unset, since "inquiry" is not a number)
+ *   5. DO400  — connections (3 SW fittings) + maxPressure  <30 bar → <13 bar
+ *      (source: 2026 final catalogue PDF p.34; the markdown source in
+ *      company-docs-private still lacks the connection table)
  *
  * Mirrors the corrections already applied to src/lib/fixtures/products.json.
  *
@@ -91,6 +94,22 @@ const PATCHES: Patch[] = [
       "massFlowSpecs.maxPressure.comparator",
     ],
   })),
+
+  // 5. DO400 connections + corrected maxPressure (PDF p.34)
+  {
+    id: "product-do400",
+    set: {
+      connections: [
+        { _key: "conn-0", type: '1/2" SW', length: "208.5 mm" },
+        { _key: "conn-1", type: '3/4" SW', length: "208.5 mm" },
+        { _key: "conn-2", type: '1" SW', length: "217.2 mm" },
+      ],
+      "massFlowSpecs.maxPressure.display": "<13 bar",
+      "massFlowSpecs.maxPressure.value": 13,
+      "massFlowSpecs.maxPressure.unit": "bar",
+      "massFlowSpecs.maxPressure.comparator": "lt",
+    },
+  },
 ];
 
 function printPlan(apply: boolean) {

--- a/src/components/products/ProductRow/ProductRow.test.tsx
+++ b/src/components/products/ProductRow/ProductRow.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: unknown;
+    children: React.ReactNode;
+  } & Record<string, unknown>) =>
+    React.createElement(
+      "a",
+      { href: typeof href === "string" ? href : "#", ...rest },
+      children,
+    ),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { ProductRow } from "./ProductRow";
+import { makeProduct } from "@/test/fixtures/products";
+import type { Product } from "@/lib/types/product";
+
+function renderRow(product: Product) {
+  return render(
+    <table>
+      <tbody>
+        <ProductRow
+          product={product}
+          imageSrc={null}
+          category="specialized"
+          locale="en"
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("ProductRow fitting cell", () => {
+  it("dedupes connection-type suffixes (DO400's three SW fittings → 'SW')", () => {
+    const do400 = makeProduct({
+      model: "DO400",
+      slug: { current: "do400" },
+      connections: [
+        { type: '1/2" SW', length: "208.5 mm", _key: "c1" },
+        { type: '3/4" SW', length: "208.5 mm", _key: "c2" },
+        { type: '1" SW', length: "217.2 mm", _key: "c3" },
+      ],
+    });
+    const { container } = renderRow(do400);
+    expect(
+      container.querySelector(".lt-prod-row__cell--fit")?.textContent,
+    ).toBe("SW");
+  });
+
+  it("joins distinct suffixes with ' · '", () => {
+    const mixed = makeProduct({
+      connections: [
+        { type: '1/4" SWG', length: "131.3 mm", _key: "c1" },
+        { type: '1/4" VCR', length: "127.8 mm", _key: "c2" },
+      ],
+    });
+    const { container } = renderRow(mixed);
+    expect(
+      container.querySelector(".lt-prod-row__cell--fit")?.textContent,
+    ).toBe("SWG · VCR");
+  });
+
+  it("renders an empty fitting cell when connections is empty", () => {
+    // Documents the current behaviour: no em-dash fallback (PR #207 closed
+    // as superseded by the data restoration). If a defensive empty-state
+    // is added later for LTI-1000/LTI-2000, update this assertion.
+    const empty = makeProduct({ connections: [] });
+    const { container } = renderRow(empty);
+    expect(
+      container.querySelector(".lt-prod-row__cell--fit")?.textContent,
+    ).toBe("");
+  });
+});

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -4319,7 +4319,20 @@
         "zh": "紧凑型连接结构"
       }
     ],
-    "connections": [],
+    "connections": [
+      {
+        "type": "1/2\" SW",
+        "length": "208.5 mm"
+      },
+      {
+        "type": "3/4\" SW",
+        "length": "208.5 mm"
+      },
+      {
+        "type": "1\" SW",
+        "length": "217.2 mm"
+      }
+    ],
     "manuals": [],
     "drawings": [],
     "connectorType": "9-Pin D-Connector",
@@ -4374,8 +4387,8 @@
         "comparator": "lt"
       },
       "maxPressure": {
-        "display": "<30 bar",
-        "value": 30,
+        "display": "<13 bar",
+        "value": 13,
         "unit": "bar",
         "comparator": "lt"
       }

--- a/src/lib/fixtures/products.test.ts
+++ b/src/lib/fixtures/products.test.ts
@@ -21,4 +21,15 @@ describe("products.json fixture", () => {
     const slugs = ALL_PRODUCTS.map((p) => p.slug.current);
     expect(new Set(slugs).size).toBe(slugs.length);
   });
+
+  it("DO400 carries the catalogue-corrected fittings + max pressure", () => {
+    // Pins the 2026-06-03 correction from PDF p.34: three SW fittings and
+    // <13 bar max pressure. A silent revert (parser regen wiping the
+    // hand-applied fix) would be caught here.
+    const do400 = ALL_PRODUCTS.find((p) => p.model === "DO400");
+    expect(do400, "DO400 missing from fixture").toBeDefined();
+    expect(do400!.connections.length).toBeGreaterThanOrEqual(1);
+    expect(do400!.massFlowSpecs?.maxPressure?.value).toBe(13);
+    expect(do400!.massFlowSpecs?.maxPressure?.display).toBe("<13 bar");
+  });
 });


### PR DESCRIPTION
## Summary

- DO400's catalogue row rendered an empty fitting cell and showed `<30 bar` max pressure. The 2026 final catalogue PDF (p.34) actually shows three SW fittings (1/2" 208.5, 3/4" 208.5, 1" 217.2 mm) and `<13 bar` max pressure.
- `products.json` was wrong because (1) the parser's `parse-catalog.ts:858-864` allow-listed DO400 from the no-connections guard with a stale comment pre-dating the p.34 update, and (2) the `≤30 bar` value was inherited from a typo in `line-tech-files/catalog-research/do400.md` (the PDF says `<13 bar`, confirmed via three extraction modes + cross-page consistency with the entire MD500–MD800 high-flow band).
- Mirrors the fix to Sanity via a new 5th entry in `patch-eng-corrections.ts`. Already `--apply`'d against production for `product-do400`.
- Supersedes #207 (em-dash workaround for the empty fitting cell — that PR was built on the false premise that the catalogue had no data; closed).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 47 files / 393 tests pass
- [x] `tsx scripts/patch-eng-corrections.ts --apply` succeeded against `product-do400` in Sanity production
- [ ] `pnpm dev` → visit `/en/products/specialized` and confirm DO400 row shows `SW` in the fitting column
- [ ] `/en/products/finder` — DO400 still surfaces with the corrected `<13 bar` pressure ceiling

## Follow-ups (out of scope)

- `docs/product-catalog-2026.md` in `company-docs-private` still lacks DO400's connection table. The dropped allow-list means the next parser run will throw until that's updated — track separately.
- `MS2400VA` and `MS3400VA` are still in `INQUIRY_SLUGS` but were retired in #231; the script logged 404s for both during apply. Cleanup is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)