### PR TITLE
feat(applications): per-page spec rows on Featured spotlight

### DIFF
--- a/e2e/applications.spec.ts
+++ b/e2e/applications.spec.ts
@@ -49,6 +49,11 @@ test.describe("Applications detail page", () => {
       "href",
       /\/products\/specialized\/do400$/,
     );
+
+    const specLabels = featured.locator(".ap-featured__spec dt");
+    const specValues = featured.locator(".ap-featured__spec dd");
+    await expect(specLabels).toHaveText(["Flow range", "Max pressure"]);
+    await expect(specValues).toHaveText(["100–400 slpm", "<30 bar"]);
   });
 
   test("applications without a featured slug do not render the featured block", async ({

--- a/src/app/[locale]/applications/[slug]/page.tsx
+++ b/src/app/[locale]/applications/[slug]/page.tsx
@@ -3,20 +3,18 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
+import { FeaturedApplicationProduct } from "@/components/applications/FeaturedApplicationProduct";
 import {
-  FeaturedApplicationProduct,
-  type FeaturedApplicationProductInput,
-  type FeaturedApplicationProductSpec,
-} from "@/components/applications/FeaturedApplicationProduct";
+  DEFAULT_FEATURED_SPEC_KEYS,
+  resolveFeaturedProduct,
+  type SanityFeaturedProduct,
+} from "@/lib/applications/resolveFeaturedProduct";
 import { LT_APPLICATIONS } from "@/lib/content/applications";
-import type { MassFlowSpecs, Product } from "@/lib/types/product";
-import { productBySlug } from "@/lib/fixtures/products";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
 import { buildApplicationDetailMetadata } from "@/lib/seo";
 import { sanityClient, sanityBuildClient } from "@/sanity/client";
 import { fetchSanity } from "@/sanity/fetch";
-import { urlFor } from "@/sanity/imageUrl";
 import {
   applicationBySlugQuery,
   applicationSlugsQuery,
@@ -24,17 +22,6 @@ import {
 import "../applications-page.css";
 
 type Props = { params: Promise<{ locale: Locale; slug: string }> };
-
-type SanityFeaturedProduct = {
-  slug: string;
-  model: string;
-  series: Product["series"];
-  productLabel?: Record<string, string> | null;
-  description?: Record<string, string> | null;
-  flowRange?: string | null;
-  image?: { asset?: { _ref: string } } | null;
-  cutout?: { asset?: { _ref: string } } | null;
-};
 
 type SanityApp = {
   slug: string;
@@ -96,68 +83,6 @@ const CATEGORY_HREFS: Record<string, string> = {
   lepc: "/products/lepc",
 };
 
-const DEFAULT_FEATURED_SPEC_KEYS: ReadonlyArray<keyof MassFlowSpecs> = [
-  "flowRange",
-];
-
-function resolveFeaturedProduct({
-  sanity,
-  staticSlug,
-  locale,
-  specKeys,
-  getSpecLabel,
-}: {
-  sanity: SanityFeaturedProduct | null;
-  staticSlug: string | undefined;
-  locale: Locale;
-  specKeys: ReadonlyArray<keyof MassFlowSpecs>;
-  getSpecLabel: (key: keyof MassFlowSpecs) => string;
-}): FeaturedApplicationProductInput | null {
-  if (sanity) {
-    const cutoutOrImage = sanity.cutout ?? sanity.image ?? null;
-    // The Sanity featured-product schema only carries `flowRange` today;
-    // any other requested key is skipped silently until the schema is extended.
-    const specs: FeaturedApplicationProductSpec[] = [];
-    for (const key of specKeys) {
-      if (key === "flowRange" && sanity.flowRange) {
-        specs.push({ label: getSpecLabel(key), value: sanity.flowRange });
-      }
-    }
-    return {
-      slug: sanity.slug,
-      model: sanity.model,
-      series: sanity.series,
-      productLabel: sanity.productLabel?.[locale] ?? null,
-      description: sanity.description?.[locale] ?? null,
-      specs,
-      imageUrl: cutoutOrImage?.asset
-        ? urlFor(cutoutOrImage).width(960).url()
-        : null,
-    };
-  }
-
-  if (!staticSlug) return null;
-  const fixture = productBySlug(staticSlug);
-  if (!fixture) return null;
-
-  const massFlowSpecs = fixture.massFlowSpecs;
-  const specs: FeaturedApplicationProductSpec[] = [];
-  for (const key of specKeys) {
-    const value = massFlowSpecs?.[key]?.display;
-    if (value) specs.push({ label: getSpecLabel(key), value });
-  }
-
-  return {
-    slug: fixture.slug.current,
-    model: fixture.model,
-    series: fixture.series,
-    productLabel: fixture.productLabel[locale] ?? null,
-    description: fixture.description?.[locale] ?? null,
-    specs,
-    imageUrl: `/products/${fixture.slug.current}/cutout-2026.png`,
-  };
-}
-
 export default async function ApplicationDetailPage({ params }: Props) {
   const { locale, slug } = await params;
   setRequestLocale(locale);
@@ -200,7 +125,7 @@ export default async function ApplicationDetailPage({ params }: Props) {
     staticSlug: staticEntry?.featuredProductSlug,
     locale,
     specKeys: staticEntry?.featuredSpecKeys ?? DEFAULT_FEATURED_SPEC_KEYS,
-    getSpecLabel: (key) => tSpecs(key),
+    getSpecLabel: tSpecs,
   });
 
   const featuredCaption = staticEntry?.featuredProductCaption ?? null;

--- a/src/app/[locale]/applications/[slug]/page.tsx
+++ b/src/app/[locale]/applications/[slug]/page.tsx
@@ -6,9 +6,10 @@ import { Breadcrumbs } from "@/components/layout/Breadcrumbs/Breadcrumbs";
 import {
   FeaturedApplicationProduct,
   type FeaturedApplicationProductInput,
+  type FeaturedApplicationProductSpec,
 } from "@/components/applications/FeaturedApplicationProduct";
 import { LT_APPLICATIONS } from "@/lib/content/applications";
-import type { Product } from "@/lib/types/product";
+import type { MassFlowSpecs, Product } from "@/lib/types/product";
 import { productBySlug } from "@/lib/fixtures/products";
 import { routing } from "@/i18n/routing";
 import type { Locale } from "@/lib/content/home";
@@ -95,24 +96,40 @@ const CATEGORY_HREFS: Record<string, string> = {
   lepc: "/products/lepc",
 };
 
+const DEFAULT_FEATURED_SPEC_KEYS: ReadonlyArray<keyof MassFlowSpecs> = [
+  "flowRange",
+];
+
 function resolveFeaturedProduct({
   sanity,
   staticSlug,
   locale,
+  specKeys,
+  getSpecLabel,
 }: {
   sanity: SanityFeaturedProduct | null;
   staticSlug: string | undefined;
   locale: Locale;
+  specKeys: ReadonlyArray<keyof MassFlowSpecs>;
+  getSpecLabel: (key: keyof MassFlowSpecs) => string;
 }): FeaturedApplicationProductInput | null {
   if (sanity) {
     const cutoutOrImage = sanity.cutout ?? sanity.image ?? null;
+    // The Sanity featured-product schema only carries `flowRange` today;
+    // any other requested key is skipped silently until the schema is extended.
+    const specs: FeaturedApplicationProductSpec[] = [];
+    for (const key of specKeys) {
+      if (key === "flowRange" && sanity.flowRange) {
+        specs.push({ label: getSpecLabel(key), value: sanity.flowRange });
+      }
+    }
     return {
       slug: sanity.slug,
       model: sanity.model,
       series: sanity.series,
       productLabel: sanity.productLabel?.[locale] ?? null,
       description: sanity.description?.[locale] ?? null,
-      flowRange: sanity.flowRange ?? null,
+      specs,
       imageUrl: cutoutOrImage?.asset
         ? urlFor(cutoutOrImage).width(960).url()
         : null,
@@ -123,13 +140,20 @@ function resolveFeaturedProduct({
   const fixture = productBySlug(staticSlug);
   if (!fixture) return null;
 
+  const massFlowSpecs = fixture.massFlowSpecs;
+  const specs: FeaturedApplicationProductSpec[] = [];
+  for (const key of specKeys) {
+    const value = massFlowSpecs?.[key]?.display;
+    if (value) specs.push({ label: getSpecLabel(key), value });
+  }
+
   return {
     slug: fixture.slug.current,
     model: fixture.model,
     series: fixture.series,
     productLabel: fixture.productLabel[locale] ?? null,
     description: fixture.description?.[locale] ?? null,
-    flowRange: fixture.massFlowSpecs?.flowRange?.display ?? null,
+    specs,
     imageUrl: `/products/${fixture.slug.current}/cutout-2026.png`,
   };
 }
@@ -138,10 +162,11 @@ export default async function ApplicationDetailPage({ params }: Props) {
   const { locale, slug } = await params;
   setRequestLocale(locale);
 
-  const [tCommon, tNav, tCategory] = await Promise.all([
+  const [tCommon, tNav, tCategory, tSpecs] = await Promise.all([
     getTranslations("common"),
     getTranslations("nav"),
     getTranslations("breadcrumbs.categories"),
+    getTranslations("product.specs"),
   ]);
 
   const c = LT_APPLICATIONS[locale];
@@ -174,6 +199,8 @@ export default async function ApplicationDetailPage({ params }: Props) {
     sanity: rawApp?.featuredProduct ?? null,
     staticSlug: staticEntry?.featuredProductSlug,
     locale,
+    specKeys: staticEntry?.featuredSpecKeys ?? DEFAULT_FEATURED_SPEC_KEYS,
+    getSpecLabel: (key) => tSpecs(key),
   });
 
   const featuredCaption = staticEntry?.featuredProductCaption ?? null;
@@ -200,7 +227,6 @@ export default async function ApplicationDetailPage({ params }: Props) {
               kickerLabel={c.featuredKicker}
               whyHeadingLabel={c.featuredWhyHeading}
               viewProductLabel={c.featuredViewProduct}
-              flowRangeLabel={c.featuredFlowRangeLabel}
             />
           ) : null}
           <div className="ap-detail__body">

--- a/src/components/applications/FeaturedApplicationProduct.test.tsx
+++ b/src/components/applications/FeaturedApplicationProduct.test.tsx
@@ -13,14 +13,13 @@ const baseProduct: FeaturedApplicationProductInput = {
   series: "specialized",
   productLabel: "Dissolved O₂ analyzer",
   description: "Fallback product description.",
-  flowRange: "0–1000 sccm",
+  specs: [{ label: "Flow range", value: "0–1000 sccm" }],
   imageUrl: "/products/do400/cutout-2026.png",
 };
 
 const labels = {
   kickerLabel: "Featured",
   whyHeadingLabel: "Why this one",
-  flowRangeLabel: "Flow range",
   viewProductLabel: "View product",
 };
 
@@ -42,6 +41,32 @@ describe("FeaturedApplicationProduct", () => {
     expect(getByText("Purpose-built for fuel cells.")).toBeInTheDocument();
     expect(getByText("Flow range")).toBeInTheDocument();
     expect(getByText("0–1000 sccm")).toBeInTheDocument();
+  });
+
+  it("renders every spec row in order when multiple are provided", () => {
+    const { container, getByText } = render(
+      <FeaturedApplicationProduct
+        product={{
+          ...baseProduct,
+          specs: [
+            { label: "Flow range", value: "100–400 slpm" },
+            { label: "Max pressure", value: "<30 bar" },
+          ],
+        }}
+        whyCaption="x"
+        {...labels}
+      />,
+    );
+
+    expect(getByText("Flow range")).toBeInTheDocument();
+    expect(getByText("100–400 slpm")).toBeInTheDocument();
+    expect(getByText("Max pressure")).toBeInTheDocument();
+    expect(getByText("<30 bar")).toBeInTheDocument();
+
+    const dts = Array.from(
+      container.querySelectorAll(".ap-featured__spec dt"),
+    ).map((n) => n.textContent);
+    expect(dts).toEqual(["Flow range", "Max pressure"]);
   });
 
   it("omits the image link when imageUrl is null", () => {
@@ -69,16 +94,24 @@ describe("FeaturedApplicationProduct", () => {
     expect(getByText("Fallback product description.")).toBeInTheDocument();
   });
 
-  it("omits the spec block when flowRange is null", () => {
-    const { container } = render(
+  it("omits the spec block when specs is empty or missing", () => {
+    const empty = render(
       <FeaturedApplicationProduct
-        product={{ ...baseProduct, flowRange: null }}
+        product={{ ...baseProduct, specs: [] }}
         whyCaption="x"
         {...labels}
       />,
     );
+    expect(empty.container.querySelector(".ap-featured__spec")).toBeNull();
 
-    expect(container.querySelector(".ap-featured__spec")).toBeNull();
+    const undef = render(
+      <FeaturedApplicationProduct
+        product={{ ...baseProduct, specs: undefined }}
+        whyCaption="x"
+        {...labels}
+      />,
+    );
+    expect(undef.container.querySelector(".ap-featured__spec")).toBeNull();
   });
 
   it("CTA href composes /products/{series}/{slug}", () => {

--- a/src/components/applications/FeaturedApplicationProduct.test.tsx
+++ b/src/components/applications/FeaturedApplicationProduct.test.tsx
@@ -44,7 +44,7 @@ describe("FeaturedApplicationProduct", () => {
   });
 
   it("renders every spec row in order when multiple are provided", () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <FeaturedApplicationProduct
         product={{
           ...baseProduct,
@@ -58,15 +58,14 @@ describe("FeaturedApplicationProduct", () => {
       />,
     );
 
-    expect(getByText("Flow range")).toBeInTheDocument();
-    expect(getByText("100–400 slpm")).toBeInTheDocument();
-    expect(getByText("Max pressure")).toBeInTheDocument();
-    expect(getByText("<30 bar")).toBeInTheDocument();
-
     const dts = Array.from(
       container.querySelectorAll(".ap-featured__spec dt"),
     ).map((n) => n.textContent);
+    const dds = Array.from(
+      container.querySelectorAll(".ap-featured__spec dd"),
+    ).map((n) => n.textContent);
     expect(dts).toEqual(["Flow range", "Max pressure"]);
+    expect(dds).toEqual(["100–400 slpm", "<30 bar"]);
   });
 
   it("omits the image link when imageUrl is null", () => {
@@ -94,24 +93,26 @@ describe("FeaturedApplicationProduct", () => {
     expect(getByText("Fallback product description.")).toBeInTheDocument();
   });
 
-  it("omits the spec block when specs is empty or missing", () => {
-    const empty = render(
+  it("omits the spec block when specs is empty", () => {
+    const { container } = render(
       <FeaturedApplicationProduct
         product={{ ...baseProduct, specs: [] }}
         whyCaption="x"
         {...labels}
       />,
     );
-    expect(empty.container.querySelector(".ap-featured__spec")).toBeNull();
+    expect(container.querySelector(".ap-featured__spec")).toBeNull();
+  });
 
-    const undef = render(
+  it("omits the spec block when specs is undefined", () => {
+    const { container } = render(
       <FeaturedApplicationProduct
         product={{ ...baseProduct, specs: undefined }}
         whyCaption="x"
         {...labels}
       />,
     );
-    expect(undef.container.querySelector(".ap-featured__spec")).toBeNull();
+    expect(container.querySelector(".ap-featured__spec")).toBeNull();
   });
 
   it("CTA href composes /products/{series}/{slug}", () => {

--- a/src/components/applications/FeaturedApplicationProduct.tsx
+++ b/src/components/applications/FeaturedApplicationProduct.tsx
@@ -72,10 +72,10 @@ export function FeaturedApplicationProduct({
         ) : null}
         {specs.length > 0 ? (
           <dl className="ap-featured__spec">
-            {specs.map((s, i) => (
+            {specs.map((spec, i) => (
               <Fragment key={i}>
-                <dt>{s.label}</dt>
-                <dd>{s.value}</dd>
+                <dt>{spec.label}</dt>
+                <dd>{spec.value}</dd>
               </Fragment>
             ))}
           </dl>

--- a/src/components/applications/FeaturedApplicationProduct.tsx
+++ b/src/components/applications/FeaturedApplicationProduct.tsx
@@ -1,7 +1,13 @@
+import { Fragment } from "react";
 import Image from "next/image";
 import { Link } from "@/i18n/navigation";
 import { categoryForSeries } from "@/lib/categories";
 import type { Product } from "@/lib/types/product";
+
+export type FeaturedApplicationProductSpec = {
+  label: string;
+  value: string;
+};
 
 export type FeaturedApplicationProductInput = {
   slug: string;
@@ -9,7 +15,7 @@ export type FeaturedApplicationProductInput = {
   series: Product["series"];
   productLabel?: string | null;
   description?: string | null;
-  flowRange?: string | null;
+  specs?: ReadonlyArray<FeaturedApplicationProductSpec>;
   imageUrl: string | null;
 };
 
@@ -19,7 +25,6 @@ type Props = {
   whyCaption: string | null;
   kickerLabel: string;
   whyHeadingLabel: string;
-  flowRangeLabel: string;
   viewProductLabel: string;
 };
 
@@ -28,11 +33,11 @@ export function FeaturedApplicationProduct({
   whyCaption,
   kickerLabel,
   whyHeadingLabel,
-  flowRangeLabel,
   viewProductLabel,
 }: Props) {
   const detailHref = `/products/${categoryForSeries(product.series)}/${product.slug}`;
   const body = whyCaption ?? product.description ?? null;
+  const specs = product.specs ?? [];
 
   return (
     <section className="ap-featured" aria-labelledby="ap-featured-title">
@@ -65,10 +70,14 @@ export function FeaturedApplicationProduct({
             <p className="ap-featured__desc">{body}</p>
           </div>
         ) : null}
-        {product.flowRange ? (
+        {specs.length > 0 ? (
           <dl className="ap-featured__spec">
-            <dt>{flowRangeLabel}</dt>
-            <dd>{product.flowRange}</dd>
+            {specs.map((s, i) => (
+              <Fragment key={i}>
+                <dt>{s.label}</dt>
+                <dd>{s.value}</dd>
+              </Fragment>
+            ))}
           </dl>
         ) : null}
         <Link href={detailHref} className="ap-featured__cta">

--- a/src/lib/applications/resolveFeaturedProduct.test.ts
+++ b/src/lib/applications/resolveFeaturedProduct.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Product } from "@/lib/types/product";
+
+import {
+  DEFAULT_FEATURED_SPEC_KEYS,
+  resolveFeaturedProduct,
+  type SanityFeaturedProduct,
+} from "./resolveFeaturedProduct";
+
+vi.mock("@/sanity/imageUrl", () => ({
+  urlFor: () => ({ width: () => ({ url: () => "https://cdn/x.png" }) }),
+}));
+
+vi.mock("@/lib/fixtures/products", () => ({
+  productBySlug: (slug: string): Partial<Product> | undefined => {
+    if (slug === "do400") {
+      return {
+        slug: { current: "do400" },
+        model: "DO400",
+        series: "specialized",
+        productLabel: {
+          en: "Mass Flow Controller",
+          ko: "MFC-ko",
+          zh: "MFC-zh",
+        },
+        description: { en: "desc-en", ko: "desc-ko", zh: "desc-zh" },
+        massFlowSpecs: {
+          flowRange: { display: "100–400 slpm" },
+          maxPressure: { display: "<30 bar" },
+          accuracy: { display: "" },
+          repeatability: { display: "" },
+          ioSignal: { display: "" },
+          supplyPower: { display: "" },
+          tempRange: { display: "" },
+          leakRate: { display: "" },
+          controlRange: { display: "" },
+        },
+      } as unknown as Partial<Product>;
+    }
+    if (slug === "no-specs") {
+      return {
+        slug: { current: "no-specs" },
+        model: "NS",
+        series: "analogue",
+        productLabel: { en: "No Specs", ko: "NS-ko", zh: "NS-zh" },
+        description: null,
+        massFlowSpecs: undefined,
+      } as unknown as Partial<Product>;
+    }
+    return undefined;
+  },
+}));
+
+const label = (key: string) => `lbl:${key}`;
+
+describe("resolveFeaturedProduct", () => {
+  it("returns null when both sanity and staticSlug are absent", () => {
+    expect(
+      resolveFeaturedProduct({
+        sanity: null,
+        staticSlug: undefined,
+        locale: "en",
+        specKeys: DEFAULT_FEATURED_SPEC_KEYS,
+        getSpecLabel: label,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when staticSlug doesn't match a fixture", () => {
+    expect(
+      resolveFeaturedProduct({
+        sanity: null,
+        staticSlug: "nonexistent",
+        locale: "en",
+        specKeys: DEFAULT_FEATURED_SPEC_KEYS,
+        getSpecLabel: label,
+      }),
+    ).toBeNull();
+  });
+
+  it("fixture branch surfaces the default flowRange spec", () => {
+    const r = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "do400",
+      locale: "en",
+      specKeys: DEFAULT_FEATURED_SPEC_KEYS,
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([
+      { label: "lbl:flowRange", value: "100–400 slpm" },
+    ]);
+    expect(r?.slug).toBe("do400");
+    expect(r?.imageUrl).toBe("/products/do400/cutout-2026.png");
+  });
+
+  it("fixture branch surfaces multiple keys in the requested order", () => {
+    const r = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "do400",
+      locale: "en",
+      specKeys: ["maxPressure", "flowRange"],
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([
+      { label: "lbl:maxPressure", value: "<30 bar" },
+      { label: "lbl:flowRange", value: "100–400 slpm" },
+    ]);
+  });
+
+  it("fixture branch silently drops keys whose display value is empty/missing", () => {
+    const r = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "do400",
+      locale: "en",
+      specKeys: ["flowRange", "accuracy", "maxPressure"],
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([
+      { label: "lbl:flowRange", value: "100–400 slpm" },
+      { label: "lbl:maxPressure", value: "<30 bar" },
+    ]);
+  });
+
+  it("fixture branch returns empty specs when massFlowSpecs is absent", () => {
+    const r = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "no-specs",
+      locale: "en",
+      specKeys: ["flowRange", "maxPressure"],
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([]);
+  });
+
+  it("fixture branch picks the locale-specific productLabel/description", () => {
+    const en = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "do400",
+      locale: "en",
+      specKeys: DEFAULT_FEATURED_SPEC_KEYS,
+      getSpecLabel: label,
+    });
+    const ko = resolveFeaturedProduct({
+      sanity: null,
+      staticSlug: "do400",
+      locale: "ko",
+      specKeys: DEFAULT_FEATURED_SPEC_KEYS,
+      getSpecLabel: label,
+    });
+    expect(en?.productLabel).toBe("Mass Flow Controller");
+    expect(ko?.productLabel).toBe("MFC-ko");
+    expect(en?.description).toBe("desc-en");
+    expect(ko?.description).toBe("desc-ko");
+  });
+
+  it("sanity branch fills flowRange when present and skips other requested keys", () => {
+    const sanity: SanityFeaturedProduct = {
+      slug: "do400",
+      model: "DO400",
+      series: "specialized",
+      productLabel: { en: "MFC", ko: "ko", zh: "zh" },
+      description: { en: "d", ko: "k", zh: "z" },
+      flowRange: "100–400 slpm",
+      cutout: { asset: { _ref: "image-asset" } },
+    };
+    const r = resolveFeaturedProduct({
+      sanity,
+      staticSlug: "ignored",
+      locale: "en",
+      specKeys: ["flowRange", "maxPressure"],
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([
+      { label: "lbl:flowRange", value: "100–400 slpm" },
+    ]);
+    expect(r?.imageUrl).toBe("https://cdn/x.png");
+  });
+
+  it("sanity branch returns empty specs when flowRange is null", () => {
+    const r = resolveFeaturedProduct({
+      sanity: {
+        slug: "x",
+        model: "X",
+        series: "analogue",
+        flowRange: null,
+      },
+      staticSlug: undefined,
+      locale: "en",
+      specKeys: ["flowRange"],
+      getSpecLabel: label,
+    });
+    expect(r?.specs).toEqual([]);
+    expect(r?.imageUrl).toBeNull();
+  });
+});

--- a/src/lib/applications/resolveFeaturedProduct.ts
+++ b/src/lib/applications/resolveFeaturedProduct.ts
@@ -1,0 +1,81 @@
+import {
+  type FeaturedApplicationProductInput,
+  type FeaturedApplicationProductSpec,
+} from "@/components/applications/FeaturedApplicationProduct";
+import type { Locale } from "@/lib/content/home";
+import { productBySlug } from "@/lib/fixtures/products";
+import type { MassFlowSpecs, Product } from "@/lib/types/product";
+import { urlFor } from "@/sanity/imageUrl";
+
+export type SanityFeaturedProduct = {
+  slug: string;
+  model: string;
+  series: Product["series"];
+  productLabel?: Record<string, string> | null;
+  description?: Record<string, string> | null;
+  flowRange?: string | null;
+  image?: { asset?: { _ref: string } } | null;
+  cutout?: { asset?: { _ref: string } } | null;
+};
+
+export const DEFAULT_FEATURED_SPEC_KEYS: ReadonlyArray<keyof MassFlowSpecs> = [
+  "flowRange",
+];
+
+export function resolveFeaturedProduct({
+  sanity,
+  staticSlug,
+  locale,
+  specKeys,
+  getSpecLabel,
+}: {
+  sanity: SanityFeaturedProduct | null;
+  staticSlug: string | undefined;
+  locale: Locale;
+  specKeys: ReadonlyArray<keyof MassFlowSpecs>;
+  getSpecLabel: (key: keyof MassFlowSpecs) => string;
+}): FeaturedApplicationProductInput | null {
+  if (sanity) {
+    const cutoutOrImage = sanity.cutout ?? sanity.image ?? null;
+    // The Sanity featured-product schema only carries `flowRange` today;
+    // any other requested key is skipped silently until the schema is extended.
+    const specs: FeaturedApplicationProductSpec[] = [];
+    for (const key of specKeys) {
+      if (key === "flowRange" && sanity.flowRange) {
+        specs.push({ label: getSpecLabel(key), value: sanity.flowRange });
+      }
+    }
+    return {
+      slug: sanity.slug,
+      model: sanity.model,
+      series: sanity.series,
+      productLabel: sanity.productLabel?.[locale] ?? null,
+      description: sanity.description?.[locale] ?? null,
+      specs,
+      imageUrl: cutoutOrImage?.asset
+        ? urlFor(cutoutOrImage).width(960).url()
+        : null,
+    };
+  }
+
+  if (!staticSlug) return null;
+  const fixture = productBySlug(staticSlug);
+  if (!fixture) return null;
+
+  const massFlowSpecs = fixture.massFlowSpecs;
+  const specs: FeaturedApplicationProductSpec[] = [];
+  for (const key of specKeys) {
+    const value = massFlowSpecs?.[key]?.display;
+    if (value) specs.push({ label: getSpecLabel(key), value });
+  }
+
+  return {
+    slug: fixture.slug.current,
+    model: fixture.model,
+    series: fixture.series,
+    productLabel: fixture.productLabel[locale] ?? null,
+    description: fixture.description?.[locale] ?? null,
+    specs,
+    imageUrl: `/products/${fixture.slug.current}/cutout-2026.png`,
+  };
+}

--- a/src/lib/content/applications.ts
+++ b/src/lib/content/applications.ts
@@ -1,4 +1,5 @@
 import type { CategorySlug } from "@/lib/categories";
+import type { MassFlowSpecs } from "@/lib/types/product";
 import type { Locale } from "./home";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -14,6 +15,11 @@ export type ApplicationEntry = {
   featuredProductSlug?: string;
   /** Application-specific "why we're featuring this" copy. 1–3 sentences. */
   featuredProductCaption?: string;
+  /**
+   * Which `massFlowSpecs` keys to surface as `<dt>/<dd>` rows on the spotlight.
+   * Keep to ≤3 — more crowds the "Why this one" copy. Defaults to `["flowRange"]`.
+   */
+  featuredSpecKeys?: ReadonlyArray<keyof MassFlowSpecs>;
 };
 
 export type ApplicationsContent = {
@@ -26,7 +32,6 @@ export type ApplicationsContent = {
   contactCtaHref: string;
   featuredKicker: string;
   featuredWhyHeading: string;
-  featuredFlowRangeLabel: string;
   featuredViewProduct: string;
   applications: ApplicationEntry[];
 };
@@ -45,7 +50,6 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
     contactCtaHref: "/contact",
     featuredKicker: "Spotlight",
     featuredWhyHeading: "Why this one",
-    featuredFlowRangeLabel: "Flow range",
     featuredViewProduct: "View product →",
     applications: [
       {
@@ -74,6 +78,7 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
         featuredProductSlug: "do400",
         featuredProductCaption:
           "Purpose-built for PEM and SOFC stack-level H₂ and O₂ feeds — delivers the stoichiometric ratios these cells require without over-pressuring the membrane. The matched MFM variant handles the monitoring side of the same loop on the same calibration.",
+        featuredSpecKeys: ["flowRange", "maxPressure"],
       },
       {
         slug: "biotech-pharmaceutical",
@@ -209,7 +214,6 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
     contactCtaHref: "/contact",
     featuredKicker: "추천 제품",
     featuredWhyHeading: "이 제품을 추천하는 이유",
-    featuredFlowRangeLabel: "유량 범위",
     featuredViewProduct: "제품 보기 →",
     applications: [
       {
@@ -238,6 +242,7 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
         featuredProductSlug: "do400",
         featuredProductCaption:
           "PEM·SOFC 스택 수준의 수소·산소 공급을 위해 설계되어, 막 손상 없이 셀이 요구하는 화학양론적 비율을 정확히 전달합니다. 동일 교정 기반의 MFM 변형 제품이 같은 루프의 모니터링 측을 함께 담당합니다.",
+        featuredSpecKeys: ["flowRange", "maxPressure"],
       },
       {
         slug: "biotech-pharmaceutical",
@@ -373,7 +378,6 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
     contactCtaHref: "/contact",
     featuredKicker: "重点产品",
     featuredWhyHeading: "为什么是这款",
-    featuredFlowRangeLabel: "流量范围",
     featuredViewProduct: "查看产品 →",
     applications: [
       {
@@ -402,6 +406,7 @@ export const LT_APPLICATIONS: Record<Locale, ApplicationsContent> = {
         featuredProductSlug: "do400",
         featuredProductCaption:
           "专为 PEM 与 SOFC 电堆级氢气、氧气供给而设计——在不令膜过压的前提下，精准实现这些电池所需的化学计量比。同一校准下的 MFM 变型可同步承担该回路的监控侧。",
+        featuredSpecKeys: ["flowRange", "maxPressure"],
       },
       {
         slug: "biotech-pharmaceutical",


### PR DESCRIPTION
## Summary

- The DO400 spotlight on `/applications/fuel-cells` only showed Flow range, even though the "Why this one" copy already alludes to pressure ("…without over-pressuring the membrane"). Adds a typed per-application `featuredSpecKeys` list so each Application page picks which `massFlowSpecs` rows to surface — fuel-cells now shows Flow range + Max pressure.
- Labels now come from the shared `product.specs` next-intl namespace (the same source SpecTable uses on PDPs), so per-page `featuredFlowRangeLabel` strings are dropped. Other Application pages can opt in by adding their own `featuredSpecKeys` (e.g. semiconductor → `["flowRange", "responseTime"]`).
- Sanity featured-product fallback preserved: it currently carries only `flowRange`, so any other requested key is silently skipped until the Sanity schema is extended.

## Test plan

- [x] `pnpm test:run src/components/applications/FeaturedApplicationProduct.test.tsx` — 6 passing (incl. new multi-row + empty/undefined-specs cases)
- [x] `pnpm typecheck` — clean on touched files (one pre-existing unrelated error in `AccessoriesSideNav.test.tsx`)
- [x] Dev server visual check on `/en|ko|zh/applications/fuel-cells` — two rows render with localized labels (Flow range / Max pressure · 유량 범위 / 최대 압력 · 流量范围 / 最大压力)
- [x] `/en/applications/semiconductor` (no featured product) — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)