### PR TITLE
feat(finder): gas mixture mode + operating pressure filter (#230)

### DIFF
--- a/e2e/product-finder.spec.ts
+++ b/e2e/product-finder.spec.ts
@@ -25,7 +25,10 @@ test.describe("Product finder", () => {
     ).toBeVisible();
 
     // Default gas is Nitrogen — leave it. Enter 250 slpm.
-    await page.getByRole("spinbutton").fill("250");
+    await page
+      .getByRole("group", { name: "Target flow rate" })
+      .getByRole("spinbutton")
+      .fill("250");
 
     // Wait for at least one result card to appear.
     const resultCards = page.locator(".lt-finder__result");
@@ -42,7 +45,11 @@ test.describe("Product finder", () => {
     await page.goto(
       "/en/products/finder?fn=MFC&gas=nitrogen&flow=250&unit=slpm",
     );
-    await expect(page.getByRole("spinbutton")).toHaveValue("250");
+    await expect(
+      page
+        .getByRole("group", { name: "Target flow rate" })
+        .getByRole("spinbutton"),
+    ).toHaveValue("250");
     await expect(page.locator(".lt-finder__result").first()).toBeVisible({
       timeout: 5000,
     });
@@ -52,7 +59,10 @@ test.describe("Product finder", () => {
     page,
   }) => {
     await page.goto("/en/products/finder");
-    await page.getByRole("spinbutton").fill("99999999");
+    await page
+      .getByRole("group", { name: "Target flow rate" })
+      .getByRole("spinbutton")
+      .fill("99999999");
     await expect(
       page.getByText(/no products fit those requirements/i),
     ).toBeVisible({ timeout: 5000 });
@@ -93,5 +103,67 @@ test.describe("Product finder", () => {
     const results = page.locator(".lt-finder__result");
     await expect(results).toHaveCount(1, { timeout: 5000 });
     await expect(results.first()).toContainText("MS3600VA");
+  });
+
+  test("mixture mode: switch toggle, enter components, see results", async ({
+    page,
+  }) => {
+    await page.goto("/en/products/finder");
+
+    // Switch to Mixture mode.
+    await page.getByRole("radio", { name: "Mixture" }).click();
+    await expect(page.locator(".lt-mix__rows")).toBeVisible();
+
+    // Two seed rows render and the × button is hidden at the minimum row count.
+    const rows = page.locator(".lt-mix__row");
+    await expect(rows).toHaveCount(2);
+    await expect(
+      page.getByRole("button", { name: "Remove component" }),
+    ).toHaveCount(0);
+
+    // Set 95/5 N₂/SiH₄ via the two percent inputs.
+    const percentInputs = page.locator(".lt-mix__row-percent input");
+    await percentInputs.nth(0).fill("95");
+    await percentInputs.nth(1).fill("5");
+    await expect(page.locator(".lt-mix__total--ok")).toBeVisible();
+
+    // Enter a flow and confirm at least one result appears.
+    await page
+      .getByRole("group", { name: "Target flow rate" })
+      .getByRole("spinbutton")
+      .fill("100");
+    await expect(page.locator(".lt-finder__result").first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("mixture URL params pre-fill the mixture editor", async ({ page }) => {
+    await page.goto(
+      "/en/products/finder?fn=MFC&gasMix=silane:5,nitrogen:95&flow=100&unit=slpm",
+    );
+    await expect(
+      page.getByRole("radio", { name: "Mixture", checked: true }),
+    ).toBeVisible();
+    const percentInputs = page.locator(".lt-mix__row-percent input");
+    await expect(percentInputs.nth(0)).toHaveValue("5");
+    await expect(percentInputs.nth(1)).toHaveValue("95");
+    await expect(page.locator(".lt-finder__result").first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("pressure filter narrows matches (LEPC drops out beyond its range)", async ({
+    page,
+  }) => {
+    // 0.1–6 barA: 2 bar is in range, 50 bar is not.
+    await page.goto("/en/products/finder?fn=EPC&p=2&pu=bar");
+    await expect(
+      page.locator(".lt-finder__result").filter({ hasText: "LEPC" }),
+    ).toHaveCount(1);
+
+    await page.goto("/en/products/finder?fn=EPC&p=50&pu=bar");
+    await expect(
+      page.locator(".lt-finder__result").filter({ hasText: "LEPC" }),
+    ).toHaveCount(0);
   });
 });

--- a/e2e/product-finder.spec.ts
+++ b/e2e/product-finder.spec.ts
@@ -125,7 +125,7 @@ test.describe("Product finder", () => {
     const percentInputs = page.locator(".lt-mix__row-percent input");
     await percentInputs.nth(0).fill("95");
     await percentInputs.nth(1).fill("5");
-    await expect(page.locator(".lt-mix__total--ok")).toBeVisible();
+    await expect(page.locator('.lt-mix__total[data-state="ok"]')).toBeVisible();
 
     // Enter a flow and confirm at least one result appears.
     await page
@@ -155,7 +155,10 @@ test.describe("Product finder", () => {
   test("pressure filter narrows matches (LEPC drops out beyond its range)", async ({
     page,
   }) => {
-    // 0.1–6 barA: 2 bar is in range, 50 bar is not.
+    // Brittleness note: anchors on LEPC's published `pressureRange`
+    // (0.1–6 barA today). A Sanity content edit that widens that range will
+    // break this test with no code change — re-anchor to whichever EPC owns
+    // a narrow range below 50 bar at that point.
     await page.goto("/en/products/finder?fn=EPC&p=2&pu=bar");
     await expect(
       page.locator(".lt-finder__result").filter({ hasText: "LEPC" }),

--- a/messages/en.json
+++ b/messages/en.json
@@ -181,7 +181,8 @@
     },
     "pressure": {
       "label": "Operating pressure (optional)",
-      "placeholder": "e.g. 2"
+      "placeholder": "e.g. 2",
+      "unitAria": "Pressure unit"
     },
     "series": {
       "label": "Series",

--- a/messages/en.json
+++ b/messages/en.json
@@ -162,7 +162,15 @@
       "placeholder": "Search by name or formula…",
       "commonLabel": "Common",
       "allLabel": "All gases",
-      "empty": "No gases match"
+      "empty": "No gases match",
+      "modeLabel": "Gas mode",
+      "modePure": "Pure gas",
+      "modeMixture": "Mixture",
+      "mixtureLegend": "Gas components",
+      "percentAria": "Component percent",
+      "addComponent": "Add component",
+      "removeComponent": "Remove component",
+      "totalLabel": "Total"
     },
     "flow": {
       "label": "Target flow rate",
@@ -170,6 +178,10 @@
         "slpm": "slpm",
         "sccm": "sccm"
       }
+    },
+    "pressure": {
+      "label": "Operating pressure (optional)",
+      "placeholder": "e.g. 2"
     },
     "series": {
       "label": "Series",
@@ -188,7 +200,8 @@
       "rankGood": "Good fit",
       "rankEdge": "Edge of range"
     },
-    "convertedNote": "≈ {n2} slpm N₂-equivalent"
+    "convertedNote": "≈ {n2} slpm N₂-equivalent",
+    "convertedNoteMix": "{mix} ≈ {n2} slpm N₂-equivalent"
   },
   "pdp": {
     "tabs": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -162,7 +162,15 @@
       "placeholder": "가스명 또는 화학식으로 검색…",
       "commonLabel": "자주 사용되는 가스",
       "allLabel": "전체 가스",
-      "empty": "일치하는 가스가 없습니다"
+      "empty": "일치하는 가스가 없습니다",
+      "modeLabel": "가스 모드",
+      "modePure": "단일 가스",
+      "modeMixture": "혼합 가스",
+      "mixtureLegend": "구성 가스",
+      "percentAria": "성분 비율",
+      "addComponent": "성분 추가",
+      "removeComponent": "성분 제거",
+      "totalLabel": "합계"
     },
     "flow": {
       "label": "목표 유량",
@@ -170,6 +178,10 @@
         "slpm": "slpm",
         "sccm": "sccm"
       }
+    },
+    "pressure": {
+      "label": "작동 압력 (선택)",
+      "placeholder": "예: 2"
     },
     "series": {
       "label": "시리즈",
@@ -188,7 +200,8 @@
       "rankGood": "적합",
       "rankEdge": "유량 범위 끝단"
     },
-    "convertedNote": "≈ {n2} slpm N₂ 환산"
+    "convertedNote": "≈ {n2} slpm N₂ 환산",
+    "convertedNoteMix": "{mix} ≈ {n2} slpm (N₂ 환산)"
   },
   "pdp": {
     "tabs": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -181,7 +181,8 @@
     },
     "pressure": {
       "label": "작동 압력 (선택)",
-      "placeholder": "예: 2"
+      "placeholder": "예: 2",
+      "unitAria": "압력 단위"
     },
     "series": {
       "label": "시리즈",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -162,7 +162,15 @@
       "placeholder": "按名称或化学式搜索…",
       "commonLabel": "常用气体",
       "allLabel": "全部气体",
-      "empty": "未找到匹配的气体"
+      "empty": "未找到匹配的气体",
+      "modeLabel": "气体模式",
+      "modePure": "单一气体",
+      "modeMixture": "混合气体",
+      "mixtureLegend": "组分",
+      "percentAria": "组分百分比",
+      "addComponent": "添加组分",
+      "removeComponent": "移除组分",
+      "totalLabel": "合计"
     },
     "flow": {
       "label": "目标流量",
@@ -170,6 +178,10 @@
         "slpm": "slpm",
         "sccm": "sccm"
       }
+    },
+    "pressure": {
+      "label": "工作压力 (可选)",
+      "placeholder": "如: 2"
     },
     "series": {
       "label": "系列",
@@ -188,7 +200,8 @@
       "rankGood": "适合",
       "rankEdge": "范围边缘"
     },
-    "convertedNote": "≈ {n2} slpm N₂ 等效流量"
+    "convertedNote": "≈ {n2} slpm N₂ 等效流量",
+    "convertedNoteMix": "{mix} ≈ {n2} slpm（N₂ 等效）"
   },
   "pdp": {
     "tabs": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -181,7 +181,8 @@
     },
     "pressure": {
       "label": "工作压力 (可选)",
-      "placeholder": "如: 2"
+      "placeholder": "如: 2",
+      "unitAria": "压力单位"
     },
     "series": {
       "label": "系列",

--- a/src/app/[locale]/products/finder/page.tsx
+++ b/src/app/[locale]/products/finder/page.tsx
@@ -6,16 +6,9 @@ import { allProductsQuery } from "@/sanity/queries";
 import { SanityProductSchema } from "@/lib/types/product";
 import { buildFinderMetadata } from "@/lib/seo";
 import type { Locale } from "@/lib/content/home";
-import {
-  ProductFinder,
-  type ProductFinderInitial,
-} from "@/components/finder/ProductFinder";
+import { ProductFinder } from "@/components/finder/ProductFinder";
+import { parseFinderUrl } from "@/lib/finder/parseFinderUrl";
 import "./finder-page.css";
-import type {
-  FinderFunction,
-  FinderSeries,
-  FinderUnit,
-} from "@/lib/finder/match";
 
 export const revalidate = 3600;
 
@@ -29,59 +22,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildFinderMetadata(locale as Locale);
 }
 
-const FUNCTIONS: ReadonlySet<FinderFunction> = new Set([
-  "any",
-  "MFC",
-  "MFM",
-  "EPC",
-]);
-const SERIES: ReadonlySet<FinderSeries> = new Set([
-  "any",
-  "analogue",
-  "digital",
-  "specialized",
-  "lepc",
-]);
-const UNITS: ReadonlySet<FinderUnit> = new Set(["slpm", "sccm"]);
-
-function pickString(value: string | string[] | undefined): string | undefined {
-  if (Array.isArray(value)) return value[0];
-  return value;
-}
-
-function parseInitial(
-  raw: Record<string, string | string[] | undefined>,
-): ProductFinderInitial {
-  const initial: ProductFinderInitial = {};
-  const fn = pickString(raw.fn);
-  if (fn && FUNCTIONS.has(fn as FinderFunction)) {
-    initial.fn = fn as FinderFunction;
-  }
-  const gas = pickString(raw.gas);
-  if (gas) initial.gas = gas;
-  const flow = pickString(raw.flow);
-  if (flow) {
-    const n = Number(flow);
-    if (Number.isFinite(n) && n > 0) initial.flow = n;
-  }
-  const unit = pickString(raw.unit);
-  if (unit && UNITS.has(unit as FinderUnit)) {
-    initial.unit = unit as FinderUnit;
-  }
-  const series = pickString(raw.series);
-  if (series && SERIES.has(series as FinderSeries)) {
-    initial.series = series as FinderSeries;
-  }
-  return initial;
-}
-
 export default async function ProductFinderPage({
   params,
   searchParams,
 }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
-  const initial = parseInitial(await searchParams);
+  const initial = parseFinderUrl(await searchParams);
 
   const [tCommon, tNav, tFinder] = await Promise.all([
     getTranslations("common"),

--- a/src/components/accessories/AccessoriesSideNav.test.tsx
+++ b/src/components/accessories/AccessoriesSideNav.test.tsx
@@ -13,7 +13,7 @@ const NAV: AccessoriesNavNode[] = [
     label: "Read-out units",
     href: "#readouts",
     children: [
-      { id: "lti-200", label: "LTI-200", href: "#lti-200" },
+      { id: "lti-2000", label: "LTI-200", href: "#lti-2000" },
       { id: "lti-1000", label: "LTI-1000", href: "#lti-1000" },
     ],
   },
@@ -24,7 +24,12 @@ const NAV: AccessoriesNavNode[] = [
   },
 ];
 
-const SECTION_IDS = ["readouts", "lti-200", "lti-1000", "pressure-accessories"];
+const SECTION_IDS = [
+  "readouts",
+  "lti-2000",
+  "lti-1000",
+  "pressure-accessories",
+];
 
 function stageSectionTargets() {
   for (const id of SECTION_IDS) {
@@ -84,7 +89,7 @@ describe("AccessoriesSideNav", () => {
     const { container } = renderNav();
 
     act(() => {
-      io.fire([{ id: "lti-200", isIntersecting: true }]);
+      io.fire([{ id: "lti-2000", isIntersecting: true }]);
     });
 
     const sublinks = container.querySelectorAll(".acc-nav__sublink");
@@ -118,7 +123,7 @@ describe("AccessoriesSideNav", () => {
 
     act(() => {
       io.fire([
-        { id: "lti-200", isIntersecting: true },
+        { id: "lti-2000", isIntersecting: true },
         { id: "readouts", isIntersecting: true },
       ]);
     });

--- a/src/components/accessories/AccessoriesSideNav.test.tsx
+++ b/src/components/accessories/AccessoriesSideNav.test.tsx
@@ -13,7 +13,7 @@ const NAV: AccessoriesNavNode[] = [
     label: "Read-out units",
     href: "#readouts",
     children: [
-      { id: "lti-2000", label: "LTI-200", href: "#lti-2000" },
+      { id: "lti-2000", label: "LTI-2000", href: "#lti-2000" },
       { id: "lti-1000", label: "LTI-1000", href: "#lti-1000" },
     ],
   },

--- a/src/components/finder/ProductFinder/FlowInput.tsx
+++ b/src/components/finder/ProductFinder/FlowInput.tsx
@@ -20,7 +20,7 @@ export function FlowInput({
   return (
     <fieldset className="lt-finder__group">
       <legend className="lt-finder__label">{labels.legend}</legend>
-      <div className="lt-finder__flow">
+      <div className="lt-finder__input-row">
         <input
           type="number"
           inputMode="decimal"

--- a/src/components/finder/ProductFinder/GasSelect.tsx
+++ b/src/components/finder/ProductFinder/GasSelect.tsx
@@ -17,6 +17,8 @@ type Props = {
     all: string;
     empty: string;
   };
+  /** When true, render just the combobox (no fieldset/legend) — caller owns the label. */
+  hideLabel?: boolean;
 };
 
 function gasMatches(gas: GasFactor, normalizedQuery: string): boolean {
@@ -28,7 +30,12 @@ function renderLabel(gas: GasFactor): string {
   return `${gas.formula} — ${gas.names.en}`;
 }
 
-export function GasSelect({ value, onChange, labels }: Props) {
+export function GasSelect({
+  value,
+  onChange,
+  labels,
+  hideLabel = false,
+}: Props) {
   const id = useId();
   const wrapRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -111,116 +118,118 @@ export function GasSelect({ value, onChange, labels }: Props) {
 
   const listboxId = `${id}-listbox`;
 
+  const body = (
+    <div ref={wrapRef} className="lt-finder__combo">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && flatOptions[activeIndex]
+            ? `${id}-opt-${activeIndex}`
+            : undefined
+        }
+        className="lt-finder__combo-input"
+        placeholder={labels.placeholder}
+        value={inputDisplay}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setActiveIndex(0);
+          if (!open) setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+      />
+      {open && (
+        <ul
+          id={listboxId}
+          ref={listRef}
+          role="listbox"
+          aria-labelledby={`${id}-label`}
+          className="lt-finder__combo-list"
+        >
+          {flatOptions.length === 0 ? (
+            <li className="lt-finder__combo-empty" role="presentation">
+              {labels.empty}
+            </li>
+          ) : (
+            <>
+              {pinned.length > 0 && (
+                <li className="lt-finder__combo-heading" role="presentation">
+                  {labels.common}
+                </li>
+              )}
+              {pinned.map((g, i) => {
+                const idx = i;
+                const isActive = idx === activeIndex;
+                return (
+                  <li
+                    key={g.id}
+                    id={`${id}-opt-${idx}`}
+                    role="option"
+                    aria-selected={isActive}
+                    data-finder-option-index={idx}
+                    className={`lt-finder__combo-opt${isActive ? " lt-finder__combo-opt--active" : ""}`}
+                    onPointerDown={(e) => {
+                      e.preventDefault();
+                      commit(g);
+                    }}
+                    onPointerEnter={() => setActiveIndex(idx)}
+                  >
+                    <span className="lt-finder__combo-formula">
+                      {g.formula}
+                    </span>
+                    <span className="lt-finder__combo-name">{g.names.en}</span>
+                  </li>
+                );
+              })}
+              {rest.length > 0 && (
+                <li className="lt-finder__combo-heading" role="presentation">
+                  {labels.all}
+                </li>
+              )}
+              {rest.map((g, i) => {
+                const idx = pinned.length + i;
+                const isActive = idx === activeIndex;
+                return (
+                  <li
+                    key={g.id}
+                    id={`${id}-opt-${idx}`}
+                    role="option"
+                    aria-selected={isActive}
+                    data-finder-option-index={idx}
+                    className={`lt-finder__combo-opt${isActive ? " lt-finder__combo-opt--active" : ""}`}
+                    onPointerDown={(e) => {
+                      e.preventDefault();
+                      commit(g);
+                    }}
+                    onPointerEnter={() => setActiveIndex(idx)}
+                  >
+                    <span className="lt-finder__combo-formula">
+                      {g.formula}
+                    </span>
+                    <span className="lt-finder__combo-name">{g.names.en}</span>
+                  </li>
+                );
+              })}
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+
+  if (hideLabel) return body;
+
   return (
     <fieldset className="lt-finder__group">
       <legend id={`${id}-label`} className="lt-finder__label">
         {labels.legend}
       </legend>
-      <div ref={wrapRef} className="lt-finder__combo">
-        <input
-          ref={inputRef}
-          type="text"
-          role="combobox"
-          aria-expanded={open}
-          aria-controls={listboxId}
-          aria-autocomplete="list"
-          aria-activedescendant={
-            open && flatOptions[activeIndex]
-              ? `${id}-opt-${activeIndex}`
-              : undefined
-          }
-          className="lt-finder__combo-input"
-          placeholder={labels.placeholder}
-          value={inputDisplay}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setActiveIndex(0);
-            if (!open) setOpen(true);
-          }}
-          onFocus={() => setOpen(true)}
-          onKeyDown={onKeyDown}
-        />
-        {open && (
-          <ul
-            id={listboxId}
-            ref={listRef}
-            role="listbox"
-            aria-labelledby={`${id}-label`}
-            className="lt-finder__combo-list"
-          >
-            {flatOptions.length === 0 ? (
-              <li className="lt-finder__combo-empty" role="presentation">
-                {labels.empty}
-              </li>
-            ) : (
-              <>
-                {pinned.length > 0 && (
-                  <li className="lt-finder__combo-heading" role="presentation">
-                    {labels.common}
-                  </li>
-                )}
-                {pinned.map((g, i) => {
-                  const idx = i;
-                  const isActive = idx === activeIndex;
-                  return (
-                    <li
-                      key={g.id}
-                      id={`${id}-opt-${idx}`}
-                      role="option"
-                      aria-selected={isActive}
-                      data-finder-option-index={idx}
-                      className={`lt-finder__combo-opt${isActive ? " lt-finder__combo-opt--active" : ""}`}
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        commit(g);
-                      }}
-                      onPointerEnter={() => setActiveIndex(idx)}
-                    >
-                      <span className="lt-finder__combo-formula">
-                        {g.formula}
-                      </span>
-                      <span className="lt-finder__combo-name">
-                        {g.names.en}
-                      </span>
-                    </li>
-                  );
-                })}
-                {rest.length > 0 && (
-                  <li className="lt-finder__combo-heading" role="presentation">
-                    {labels.all}
-                  </li>
-                )}
-                {rest.map((g, i) => {
-                  const idx = pinned.length + i;
-                  const isActive = idx === activeIndex;
-                  return (
-                    <li
-                      key={g.id}
-                      id={`${id}-opt-${idx}`}
-                      role="option"
-                      aria-selected={isActive}
-                      data-finder-option-index={idx}
-                      className={`lt-finder__combo-opt${isActive ? " lt-finder__combo-opt--active" : ""}`}
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        commit(g);
-                      }}
-                      onPointerEnter={() => setActiveIndex(idx)}
-                    >
-                      <span className="lt-finder__combo-formula">
-                        {g.formula}
-                      </span>
-                      <span className="lt-finder__combo-name">
-                        {g.names.en}
-                      </span>
-                    </li>
-                  );
-                })}
-              </>
-            )}
-          </ul>
-        )}
-      </div>
+      {body}
     </fieldset>
   );
 }

--- a/src/components/finder/ProductFinder/MixtureEditor.test.tsx
+++ b/src/components/finder/ProductFinder/MixtureEditor.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { GasComponent } from "@/lib/finder/mixture";
+import { MixtureEditor, defaultMixtureComponents } from "./MixtureEditor";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const LABELS = {
+  gasLegend: "Gas",
+  gasPlaceholder: "Pick a gas",
+  gasCommon: "Common",
+  gasAll: "All",
+  gasEmpty: "No matches",
+  percentAria: "Component percent",
+  addComponent: "Add component",
+  removeComponent: "Remove component",
+  totalLabel: "Total",
+};
+
+function setup(initial: GasComponent[] = defaultMixtureComponents()) {
+  const onChange = vi.fn();
+  let value = initial;
+  const { rerender } = render(
+    <MixtureEditor
+      components={value}
+      onChange={(next) => {
+        value = next;
+        onChange(next);
+        rerender(
+          <MixtureEditor
+            components={next}
+            onChange={onChange}
+            labels={LABELS}
+          />,
+        );
+      }}
+      labels={LABELS}
+    />,
+  );
+  return { onChange, get: () => value };
+}
+
+describe("<MixtureEditor />", () => {
+  it("renders two seed rows by default and hides the remove buttons", () => {
+    setup();
+    const removeButtons = screen.queryAllByRole("button", {
+      name: "Remove component",
+    });
+    expect(removeButtons).toHaveLength(0);
+    expect(
+      screen.getByRole("button", { name: /Add component/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("adds a row when '+ Add component' is clicked, exposing remove buttons", () => {
+    const { get } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Add component/ }));
+    expect(get()).toHaveLength(3);
+    expect(
+      screen.getAllByRole("button", { name: "Remove component" }),
+    ).toHaveLength(3);
+  });
+
+  it("updates a component percent on input", () => {
+    const { get } = setup();
+    const inputs = screen.getAllByRole("spinbutton");
+    fireEvent.change(inputs[0], { target: { value: "90" } });
+    expect(get()[0].percent).toBe(90);
+  });
+
+  it("removes a row when × clicked (only available with 3+ rows)", () => {
+    const { get } = setup([
+      { gasId: "nitrogen", percent: 80 },
+      { gasId: "oxygen", percent: 10 },
+      { gasId: "argon", percent: 10 },
+    ]);
+    const removes = screen.getAllByRole("button", {
+      name: "Remove component",
+    });
+    expect(removes).toHaveLength(3);
+    fireEvent.click(removes[2]);
+    expect(get()).toHaveLength(2);
+  });
+
+  it("flags the total as ok when components sum to 100", () => {
+    setup([
+      { gasId: "nitrogen", percent: 95 },
+      { gasId: "silane", percent: 5 },
+    ]);
+    const total = screen.getByRole("status");
+    expect(total.className).toContain("lt-mix__total--ok");
+    expect(total.textContent).toMatch(/100/);
+  });
+
+  it("flags the total as bad when components do not sum to 100", () => {
+    setup([
+      { gasId: "nitrogen", percent: 80 },
+      { gasId: "silane", percent: 5 },
+    ]);
+    const total = screen.getByRole("status");
+    expect(total.className).toContain("lt-mix__total--bad");
+    expect(total.textContent).toMatch(/85/);
+  });
+});

--- a/src/components/finder/ProductFinder/MixtureEditor.test.tsx
+++ b/src/components/finder/ProductFinder/MixtureEditor.test.tsx
@@ -84,23 +84,43 @@ describe("<MixtureEditor />", () => {
     expect(get()).toHaveLength(2);
   });
 
-  it("flags the total as ok when components sum to 100", () => {
+  it("marks the total data-state=ok when components sum to 100", () => {
     setup([
       { gasId: "nitrogen", percent: 95 },
       { gasId: "silane", percent: 5 },
     ]);
     const total = screen.getByRole("status");
-    expect(total.className).toContain("lt-mix__total--ok");
-    expect(total.textContent).toMatch(/100/);
+    expect(total).toHaveAttribute("data-state", "ok");
+    expect(total).toHaveTextContent(/100/);
   });
 
-  it("flags the total as bad when components do not sum to 100", () => {
+  it("marks the total data-state=bad when components do not sum to 100", () => {
     setup([
       { gasId: "nitrogen", percent: 80 },
       { gasId: "silane", percent: 5 },
     ]);
     const total = screen.getByRole("status");
-    expect(total.className).toContain("lt-mix__total--bad");
-    expect(total.textContent).toMatch(/85/);
+    expect(total).toHaveAttribute("data-state", "bad");
+    expect(total).toHaveTextContent(/85/);
+  });
+
+  it("gives each percent input a distinct row-numbered aria-label", () => {
+    setup();
+    expect(screen.getByLabelText("Component percent 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Component percent 2")).toBeInTheDocument();
+  });
+
+  it("hides the % glyph from assistive tech (aria-hidden)", () => {
+    const { container } = render(
+      <MixtureEditor
+        components={defaultMixtureComponents()}
+        onChange={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const glyphs = container.querySelectorAll('[aria-hidden="true"]');
+    // One per row: the visual "%" glyph next to each number input.
+    expect(glyphs.length).toBeGreaterThanOrEqual(2);
+    for (const g of glyphs) expect(g.textContent).toBe("%");
   });
 });

--- a/src/components/finder/ProductFinder/MixtureEditor.tsx
+++ b/src/components/finder/ProductFinder/MixtureEditor.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 const DEFAULT_GAS = "nitrogen";
 
-/** Two empty seed rows — the QuoteFields convention. */
+/** Seed with two empty rows so users see this is a multi-component editor. */
 export function defaultMixtureComponents(): GasComponent[] {
   return [
     { gasId: DEFAULT_GAS, percent: 0 },
@@ -83,6 +83,9 @@ export function MixtureEditor({ components, onChange, labels }: Props) {
                 max={100}
                 step="any"
                 className="lt-finder__num"
+                // A 0% component contributes nothing to the mixture, so we
+                // surface 0 as an empty field with a "0" placeholder — clearer
+                // than displaying a literal "0" the user has to delete.
                 value={component.percent === 0 ? "" : component.percent}
                 placeholder="0"
                 onChange={(e) =>
@@ -115,6 +118,7 @@ export function MixtureEditor({ components, onChange, labels }: Props) {
           className={`lt-mix__total ${totalValid ? "lt-mix__total--ok" : "lt-mix__total--bad"}`}
           role="status"
           aria-live="polite"
+          data-state={totalValid ? "ok" : "bad"}
         >
           {labels.totalLabel}: {formatTotal(totalPercent)}%
         </span>

--- a/src/components/finder/ProductFinder/MixtureEditor.tsx
+++ b/src/components/finder/ProductFinder/MixtureEditor.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import type { GasComponent } from "@/lib/finder/mixture";
+import { isMixturePercentValid } from "@/lib/finder/mixture";
+import { GasSelect } from "./GasSelect";
+
+export type MixtureEditorLabels = {
+  gasLegend: string;
+  gasPlaceholder: string;
+  gasCommon: string;
+  gasAll: string;
+  gasEmpty: string;
+  percentAria: string;
+  addComponent: string;
+  removeComponent: string;
+  totalLabel: string;
+};
+
+type Props = {
+  components: GasComponent[];
+  onChange: (next: GasComponent[]) => void;
+  labels: MixtureEditorLabels;
+};
+
+const DEFAULT_GAS = "nitrogen";
+
+/** Two empty seed rows — the QuoteFields convention. */
+export function defaultMixtureComponents(): GasComponent[] {
+  return [
+    { gasId: DEFAULT_GAS, percent: 0 },
+    { gasId: DEFAULT_GAS, percent: 0 },
+  ];
+}
+
+export function MixtureEditor({ components, onChange, labels }: Props) {
+  const totalPercent = components.reduce(
+    (sum, c) => sum + (Number.isFinite(c.percent) ? c.percent : 0),
+    0,
+  );
+  const totalValid = isMixturePercentValid(totalPercent);
+  const minRows = 2;
+  const canRemove = components.length > minRows;
+
+  function updateAt(index: number, patch: Partial<GasComponent>) {
+    onChange(components.map((c, i) => (i === index ? { ...c, ...patch } : c)));
+  }
+
+  function add() {
+    onChange([...components, { gasId: DEFAULT_GAS, percent: 0 }]);
+  }
+
+  function removeAt(index: number) {
+    if (components.length <= minRows) return;
+    onChange(components.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="lt-mix">
+      <ul
+        className={`lt-mix__rows${canRemove ? " lt-mix__rows--removable" : ""}`}
+      >
+        {components.map((component, index) => (
+          <li key={index} className="lt-mix__row">
+            <div className="lt-mix__row-gas">
+              <GasSelect
+                value={component.gasId}
+                onChange={(gasId) => updateAt(index, { gasId })}
+                hideLabel
+                labels={{
+                  legend: labels.gasLegend,
+                  placeholder: labels.gasPlaceholder,
+                  common: labels.gasCommon,
+                  all: labels.gasAll,
+                  empty: labels.gasEmpty,
+                }}
+              />
+            </div>
+            <label className="lt-mix__row-percent">
+              <input
+                type="number"
+                inputMode="decimal"
+                min={0}
+                max={100}
+                step="any"
+                className="lt-finder__num"
+                value={component.percent === 0 ? "" : component.percent}
+                placeholder="0"
+                onChange={(e) =>
+                  updateAt(index, {
+                    percent: e.target.value === "" ? 0 : Number(e.target.value),
+                  })
+                }
+                aria-label={`${labels.percentAria} ${index + 1}`}
+              />
+              <span aria-hidden="true">%</span>
+            </label>
+            {canRemove && (
+              <button
+                type="button"
+                onClick={() => removeAt(index)}
+                className="lt-mix__row-remove"
+                aria-label={labels.removeComponent}
+              >
+                ×
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      <div className="lt-mix__actions">
+        <button type="button" className="lt-mix__add" onClick={add}>
+          + {labels.addComponent}
+        </button>
+        <span
+          className={`lt-mix__total ${totalValid ? "lt-mix__total--ok" : "lt-mix__total--bad"}`}
+          role="status"
+          aria-live="polite"
+        >
+          {labels.totalLabel}: {formatTotal(totalPercent)}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function formatTotal(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : Number(value.toFixed(4)).toString();
+}

--- a/src/components/finder/ProductFinder/PressureInput.test.tsx
+++ b/src/components/finder/ProductFinder/PressureInput.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PressureInput } from "./PressureInput";
+
+const LABELS = {
+  legend: "Operating pressure",
+  placeholder: "e.g. 2",
+  unitAria: "Pressure unit",
+};
+
+function setup(
+  initial: { pressure: number | ""; unit?: "bar" | "kPa" } = {
+    pressure: "",
+  },
+) {
+  const onPressureChange = vi.fn();
+  const onUnitChange = vi.fn();
+  render(
+    <PressureInput
+      pressure={initial.pressure}
+      unit={initial.unit ?? "bar"}
+      onPressureChange={onPressureChange}
+      onUnitChange={onUnitChange}
+      labels={LABELS}
+    />,
+  );
+  return { onPressureChange, onUnitChange };
+}
+
+describe("<PressureInput />", () => {
+  it("emits the numeric value when the user types a number", () => {
+    const { onPressureChange } = setup();
+    fireEvent.change(screen.getByRole("spinbutton"), {
+      target: { value: "5" },
+    });
+    expect(onPressureChange).toHaveBeenCalledWith(5);
+  });
+
+  it("emits empty-string when the user clears the field", () => {
+    const { onPressureChange } = setup({ pressure: 5 });
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+    expect(onPressureChange).toHaveBeenCalledWith("");
+  });
+
+  it("does not emit when the user types non-numeric garbage", () => {
+    const { onPressureChange } = setup();
+    // Native number inputs strip non-numeric text via the browser; jsdom
+    // delivers an empty value here. Either way, the handler must not invoke
+    // with NaN — its `Number.isFinite` guard owns that contract.
+    fireEvent.change(screen.getByRole("spinbutton"), {
+      target: { value: "abc" },
+    });
+    for (const call of onPressureChange.mock.calls) {
+      expect(call[0] === "" || Number.isFinite(call[0])).toBe(true);
+    }
+  });
+
+  it("emits the unit change without touching the value", () => {
+    const { onPressureChange, onUnitChange } = setup({ pressure: 2 });
+    fireEvent.change(screen.getByRole("combobox", { name: LABELS.unitAria }), {
+      target: { value: "kPa" },
+    });
+    expect(onUnitChange).toHaveBeenCalledWith("kPa");
+    expect(onPressureChange).not.toHaveBeenCalled();
+  });
+
+  it("renders the accessible legend and placeholder", () => {
+    setup();
+    expect(screen.getByText(LABELS.legend)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(LABELS.placeholder)).toBeInTheDocument();
+  });
+});

--- a/src/components/finder/ProductFinder/PressureInput.tsx
+++ b/src/components/finder/ProductFinder/PressureInput.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { PRESSURE_UNITS, type PressureUnit } from "@/lib/finder/pressure";
+
+type Props = {
+  value: number | "";
+  unit: PressureUnit;
+  onValueChange: (next: number | "") => void;
+  onUnitChange: (next: PressureUnit) => void;
+  labels: { legend: string; placeholder: string };
+};
+
+export function PressureInput({
+  value,
+  unit,
+  onValueChange,
+  onUnitChange,
+  labels,
+}: Props) {
+  return (
+    <fieldset className="lt-finder__group">
+      <legend className="lt-finder__label">{labels.legend}</legend>
+      <div className="lt-finder__flow">
+        <input
+          type="number"
+          inputMode="decimal"
+          min={0}
+          step="any"
+          className="lt-finder__num"
+          placeholder={labels.placeholder}
+          value={value}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === "") onValueChange("");
+            else {
+              const n = Number(v);
+              if (Number.isFinite(n)) onValueChange(n);
+            }
+          }}
+        />
+        <select
+          className="lt-finder__unit"
+          value={unit}
+          onChange={(e) => onUnitChange(e.target.value as PressureUnit)}
+        >
+          {PRESSURE_UNITS.map((u) => (
+            <option key={u} value={u}>
+              {u}
+            </option>
+          ))}
+        </select>
+      </div>
+    </fieldset>
+  );
+}

--- a/src/components/finder/ProductFinder/PressureInput.tsx
+++ b/src/components/finder/ProductFinder/PressureInput.tsx
@@ -3,24 +3,24 @@
 import { PRESSURE_UNITS, type PressureUnit } from "@/lib/finder/pressure";
 
 type Props = {
-  value: number | "";
+  pressure: number | "";
   unit: PressureUnit;
-  onValueChange: (next: number | "") => void;
+  onPressureChange: (next: number | "") => void;
   onUnitChange: (next: PressureUnit) => void;
-  labels: { legend: string; placeholder: string };
+  labels: { legend: string; placeholder: string; unitAria: string };
 };
 
 export function PressureInput({
-  value,
+  pressure,
   unit,
-  onValueChange,
+  onPressureChange,
   onUnitChange,
   labels,
 }: Props) {
   return (
     <fieldset className="lt-finder__group">
       <legend className="lt-finder__label">{labels.legend}</legend>
-      <div className="lt-finder__flow">
+      <div className="lt-finder__input-row">
         <input
           type="number"
           inputMode="decimal"
@@ -28,18 +28,19 @@ export function PressureInput({
           step="any"
           className="lt-finder__num"
           placeholder={labels.placeholder}
-          value={value}
+          value={pressure}
           onChange={(e) => {
             const v = e.target.value;
-            if (v === "") onValueChange("");
+            if (v === "") onPressureChange("");
             else {
               const n = Number(v);
-              if (Number.isFinite(n)) onValueChange(n);
+              if (Number.isFinite(n)) onPressureChange(n);
             }
           }}
         />
         <select
           className="lt-finder__unit"
+          aria-label={labels.unitAria}
           value={unit}
           onChange={(e) => onUnitChange(e.target.value as PressureUnit)}
         >

--- a/src/components/finder/ProductFinder/ProductFinder.css
+++ b/src/components/finder/ProductFinder/ProductFinder.css
@@ -19,6 +19,9 @@
     grid-template-columns: 1fr 1fr;
     gap: 24px 32px;
   }
+  .lt-finder__group--full {
+    grid-column: 1 / -1;
+  }
 }
 
 .lt-finder__group {
@@ -31,7 +34,7 @@
 }
 
 .lt-finder__label {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--lt-neutral-700);
   letter-spacing: -0.005em;
@@ -106,7 +109,7 @@
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  max-height: 280px;
+  max-height: 200px;
   overflow-y: auto;
   margin: 0;
   padding: 4px;
@@ -297,4 +300,123 @@
   font-size: 13px;
   color: var(--lt-neutral-800);
   font-variant-numeric: tabular-nums;
+}
+
+/* Pure/Mixture mode toggle (radios inline with the Gas field) ------ */
+.lt-finder__gas-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 0 0 4px;
+}
+.lt-finder__gas-mode-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--lt-neutral-700);
+  cursor: pointer;
+}
+
+/* Mixture editor -------------------------------------------------- */
+.lt-mix__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.lt-mix__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 110px;
+  gap: 8px;
+  align-items: center;
+}
+.lt-mix__rows--removable .lt-mix__row {
+  grid-template-columns: minmax(0, 1fr) 110px 40px;
+}
+
+.lt-mix__row-gas {
+  min-width: 0;
+}
+
+.lt-mix__row-percent {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 40px;
+  margin: 0;
+}
+.lt-mix__row-percent input {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: right;
+}
+.lt-mix__row-percent > span[aria-hidden] {
+  flex: 0 0 auto;
+  font-size: 14px;
+  color: var(--lt-neutral-600);
+}
+
+.lt-mix__row-remove {
+  appearance: none;
+  border: 1px solid var(--lt-neutral-300);
+  background: white;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: var(--pd-r-md, 8px);
+  color: var(--lt-neutral-700);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+.lt-mix__row-remove:hover:not(:disabled) {
+  border-color: var(--lt-danger-500, #d8513b);
+  color: var(--lt-danger-500, #d8513b);
+}
+.lt-mix__row-remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.lt-mix__actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.lt-mix__add {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 4px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--lt-primary-600, var(--lt-neutral-700));
+  cursor: pointer;
+}
+.lt-mix__add:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.lt-mix__total {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+}
+.lt-mix__total--ok {
+  color: var(--lt-success-600, #1f7a3a);
+}
+.lt-mix__total--bad {
+  color: var(--lt-neutral-500);
 }

--- a/src/components/finder/ProductFinder/ProductFinder.css
+++ b/src/components/finder/ProductFinder/ProductFinder.css
@@ -168,8 +168,8 @@
   font-size: 13px;
 }
 
-/* Flow input ----------------------------------------------------- */
-.lt-finder__flow {
+/* Numeric input + unit selector (Flow, Pressure) ----------------- */
+.lt-finder__input-row {
   display: grid;
   grid-template-columns: 1fr 110px;
   gap: 8px;
@@ -376,8 +376,8 @@
     color 0.15s;
 }
 .lt-mix__row-remove:hover:not(:disabled) {
-  border-color: var(--lt-danger-500, #d8513b);
-  color: var(--lt-danger-500, #d8513b);
+  border-color: var(--lt-danger);
+  color: var(--lt-danger);
 }
 .lt-mix__row-remove:disabled {
   opacity: 0.4;
@@ -400,7 +400,7 @@
   padding: 4px 0;
   font-size: 14px;
   font-weight: 600;
-  color: var(--lt-primary-600, var(--lt-neutral-700));
+  color: var(--lt-primary-600);
   cursor: pointer;
 }
 .lt-mix__add:hover {
@@ -415,7 +415,7 @@
   font-variant-numeric: tabular-nums;
 }
 .lt-mix__total--ok {
-  color: var(--lt-success-600, #1f7a3a);
+  color: var(--lt-success);
 }
 .lt-mix__total--bad {
   color: var(--lt-neutral-500);

--- a/src/components/finder/ProductFinder/ProductFinder.test.tsx
+++ b/src/components/finder/ProductFinder/ProductFinder.test.tsx
@@ -48,6 +48,20 @@ function withRange(
   });
 }
 
+/** Resolve the flow number input by walking down from its fieldset legend. */
+function flowSpin(): HTMLElement {
+  return within(screen.getByRole("group", { name: "flow.label" })).getByRole(
+    "spinbutton",
+  );
+}
+
+/** Resolve the pressure number input by walking down from its fieldset legend. */
+function pressureSpin(): HTMLElement {
+  return within(
+    screen.getByRole("group", { name: "pressure.label" }),
+  ).getByRole("spinbutton");
+}
+
 const PRODUCTS: Product[] = [
   withRange("M3030VA", 0.01, 300, { series: "analogue", function: "MFC" }),
   withRange("M3200VA", 100, 300, { series: "analogue", function: "MFC" }),
@@ -74,8 +88,7 @@ describe("<ProductFinder />", () => {
 
   it("computes matches once a flow rate is entered", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    const flowInput = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(flowInput, { target: { value: "200" } });
+    fireEvent.change(flowSpin(), { target: { value: "200" } });
     expect(screen.getByText(/results\.heading:/)).toBeInTheDocument();
     expect(screen.getByText("M3030VA")).toBeInTheDocument();
     expect(screen.getByText("M3200VA")).toBeInTheDocument();
@@ -83,27 +96,20 @@ describe("<ProductFinder />", () => {
 
   it("respects the function filter chips", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
-      target: { value: "200" },
-    });
-    // Only "MFC" — no MFM/EPC products in our fixture, but function chip should still work
+    fireEvent.change(flowSpin(), { target: { value: "200" } });
     fireEvent.click(screen.getByRole("radio", { name: "fn.mfc" }));
     expect(screen.getByText("M3030VA")).toBeInTheDocument();
   });
 
   it("filters out products outside the requested range", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
-      target: { value: "10000" },
-    });
+    fireEvent.change(flowSpin(), { target: { value: "10000" } });
     expect(screen.getByText("results.empty")).toBeInTheDocument();
   });
 
   it("syncs state to the URL via router.replace", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
-      target: { value: "250" },
-    });
+    fireEvent.change(flowSpin(), { target: { value: "250" } });
     expect(replace).toHaveBeenCalled();
     const lastCall = replace.mock.calls.at(-1)![0];
     expect(lastCall.query.flow).toBe("250");
@@ -150,7 +156,6 @@ describe("<ProductFinder />", () => {
     fireEvent.change(combo, { target: { value: "CO2" } });
     const list = screen.getByRole("listbox");
     expect(within(list).getByText("Carbon Dioxide")).toBeInTheDocument();
-    // Other CO₂-typed entries (e.g. CO₂ shouldn't pull in unrelated gases) — sanity check
     expect(within(list).queryByText("Nitrogen")).not.toBeInTheDocument();
   });
 
@@ -176,11 +181,71 @@ describe("<ProductFinder />", () => {
     fireEvent.focus(combo);
     fireEvent.keyDown(combo, { key: "ArrowDown" });
     fireEvent.keyDown(combo, { key: "Enter" });
-    // First pinned gas after Nitrogen (default) is Oxygen — but ArrowDown from index 0 lands on index 1 = Oxygen
-    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
-      target: { value: "100" },
-    });
+    fireEvent.change(flowSpin(), { target: { value: "100" } });
     expect(screen.getByDisplayValue(/O₂/)).toBeInTheDocument();
+  });
+
+  describe("gas mixture mode", () => {
+    it("renders the mixture editor when the user toggles to Mixture", () => {
+      render(<ProductFinder products={PRODUCTS} locale="en" />);
+      // Mixture editor is hidden in pure mode.
+      expect(
+        screen.queryByRole("button", { name: "+ gas.addComponent" }),
+      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("radio", { name: "gas.modeMixture" }));
+      expect(
+        screen.getByRole("button", { name: "+ gas.addComponent" }),
+      ).toBeInTheDocument();
+    });
+
+    it("emits ?gasMix to the URL (and drops ?gas) when filled in", () => {
+      render(<ProductFinder products={PRODUCTS} locale="en" />);
+      fireEvent.click(screen.getByRole("radio", { name: "gas.modeMixture" }));
+      const percentInputs = within(
+        screen.getByRole("group", { name: "gas.label" }),
+      ).getAllByRole("spinbutton");
+      fireEvent.change(percentInputs[0], { target: { value: "5" } });
+      fireEvent.change(percentInputs[1], { target: { value: "95" } });
+      fireEvent.change(flowSpin(), { target: { value: "100" } });
+      const lastCall = replace.mock.calls.at(-1)![0];
+      expect(lastCall.query.gasMix).toBe("nitrogen:5,nitrogen:95");
+      expect(lastCall.query.gas).toBeUndefined();
+    });
+
+    it("hides the Mixture toggle when EPC is selected (no flow → no K-factor)", () => {
+      render(<ProductFinder products={PRODUCTS} locale="en" />);
+      // Visible in pure-mode default.
+      expect(
+        screen.getByRole("radio", { name: "gas.modeMixture" }),
+      ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("radio", { name: "fn.epc" }));
+      expect(
+        screen.queryByRole("radio", { name: "gas.modeMixture" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("pre-fills the mixture editor from initial state", () => {
+      render(
+        <ProductFinder
+          products={PRODUCTS}
+          locale="en"
+          initial={{
+            gasMode: "mixture",
+            components: [
+              { gasId: "silane", percent: 5 },
+              { gasId: "nitrogen", percent: 95 },
+            ],
+            flow: 100,
+            unit: "slpm",
+          }}
+        />,
+      );
+      const percentInputs = within(
+        screen.getByRole("group", { name: "gas.label" }),
+      ).getAllByRole("spinbutton");
+      expect(percentInputs[0]).toHaveValue(5);
+      expect(percentInputs[1]).toHaveValue(95);
+    });
   });
 
   describe("pressure input", () => {
@@ -226,25 +291,20 @@ describe("<ProductFinder />", () => {
 
     it("syncs the pressure value to the URL as ?p", () => {
       render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
-      const [flow, pressure] = screen.getAllByRole("spinbutton");
-      fireEvent.change(flow, { target: { value: "100" } });
-      fireEvent.change(pressure, { target: { value: "2" } });
+      fireEvent.change(flowSpin(), { target: { value: "100" } });
+      fireEvent.change(pressureSpin(), { target: { value: "2" } });
       const lastCall = replace.mock.calls.at(-1)![0];
       expect(lastCall.query.p).toBe("2");
     });
 
     it("appends ?pu when the unit differs from bar default", () => {
       render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
-      const [flow, pressure] = screen.getAllByRole("spinbutton");
-      fireEvent.change(flow, { target: { value: "100" } });
-      fireEvent.change(pressure, { target: { value: "200" } });
-      const unitSelects = screen.getAllByRole("combobox");
-      // The first combobox is the gas combobox; the unit <select>s come after.
-      // Pressure unit is the last <select> on the form.
-      const selects = unitSelects.filter((el) => el.tagName === "SELECT");
-      fireEvent.change(selects[selects.length - 1], {
-        target: { value: "kPa" },
-      });
+      fireEvent.change(flowSpin(), { target: { value: "100" } });
+      fireEvent.change(pressureSpin(), { target: { value: "200" } });
+      fireEvent.change(
+        screen.getByRole("combobox", { name: "pressure.unitAria" }),
+        { target: { value: "kPa" } },
+      );
       const lastCall = replace.mock.calls.at(-1)![0];
       expect(lastCall.query.p).toBe("200");
       expect(lastCall.query.pu).toBe("kPa");
@@ -252,13 +312,10 @@ describe("<ProductFinder />", () => {
 
     it("filters matches by maxPressure when a pressure is entered", () => {
       render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
-      const [flow, pressure] = screen.getAllByRole("spinbutton");
-      // Without pressure: both MFCs surface.
-      fireEvent.change(flow, { target: { value: "100" } });
+      fireEvent.change(flowSpin(), { target: { value: "100" } });
       expect(screen.getByText("MFC-LOW")).toBeInTheDocument();
       expect(screen.getByText("MFC-HIGH")).toBeInTheDocument();
-      // With pressure 5 bar: MFC-LOW (max 3 bar) drops out.
-      fireEvent.change(pressure, { target: { value: "5" } });
+      fireEvent.change(pressureSpin(), { target: { value: "5" } });
       expect(screen.queryByText("MFC-LOW")).not.toBeInTheDocument();
       expect(screen.getByText("MFC-HIGH")).toBeInTheDocument();
     });

--- a/src/components/finder/ProductFinder/ProductFinder.test.tsx
+++ b/src/components/finder/ProductFinder/ProductFinder.test.tsx
@@ -74,7 +74,7 @@ describe("<ProductFinder />", () => {
 
   it("computes matches once a flow rate is entered", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    const flowInput = screen.getByRole("spinbutton");
+    const flowInput = screen.getAllByRole("spinbutton")[0];
     fireEvent.change(flowInput, { target: { value: "200" } });
     expect(screen.getByText(/results\.heading:/)).toBeInTheDocument();
     expect(screen.getByText("M3030VA")).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe("<ProductFinder />", () => {
 
   it("respects the function filter chips", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getByRole("spinbutton"), {
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
       target: { value: "200" },
     });
     // Only "MFC" — no MFM/EPC products in our fixture, but function chip should still work
@@ -93,7 +93,7 @@ describe("<ProductFinder />", () => {
 
   it("filters out products outside the requested range", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getByRole("spinbutton"), {
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
       target: { value: "10000" },
     });
     expect(screen.getByText("results.empty")).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("<ProductFinder />", () => {
 
   it("syncs state to the URL via router.replace", () => {
     render(<ProductFinder products={PRODUCTS} locale="en" />);
-    fireEvent.change(screen.getByRole("spinbutton"), {
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
       target: { value: "250" },
     });
     expect(replace).toHaveBeenCalled();
@@ -177,9 +177,108 @@ describe("<ProductFinder />", () => {
     fireEvent.keyDown(combo, { key: "ArrowDown" });
     fireEvent.keyDown(combo, { key: "Enter" });
     // First pinned gas after Nitrogen (default) is Oxygen — but ArrowDown from index 0 lands on index 1 = Oxygen
-    fireEvent.change(screen.getByRole("spinbutton"), {
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
       target: { value: "100" },
     });
     expect(screen.getByDisplayValue(/O₂/)).toBeInTheDocument();
+  });
+
+  describe("pressure input", () => {
+    const lowPressureMfc = withRange("MFC-LOW", 0.01, 300, {
+      series: "analogue",
+      function: "MFC",
+      massFlowSpecs: {
+        ...makeProduct().massFlowSpecs!,
+        flowRange: {
+          display: "0.01-300 slpm",
+          min: 0.01,
+          max: 300,
+          unit: "slpm",
+        },
+        maxPressure: {
+          display: "<3 bar",
+          value: 3,
+          unit: "bar",
+          comparator: "lt",
+        },
+      },
+    });
+    const highPressureMfc = withRange("MFC-HIGH", 0.01, 300, {
+      series: "analogue",
+      function: "MFC",
+      massFlowSpecs: {
+        ...makeProduct().massFlowSpecs!,
+        flowRange: {
+          display: "0.01-300 slpm",
+          min: 0.01,
+          max: 300,
+          unit: "slpm",
+        },
+        maxPressure: {
+          display: "<10 bar",
+          value: 10,
+          unit: "bar",
+          comparator: "lt",
+        },
+      },
+    });
+    const PRESSURE_PRODUCTS: Product[] = [lowPressureMfc, highPressureMfc];
+
+    it("syncs the pressure value to the URL as ?p", () => {
+      render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
+      const [flow, pressure] = screen.getAllByRole("spinbutton");
+      fireEvent.change(flow, { target: { value: "100" } });
+      fireEvent.change(pressure, { target: { value: "2" } });
+      const lastCall = replace.mock.calls.at(-1)![0];
+      expect(lastCall.query.p).toBe("2");
+    });
+
+    it("appends ?pu when the unit differs from bar default", () => {
+      render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
+      const [flow, pressure] = screen.getAllByRole("spinbutton");
+      fireEvent.change(flow, { target: { value: "100" } });
+      fireEvent.change(pressure, { target: { value: "200" } });
+      const unitSelects = screen.getAllByRole("combobox");
+      // The first combobox is the gas combobox; the unit <select>s come after.
+      // Pressure unit is the last <select> on the form.
+      const selects = unitSelects.filter((el) => el.tagName === "SELECT");
+      fireEvent.change(selects[selects.length - 1], {
+        target: { value: "kPa" },
+      });
+      const lastCall = replace.mock.calls.at(-1)![0];
+      expect(lastCall.query.p).toBe("200");
+      expect(lastCall.query.pu).toBe("kPa");
+    });
+
+    it("filters matches by maxPressure when a pressure is entered", () => {
+      render(<ProductFinder products={PRESSURE_PRODUCTS} locale="en" />);
+      const [flow, pressure] = screen.getAllByRole("spinbutton");
+      // Without pressure: both MFCs surface.
+      fireEvent.change(flow, { target: { value: "100" } });
+      expect(screen.getByText("MFC-LOW")).toBeInTheDocument();
+      expect(screen.getByText("MFC-HIGH")).toBeInTheDocument();
+      // With pressure 5 bar: MFC-LOW (max 3 bar) drops out.
+      fireEvent.change(pressure, { target: { value: "5" } });
+      expect(screen.queryByText("MFC-LOW")).not.toBeInTheDocument();
+      expect(screen.getByText("MFC-HIGH")).toBeInTheDocument();
+    });
+
+    it("pre-fills pressure value + unit from initial props", () => {
+      render(
+        <ProductFinder
+          products={PRESSURE_PRODUCTS}
+          locale="en"
+          initial={{
+            flow: 100,
+            unit: "slpm",
+            pressure: 200,
+            pressureUnit: "kPa",
+          }}
+        />,
+      );
+      // 200 kPa = 2 bar → MFC-LOW (max 3 bar) should still match.
+      expect(screen.getByText("MFC-LOW")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("200")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/finder/ProductFinder/ProductFinder.tsx
+++ b/src/components/finder/ProductFinder/ProductFinder.tsx
@@ -14,9 +14,11 @@ import {
 import {
   computeMixtureFactor,
   formatMixtureLabel,
+  isMixturePercentValid,
   type GasComponent,
 } from "@/lib/finder/mixture";
 import { toBar, type PressureUnit } from "@/lib/finder/pressure";
+import type { GasMode, ProductFinderInitial } from "@/lib/finder/types";
 import { FunctionPicker } from "./FunctionPicker";
 import { GasSelect } from "./GasSelect";
 import { FlowInput } from "./FlowInput";
@@ -26,19 +28,7 @@ import { ResultCard } from "./ResultCard";
 import { MixtureEditor, defaultMixtureComponents } from "./MixtureEditor";
 import "./ProductFinder.css";
 
-export type GasMode = "pure" | "mixture";
-
-export type ProductFinderInitial = {
-  fn?: FinderFunction;
-  gas?: string;
-  flow?: number;
-  unit?: FinderUnit;
-  series?: FinderSeries;
-  gasMode?: GasMode;
-  components?: GasComponent[];
-  pressure?: number;
-  pressureUnit?: PressureUnit;
-};
+export type { GasMode, ProductFinderInitial };
 
 type Props = {
   products: readonly Product[];
@@ -81,6 +71,11 @@ export function ProductFinder({ products, locale, initial }: Props) {
     initial?.pressureUnit ?? DEFAULT_PRESSURE_UNIT,
   );
 
+  // K-factor matching is meaningless for an EPC product (which controls
+  // pressure, not flow). Force pure mode the moment the user picks EPC so the
+  // Mixture editor doesn't render stale state that the matcher would ignore.
+  const effectiveGasMode: GasMode = fn === "EPC" ? "pure" : gasMode;
+
   // Sync state to URL whenever the form changes.
   useEffect(() => {
     const query: Record<string, string> = {};
@@ -88,7 +83,7 @@ export function ProductFinder({ products, locale, initial }: Props) {
     if (series !== DEFAULT_SERIES) query.series = series;
     if (flow !== "" && Number.isFinite(flow)) query.flow = String(flow);
     if (unit !== DEFAULT_UNIT) query.unit = unit;
-    if (gasMode === "mixture") {
+    if (effectiveGasMode === "mixture") {
       const encoded = components
         .filter((c) => c.gasId.trim() !== "" && c.percent > 0)
         .map((c) => `${c.gasId}:${c.percent}`)
@@ -109,7 +104,7 @@ export function ProductFinder({ products, locale, initial }: Props) {
   }, [
     fn,
     gasId,
-    gasMode,
+    effectiveGasMode,
     components,
     flow,
     unit,
@@ -120,18 +115,23 @@ export function ProductFinder({ products, locale, initial }: Props) {
     router,
   ]);
 
+  // Only feed `findProducts` a mixture when (a) we're in mixture mode, (b) the
+  // math resolves, and (c) the user's percentages actually sum to ~100. Off-100
+  // sums would produce a numerically wrong K-factor and silently surface bad
+  // matches; gating here forces the UI's "Total" indicator to drive results.
   const mixture = useMemo(() => {
-    if (gasMode !== "mixture") return null;
+    if (effectiveGasMode !== "mixture") return null;
     const result = computeMixtureFactor(components);
     if (!result || "missingGas" in result) return null;
+    if (!isMixturePercentValid(result.totalPercent)) return null;
     return result;
-  }, [gasMode, components]);
+  }, [effectiveGasMode, components]);
 
   const result = useMemo(() => {
     const flowProvided =
       flow !== "" && Number.isFinite(flow) && (flow as number) > 0;
     if (fn !== "EPC" && !flowProvided) return null;
-    if (gasMode === "mixture" && !mixture) return null;
+    if (effectiveGasMode === "mixture" && !mixture) return null;
     const pressureProvided =
       pressure !== "" && Number.isFinite(pressure) && (pressure as number) > 0;
     return findProducts(products, {
@@ -157,7 +157,7 @@ export function ProductFinder({ products, locale, initial }: Props) {
     flow,
     unit,
     series,
-    gasMode,
+    effectiveGasMode,
     mixture,
     pressure,
     pressureUnit,
@@ -202,6 +202,21 @@ export function ProductFinder({ products, locale, initial }: Props) {
     return t("results.rankEdge");
   };
 
+  let convertedLine: string | null = null;
+  if (result && fn !== "EPC") {
+    const n2 = result.n2EquivalentSlpm.toLocaleString(locale, {
+      maximumFractionDigits: 3,
+    });
+    if (effectiveGasMode === "mixture" && mixture) {
+      convertedLine = t("convertedNoteMix", {
+        mix: formatMixtureLabel(components),
+        n2,
+      });
+    } else if (result.gas && result.gas.id !== DEFAULT_GAS) {
+      convertedLine = t("convertedNote", { n2 });
+    }
+  }
+
   return (
     <section className="lt-finder">
       <form
@@ -223,33 +238,35 @@ export function ProductFinder({ products, locale, initial }: Props) {
         />
         <fieldset className="lt-finder__group lt-finder__group--full">
           <legend className="lt-finder__label">{t("gas.label")}</legend>
-          <div
-            className="lt-finder__gas-mode"
-            role="radiogroup"
-            aria-label={t("gas.modeLabel")}
-          >
-            <label className="lt-finder__gas-mode-option">
-              <input
-                type="radio"
-                name={`${modeId}-mode`}
-                value="pure"
-                checked={gasMode === "pure"}
-                onChange={() => setGasMode("pure")}
-              />
-              <span>{t("gas.modePure")}</span>
-            </label>
-            <label className="lt-finder__gas-mode-option">
-              <input
-                type="radio"
-                name={`${modeId}-mode`}
-                value="mixture"
-                checked={gasMode === "mixture"}
-                onChange={() => setGasMode("mixture")}
-              />
-              <span>{t("gas.modeMixture")}</span>
-            </label>
-          </div>
-          {gasMode === "pure" ? (
+          {fn !== "EPC" && (
+            <div
+              className="lt-finder__gas-mode"
+              role="radiogroup"
+              aria-label={t("gas.modeLabel")}
+            >
+              <label className="lt-finder__gas-mode-option">
+                <input
+                  type="radio"
+                  name={`${modeId}-mode`}
+                  value="pure"
+                  checked={gasMode === "pure"}
+                  onChange={() => setGasMode("pure")}
+                />
+                <span>{t("gas.modePure")}</span>
+              </label>
+              <label className="lt-finder__gas-mode-option">
+                <input
+                  type="radio"
+                  name={`${modeId}-mode`}
+                  value="mixture"
+                  checked={gasMode === "mixture"}
+                  onChange={() => setGasMode("mixture")}
+                />
+                <span>{t("gas.modeMixture")}</span>
+              </label>
+            </div>
+          )}
+          {effectiveGasMode === "pure" ? (
             <GasSelect
               value={gasId}
               onChange={setGasId}
@@ -274,13 +291,14 @@ export function ProductFinder({ products, locale, initial }: Props) {
           />
         )}
         <PressureInput
-          value={pressure}
+          pressure={pressure}
           unit={pressureUnit}
-          onValueChange={setPressure}
+          onPressureChange={setPressure}
           onUnitChange={setPressureUnit}
           labels={{
             legend: t("pressure.label"),
             placeholder: t("pressure.placeholder"),
+            unitAria: t("pressure.unitAria"),
           }}
         />
       </form>
@@ -294,28 +312,9 @@ export function ProductFinder({ products, locale, initial }: Props) {
               <h2 className="lt-finder__results-title">
                 {t("results.heading", { count: result.matches.length })}
               </h2>
-              {fn !== "EPC" &&
-                (gasMode === "mixture"
-                  ? mixture && (
-                      <p className="lt-finder__converted">
-                        {t("convertedNoteMix", {
-                          mix: formatMixtureLabel(components),
-                          n2: result.n2EquivalentSlpm.toLocaleString(locale, {
-                            maximumFractionDigits: 3,
-                          }),
-                        })}
-                      </p>
-                    )
-                  : result.gas &&
-                    result.gas.id !== DEFAULT_GAS && (
-                      <p className="lt-finder__converted">
-                        {t("convertedNote", {
-                          n2: result.n2EquivalentSlpm.toLocaleString(locale, {
-                            maximumFractionDigits: 3,
-                          }),
-                        })}
-                      </p>
-                    ))}
+              {convertedLine && (
+                <p className="lt-finder__converted">{convertedLine}</p>
+              )}
             </header>
 
             {result.warning === "specialty-gas" && (

--- a/src/components/finder/ProductFinder/ProductFinder.tsx
+++ b/src/components/finder/ProductFinder/ProductFinder.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { usePathname, useRouter } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
@@ -11,12 +11,22 @@ import {
   type FinderSeries,
   type FinderUnit,
 } from "@/lib/finder/match";
+import {
+  computeMixtureFactor,
+  formatMixtureLabel,
+  type GasComponent,
+} from "@/lib/finder/mixture";
+import { toBar, type PressureUnit } from "@/lib/finder/pressure";
 import { FunctionPicker } from "./FunctionPicker";
 import { GasSelect } from "./GasSelect";
 import { FlowInput } from "./FlowInput";
+import { PressureInput } from "./PressureInput";
 import { SeriesPicker } from "./SeriesPicker";
 import { ResultCard } from "./ResultCard";
+import { MixtureEditor, defaultMixtureComponents } from "./MixtureEditor";
 import "./ProductFinder.css";
+
+export type GasMode = "pure" | "mixture";
 
 export type ProductFinderInitial = {
   fn?: FinderFunction;
@@ -24,6 +34,10 @@ export type ProductFinderInitial = {
   flow?: number;
   unit?: FinderUnit;
   series?: FinderSeries;
+  gasMode?: GasMode;
+  components?: GasComponent[];
+  pressure?: number;
+  pressureUnit?: PressureUnit;
 };
 
 type Props = {
@@ -36,11 +50,14 @@ const DEFAULT_GAS = "nitrogen";
 const DEFAULT_FN: FinderFunction = "any";
 const DEFAULT_SERIES: FinderSeries = "any";
 const DEFAULT_UNIT: FinderUnit = "slpm";
+const DEFAULT_MODE: GasMode = "pure";
+const DEFAULT_PRESSURE_UNIT: PressureUnit = "bar";
 
 export function ProductFinder({ products, locale, initial }: Props) {
   const t = useTranslations("productFinder");
   const router = useRouter();
   const pathname = usePathname();
+  const modeId = useId();
 
   const [fn, setFn] = useState<FinderFunction>(initial?.fn ?? DEFAULT_FN);
   const [gasId, setGasId] = useState<string>(initial?.gas ?? DEFAULT_GAS);
@@ -51,34 +68,100 @@ export function ProductFinder({ products, locale, initial }: Props) {
   const [series, setSeries] = useState<FinderSeries>(
     initial?.series ?? DEFAULT_SERIES,
   );
+  const [gasMode, setGasMode] = useState<GasMode>(
+    initial?.gasMode ?? DEFAULT_MODE,
+  );
+  const [components, setComponents] = useState<GasComponent[]>(
+    initial?.components ?? defaultMixtureComponents(),
+  );
+  const [pressure, setPressure] = useState<number | "">(
+    initial?.pressure != null ? initial.pressure : "",
+  );
+  const [pressureUnit, setPressureUnit] = useState<PressureUnit>(
+    initial?.pressureUnit ?? DEFAULT_PRESSURE_UNIT,
+  );
 
   // Sync state to URL whenever the form changes.
   useEffect(() => {
     const query: Record<string, string> = {};
     if (fn !== DEFAULT_FN) query.fn = fn;
-    if (gasId !== DEFAULT_GAS) query.gas = gasId;
+    if (series !== DEFAULT_SERIES) query.series = series;
     if (flow !== "" && Number.isFinite(flow)) query.flow = String(flow);
     if (unit !== DEFAULT_UNIT) query.unit = unit;
-    if (series !== DEFAULT_SERIES) query.series = series;
+    if (gasMode === "mixture") {
+      const encoded = components
+        .filter((c) => c.gasId.trim() !== "" && c.percent > 0)
+        .map((c) => `${c.gasId}:${c.percent}`)
+        .join(",");
+      if (encoded) query.gasMix = encoded;
+    } else if (gasId !== DEFAULT_GAS) {
+      query.gas = gasId;
+    }
+    if (
+      pressure !== "" &&
+      Number.isFinite(pressure) &&
+      (pressure as number) > 0
+    ) {
+      query.p = String(pressure);
+      if (pressureUnit !== DEFAULT_PRESSURE_UNIT) query.pu = pressureUnit;
+    }
     router.replace({ pathname, query }, { scroll: false });
-  }, [fn, gasId, flow, unit, series, pathname, router]);
+  }, [
+    fn,
+    gasId,
+    gasMode,
+    components,
+    flow,
+    unit,
+    series,
+    pressure,
+    pressureUnit,
+    pathname,
+    router,
+  ]);
+
+  const mixture = useMemo(() => {
+    if (gasMode !== "mixture") return null;
+    const result = computeMixtureFactor(components);
+    if (!result || "missingGas" in result) return null;
+    return result;
+  }, [gasMode, components]);
 
   const result = useMemo(() => {
     const flowProvided =
       flow !== "" && Number.isFinite(flow) && (flow as number) > 0;
-    // EPC products use pressureRange, not flowRange — surface them without
-    // requiring a flow value.
-    if (fn !== "EPC" && !flowProvided) {
-      return null;
-    }
+    if (fn !== "EPC" && !flowProvided) return null;
+    if (gasMode === "mixture" && !mixture) return null;
+    const pressureProvided =
+      pressure !== "" && Number.isFinite(pressure) && (pressure as number) > 0;
     return findProducts(products, {
       function: fn,
       gasId,
       flow: flowProvided ? (flow as number) : 0,
       unit,
       series,
+      mixture: mixture
+        ? {
+            factor: mixture.factor,
+            specialty: mixture.category === "specialty",
+          }
+        : undefined,
+      pressureBar: pressureProvided
+        ? toBar(pressure as number, pressureUnit)
+        : undefined,
     });
-  }, [products, fn, gasId, flow, unit, series]);
+  }, [
+    products,
+    fn,
+    gasId,
+    flow,
+    unit,
+    series,
+    gasMode,
+    mixture,
+    pressure,
+    pressureUnit,
+  ]);
 
   const fnLabels: Record<FinderFunction, string> = {
     any: t("fn.any"),
@@ -100,6 +183,17 @@ export function ProductFinder({ products, locale, initial }: Props) {
     common: t("gas.commonLabel"),
     all: t("gas.allLabel"),
     empty: t("gas.empty"),
+  };
+  const mixtureLabels = {
+    gasLegend: t("gas.label"),
+    gasPlaceholder: t("gas.placeholder"),
+    gasCommon: t("gas.commonLabel"),
+    gasAll: t("gas.allLabel"),
+    gasEmpty: t("gas.empty"),
+    percentAria: t("gas.percentAria"),
+    addComponent: t("gas.addComponent"),
+    removeComponent: t("gas.removeComponent"),
+    totalLabel: t("gas.totalLabel"),
   };
 
   const rankLabel = (score: number) => {
@@ -127,7 +221,49 @@ export function ProductFinder({ products, locale, initial }: Props) {
           labels={seriesLabels}
           legend={t("series.label")}
         />
-        <GasSelect value={gasId} onChange={setGasId} labels={gasLabels} />
+        <fieldset className="lt-finder__group lt-finder__group--full">
+          <legend className="lt-finder__label">{t("gas.label")}</legend>
+          <div
+            className="lt-finder__gas-mode"
+            role="radiogroup"
+            aria-label={t("gas.modeLabel")}
+          >
+            <label className="lt-finder__gas-mode-option">
+              <input
+                type="radio"
+                name={`${modeId}-mode`}
+                value="pure"
+                checked={gasMode === "pure"}
+                onChange={() => setGasMode("pure")}
+              />
+              <span>{t("gas.modePure")}</span>
+            </label>
+            <label className="lt-finder__gas-mode-option">
+              <input
+                type="radio"
+                name={`${modeId}-mode`}
+                value="mixture"
+                checked={gasMode === "mixture"}
+                onChange={() => setGasMode("mixture")}
+              />
+              <span>{t("gas.modeMixture")}</span>
+            </label>
+          </div>
+          {gasMode === "pure" ? (
+            <GasSelect
+              value={gasId}
+              onChange={setGasId}
+              labels={gasLabels}
+              hideLabel
+            />
+          ) : (
+            <MixtureEditor
+              components={components}
+              onChange={setComponents}
+              labels={mixtureLabels}
+            />
+          )}
+        </fieldset>
         {fn !== "EPC" && (
           <FlowInput
             flow={flow}
@@ -137,6 +273,16 @@ export function ProductFinder({ products, locale, initial }: Props) {
             labels={{ legend: t("flow.label"), unit: unitLabels }}
           />
         )}
+        <PressureInput
+          value={pressure}
+          unit={pressureUnit}
+          onValueChange={setPressure}
+          onUnitChange={setPressureUnit}
+          labels={{
+            legend: t("pressure.label"),
+            placeholder: t("pressure.placeholder"),
+          }}
+        />
       </form>
 
       <div className="lt-finder__results" aria-live="polite">
@@ -148,15 +294,28 @@ export function ProductFinder({ products, locale, initial }: Props) {
               <h2 className="lt-finder__results-title">
                 {t("results.heading", { count: result.matches.length })}
               </h2>
-              {fn !== "EPC" && result.gas && result.gas.id !== DEFAULT_GAS && (
-                <p className="lt-finder__converted">
-                  {t("convertedNote", {
-                    n2: result.n2EquivalentSlpm.toLocaleString(locale, {
-                      maximumFractionDigits: 3,
-                    }),
-                  })}
-                </p>
-              )}
+              {fn !== "EPC" &&
+                (gasMode === "mixture"
+                  ? mixture && (
+                      <p className="lt-finder__converted">
+                        {t("convertedNoteMix", {
+                          mix: formatMixtureLabel(components),
+                          n2: result.n2EquivalentSlpm.toLocaleString(locale, {
+                            maximumFractionDigits: 3,
+                          }),
+                        })}
+                      </p>
+                    )
+                  : result.gas &&
+                    result.gas.id !== DEFAULT_GAS && (
+                      <p className="lt-finder__converted">
+                        {t("convertedNote", {
+                          n2: result.n2EquivalentSlpm.toLocaleString(locale, {
+                            maximumFractionDigits: 3,
+                          }),
+                        })}
+                      </p>
+                    ))}
             </header>
 
             {result.warning === "specialty-gas" && (

--- a/src/lib/finder/match.test.ts
+++ b/src/lib/finder/match.test.ts
@@ -276,6 +276,165 @@ describe("findProducts", () => {
       expect(result.matches.map((m) => m.product.model)).not.toContain("LEPC");
     });
   });
+
+  describe("custom gas mixture", () => {
+    it("uses the supplied K-factor instead of looking up gasId", () => {
+      // 5% SiH₄ + 95% N₂ harmonic-mean K ≈ 0.9709 → 100 slpm @ K=0.9709
+      // converts to ~103 slpm N₂-equivalent.
+      const result = findProducts(products, {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 100,
+        unit: "slpm",
+        mixture: { factor: 0.9709, specialty: true },
+      });
+      expect(result.n2EquivalentSlpm).toBeCloseTo(103, 0);
+      expect(result.warning).toBe("specialty-gas");
+      // gas record is suppressed when matching via mixture.
+      expect(result.gas).toBeUndefined();
+    });
+
+    it("flags non-specialty mixtures correctly", () => {
+      const result = findProducts(products, {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 100,
+        unit: "slpm",
+        mixture: { factor: 1.3398, specialty: false },
+      });
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("returns empty matches when the mixture factor is zero", () => {
+      const result = findProducts(products, {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 100,
+        unit: "slpm",
+        mixture: { factor: 0, specialty: false },
+      });
+      expect(result.matches).toEqual([]);
+      expect(result.n2EquivalentSlpm).toBe(0);
+    });
+  });
+
+  describe("operating pressure filter", () => {
+    const lepc = makeProduct({
+      model: "LEPC",
+      slug: { current: "lepc" },
+      series: "lepc",
+      function: "EPC",
+      massFlowSpecs: {
+        ...makeProduct().massFlowSpecs!,
+        flowRange: undefined,
+        pressureRange: {
+          display: "0.1–6 barA",
+          min: 0.1,
+          max: 6,
+          unit: "barA",
+        },
+      },
+    });
+    const mfcWithMax = withRange("M2030VA-CAP", 0.01, 30, {
+      series: "analogue",
+      function: "MFC",
+      massFlowSpecs: {
+        ...makeProduct().massFlowSpecs!,
+        flowRange: {
+          display: "0.01–30 slpm",
+          min: 0.01,
+          max: 30,
+          unit: "slpm",
+        },
+        maxPressure: {
+          display: "<3 bar",
+          value: 3,
+          unit: "bar",
+          comparator: "lt",
+        },
+      },
+    });
+    const mfcHighMax = withRange("M2030VA-HIGH", 0.01, 30, {
+      series: "analogue",
+      function: "MFC",
+      massFlowSpecs: {
+        ...makeProduct().massFlowSpecs!,
+        flowRange: {
+          display: "0.01–30 slpm",
+          min: 0.01,
+          max: 30,
+          unit: "slpm",
+        },
+        maxPressure: {
+          display: "<10 bar",
+          value: 10,
+          unit: "bar",
+          comparator: "lt",
+        },
+      },
+    });
+
+    it("EPC: matches when pressure falls inside pressureRange", () => {
+      const result = findProducts([lepc], {
+        function: "EPC",
+        gasId: "nitrogen",
+        flow: 0,
+        unit: "slpm",
+        pressureBar: 2,
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual(["LEPC"]);
+    });
+
+    it("EPC: filters out when pressure outside pressureRange", () => {
+      const result = findProducts([lepc], {
+        function: "EPC",
+        gasId: "nitrogen",
+        flow: 0,
+        unit: "slpm",
+        pressureBar: 50,
+      });
+      expect(result.matches).toEqual([]);
+    });
+
+    it("MFC: matches when pressure ≤ maxPressure", () => {
+      const result = findProducts([mfcWithMax, mfcHighMax], {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 10,
+        unit: "slpm",
+        pressureBar: 2,
+      });
+      expect(result.matches.map((m) => m.product.model).sort()).toEqual([
+        "M2030VA-CAP",
+        "M2030VA-HIGH",
+      ]);
+    });
+
+    it("MFC: filters out when pressure > maxPressure", () => {
+      const result = findProducts([mfcWithMax, mfcHighMax], {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 10,
+        unit: "slpm",
+        pressureBar: 5,
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual([
+        "M2030VA-HIGH",
+      ]);
+    });
+
+    it("no pressure filter when pressureBar undefined", () => {
+      const result = findProducts([mfcWithMax], {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 10,
+        unit: "slpm",
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual([
+        "M2030VA-CAP",
+      ]);
+    });
+  });
 });
 
 describe("seam handling", () => {

--- a/src/lib/finder/match.test.ts
+++ b/src/lib/finder/match.test.ts
@@ -434,6 +434,76 @@ describe("findProducts", () => {
         "M2030VA-CAP",
       ]);
     });
+
+    it("MFC: honours 'lt' comparator (pressure equal to maxPressure rejected)", () => {
+      // mfcWithMax has maxPressure {value: 3, comparator: "lt"} — "<3 bar".
+      // A user running at exactly 3.0 bar must be rejected.
+      const result = findProducts([mfcWithMax, mfcHighMax], {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 10,
+        unit: "slpm",
+        pressureBar: 3,
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual([
+        "M2030VA-HIGH",
+      ]);
+    });
+
+    it("MFC: treats unknown maxPressure unit as a pass (don't disappear products)", () => {
+      const mfcUnknownUnit = withRange("MFC-UNK", 0.01, 30, {
+        series: "analogue",
+        function: "MFC",
+        massFlowSpecs: {
+          ...makeProduct().massFlowSpecs!,
+          flowRange: {
+            display: "0.01–30 slpm",
+            min: 0.01,
+            max: 30,
+            unit: "slpm",
+          },
+          maxPressure: {
+            display: "?",
+            value: 1,
+            unit: "atm",
+            comparator: "lt",
+          },
+        },
+      });
+      const result = findProducts([mfcUnknownUnit], {
+        function: "MFC",
+        gasId: "nitrogen",
+        flow: 10,
+        unit: "slpm",
+        pressureBar: 999,
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual(["MFC-UNK"]);
+    });
+
+    it("EPC: assigns neutral fit when pressureRange unit can't be normalized", () => {
+      const lepcWeird = makeProduct({
+        model: "LEPC-WEIRD",
+        slug: { current: "lepc-weird" },
+        series: "lepc",
+        function: "EPC",
+        massFlowSpecs: {
+          ...makeProduct().massFlowSpecs!,
+          flowRange: undefined,
+          pressureRange: { display: "?", min: 0.1, max: 6, unit: "atm" },
+        },
+      });
+      const result = findProducts([lepcWeird], {
+        function: "EPC",
+        gasId: "nitrogen",
+        flow: 0,
+        unit: "slpm",
+        pressureBar: 2,
+      });
+      expect(result.matches.map((m) => m.product.model)).toEqual([
+        "LEPC-WEIRD",
+      ]);
+      expect(result.matches[0].fitScore).toBeCloseTo(0.7, 6);
+    });
   });
 });
 

--- a/src/lib/finder/match.ts
+++ b/src/lib/finder/match.ts
@@ -125,6 +125,39 @@ function functionMatches(product: Product, target: FinderFunction): boolean {
   return product.function === target;
 }
 
+/**
+ * Does the user pressure fall inside the product's operating pressureRange?
+ * Returns the fitScore (0..1) when in range, or null when the range itself is
+ * unusable (missing bounds). Unit normalization failure returns a neutral 0.7
+ * — we don't want an authoring typo in `unit` to silently disappear a product.
+ */
+function pressureRangeFit(
+  range: NonNullable<NonNullable<Product["massFlowSpecs"]>["pressureRange"]>,
+  pressureBar: number,
+): number | null {
+  if (range.min == null || range.max == null) return null;
+  const minBar = catalogValueToBar(range.min, range.unit);
+  const maxBar = catalogValueToBar(range.max, range.unit);
+  if (minBar == null || maxBar == null) return 0.7;
+  return fitScore(pressureBar, minBar, maxBar);
+}
+
+/**
+ * Does the user pressure stay within the product's `maxPressure` rating?
+ * Honours the catalogue's `comparator` field: `"lt"` means strict `<` (e.g.
+ * "<3 bar"), anything else is treated as `≤`. Unit normalization failure
+ * passes (same rationale as `pressureRangeFit`).
+ */
+function pressureWithinMax(
+  max: NonNullable<NonNullable<Product["massFlowSpecs"]>["maxPressure"]>,
+  pressureBar: number,
+): boolean {
+  if (max.value == null) return false;
+  const maxBar = catalogValueToBar(max.value, max.unit);
+  if (maxBar == null) return true;
+  return max.comparator === "lt" ? pressureBar < maxBar : pressureBar <= maxBar;
+}
+
 function seriesMatches(
   product: Product,
   target: FinderSeries | undefined,
@@ -150,19 +183,10 @@ export function findProducts(
       let score = 1;
       if (input.pressureBar != null) {
         const range = product.massFlowSpecs?.pressureRange;
-        if (
-          !range ||
-          range.min == null ||
-          range.max == null ||
-          !product.massFlowSpecs
-        ) {
-          continue;
-        }
-        const minBar = catalogValueToBar(range.min, range.unit);
-        const maxBar = catalogValueToBar(range.max, range.unit);
-        if (minBar == null || maxBar == null) continue;
-        score = fitScore(input.pressureBar, minBar, maxBar);
-        if (score === 0) continue;
+        if (!range) continue;
+        const fit = pressureRangeFit(range, input.pressureBar);
+        if (fit == null || fit === 0) continue;
+        score = fit;
       }
       matches.push({ product, n2EquivalentSlpm: flowSlpm, fitScore: score });
     }
@@ -179,8 +203,8 @@ export function findProducts(
     };
   }
 
-  // Mixture overrides the K-factor lookup. The caller pre-computed the
-  // harmonic-mean factor for the blend; we apply it like a normal gas.
+  // Pure and mixture share the same downstream ranking; mixture just provides
+  // a pre-computed effectiveFactor instead of looking up a single-gas record.
   let effectiveFactor: number;
   let mixtureSpecialty = false;
   if (input.mixture) {
@@ -213,9 +237,7 @@ export function findProducts(
 
     if (input.pressureBar != null) {
       const max = product.massFlowSpecs.maxPressure;
-      if (max?.value == null) continue;
-      const maxBar = catalogValueToBar(max.value, max.unit);
-      if (maxBar == null || input.pressureBar > maxBar) continue;
+      if (!max || !pressureWithinMax(max, input.pressureBar)) continue;
     }
 
     const match: FinderMatch = {

--- a/src/lib/finder/match.ts
+++ b/src/lib/finder/match.ts
@@ -5,6 +5,7 @@ import {
   getGasFactor,
   type GasFactor,
 } from "./gas-factors";
+import { catalogValueToBar } from "./pressure";
 
 export type FinderFunction = "MFC" | "MFM" | "EPC" | "any";
 export type FinderSeries =
@@ -21,6 +22,23 @@ export type FinderInput = {
   flow: number;
   unit: FinderUnit;
   series?: FinderSeries;
+  /**
+   * When set, overrides the K-factor that would otherwise be resolved from
+   * `gasId`. Used for custom gas mixtures: callers compute the harmonic-mean
+   * factor (see `mixture.ts`) and pass it through here. `gasId` becomes a
+   * label/back-compat token only when this is provided.
+   */
+  mixture?: {
+    factor: number;
+    specialty: boolean;
+  };
+  /**
+   * Operating pressure the user will run at, normalized to bar.
+   * EPC: must fall inside the product's `pressureRange`.
+   * MFC/MFM: must be ≤ the product's `maxPressure` value.
+   * When undefined, pressure is not used to filter.
+   */
+  pressureBar?: number;
 };
 
 export type FinderMatch = {
@@ -123,15 +141,35 @@ export function findProducts(
   const flowSlpm = toSlpm(input.flow, input.unit);
 
   // EPC products use pressureRange, not flowRange, and the gas factor is only
-  // used for flow conversion. Surface every EPC match regardless of gas/flow.
+  // used for flow conversion. Filter by user pressure when provided.
   if (input.function === "EPC") {
     const matches: FinderMatch[] = [];
     for (const product of products) {
       if (product.function !== "EPC") continue;
       if (!seriesMatches(product, input.series)) continue;
-      matches.push({ product, n2EquivalentSlpm: flowSlpm, fitScore: 1 });
+      let score = 1;
+      if (input.pressureBar != null) {
+        const range = product.massFlowSpecs?.pressureRange;
+        if (
+          !range ||
+          range.min == null ||
+          range.max == null ||
+          !product.massFlowSpecs
+        ) {
+          continue;
+        }
+        const minBar = catalogValueToBar(range.min, range.unit);
+        const maxBar = catalogValueToBar(range.max, range.unit);
+        if (minBar == null || maxBar == null) continue;
+        score = fitScore(input.pressureBar, minBar, maxBar);
+        if (score === 0) continue;
+      }
+      matches.push({ product, n2EquivalentSlpm: flowSlpm, fitScore: score });
     }
-    matches.sort((a, b) => a.product.model.localeCompare(b.product.model));
+    matches.sort((a, b) => {
+      if (b.fitScore !== a.fitScore) return b.fitScore - a.fitScore;
+      return a.product.model.localeCompare(b.product.model);
+    });
     return {
       matches,
       n2EquivalentSlpm: flowSlpm,
@@ -141,10 +179,23 @@ export function findProducts(
     };
   }
 
-  if (!gas) {
-    return { matches: [], n2EquivalentSlpm: flowSlpm };
+  // Mixture overrides the K-factor lookup. The caller pre-computed the
+  // harmonic-mean factor for the blend; we apply it like a normal gas.
+  let effectiveFactor: number;
+  let mixtureSpecialty = false;
+  if (input.mixture) {
+    effectiveFactor = input.mixture.factor;
+    mixtureSpecialty = input.mixture.specialty;
+  } else {
+    if (!gas) {
+      return { matches: [], n2EquivalentSlpm: flowSlpm };
+    }
+    effectiveFactor = gas.factor;
   }
-  const n2EquivalentSlpm = toN2Equivalent(flowSlpm, gas);
+  const reference = getGasFactor(REFERENCE_GAS_ID);
+  if (!reference) throw new Error("Reference gas (N₂) missing from gas table");
+  const n2EquivalentSlpm =
+    effectiveFactor > 0 ? flowSlpm * (reference.factor / effectiveFactor) : 0;
 
   const normalMatches: FinderMatch[] = [];
   const bottomEdgeMatches: FinderMatch[] = [];
@@ -159,6 +210,13 @@ export function findProducts(
 
     const fit = fitScoreForRange(n2EquivalentSlpm, range.min, range.max);
     if (fit.score === 0) continue;
+
+    if (input.pressureBar != null) {
+      const max = product.massFlowSpecs.maxPressure;
+      if (max?.value == null) continue;
+      const maxBar = catalogValueToBar(max.value, max.unit);
+      if (maxBar == null || input.pressureBar > maxBar) continue;
+    }
 
     const match: FinderMatch = {
       product,
@@ -198,8 +256,11 @@ export function findProducts(
   return {
     matches,
     n2EquivalentSlpm,
-    gas,
-    warning: gas.category === "specialty" ? "specialty-gas" : undefined,
+    gas: input.mixture ? undefined : gas,
+    warning:
+      mixtureSpecialty || gas?.category === "specialty"
+        ? "specialty-gas"
+        : undefined,
   };
 }
 

--- a/src/lib/finder/mixture.test.ts
+++ b/src/lib/finder/mixture.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeMixtureFactor,
+  formatMixtureLabel,
+  isMixturePercentValid,
+  type MixtureError,
+  type MixtureResult,
+} from "./mixture";
+
+function asResult(
+  value: ReturnType<typeof computeMixtureFactor>,
+): MixtureResult {
+  if (!value || "missingGas" in value) {
+    throw new Error("expected MixtureResult, got " + JSON.stringify(value));
+  }
+  return value;
+}
+
+function asError(value: ReturnType<typeof computeMixtureFactor>): MixtureError {
+  if (!value || !("missingGas" in value)) {
+    throw new Error("expected MixtureError, got " + JSON.stringify(value));
+  }
+  return value;
+}
+
+describe("computeMixtureFactor", () => {
+  it("returns null for an empty list", () => {
+    expect(computeMixtureFactor([])).toBeNull();
+  });
+
+  it("returns null when every row is blank", () => {
+    expect(
+      computeMixtureFactor([
+        { gasId: "", percent: 0 },
+        { gasId: "", percent: 0 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns missingGas for an unknown component", () => {
+    const result = computeMixtureFactor([
+      { gasId: "nitrogen", percent: 50 },
+      { gasId: "not-a-real-gas", percent: 50 },
+    ]);
+    expect(asError(result).missingGas).toBe("not-a-real-gas");
+  });
+
+  it("degenerates to the single component's factor", () => {
+    const result = asResult(
+      computeMixtureFactor([{ gasId: "argon", percent: 100 }]),
+    );
+    expect(result.factor).toBeCloseTo(1.395, 3);
+    expect(result.totalPercent).toBe(100);
+    expect(result.category).toBe("common");
+  });
+
+  it("computes 5% SiH₄ + 95% N₂ via the harmonic-mean formula", () => {
+    // 1/K = 0.05/0.625 + 0.95/1.000 = 0.08 + 0.95 = 1.03 → K ≈ 0.9709
+    const result = asResult(
+      computeMixtureFactor([
+        { gasId: "silane", percent: 5 },
+        { gasId: "nitrogen", percent: 95 },
+      ]),
+    );
+    expect(result.factor).toBeCloseTo(0.9709, 4);
+    expect(result.totalPercent).toBe(100);
+    expect(result.category).toBe("specialty");
+    expect(result.sealNote).toBe("kalrez");
+  });
+
+  it("computes 10% O₂ + 90% Ar (common-only mixture)", () => {
+    const result = asResult(
+      computeMixtureFactor([
+        { gasId: "oxygen", percent: 10 },
+        { gasId: "argon", percent: 90 },
+      ]),
+    );
+    expect(result.factor).toBeCloseTo(1.3398, 3);
+    expect(result.category).toBe("common");
+    expect(result.sealNote).toBeUndefined();
+  });
+
+  it("propagates the most-restrictive seal recommendation", () => {
+    // disilane: teflon, silane: kalrez → kalrez wins (higher rank).
+    const result = asResult(
+      computeMixtureFactor([
+        { gasId: "disilane", percent: 50 },
+        { gasId: "silane", percent: 50 },
+      ]),
+    );
+    expect(result.sealNote).toBe("kalrez");
+  });
+
+  it("ignores blank component rows and computes from the rest", () => {
+    const result = asResult(
+      computeMixtureFactor([
+        { gasId: "nitrogen", percent: 100 },
+        { gasId: "", percent: 0 },
+      ]),
+    );
+    expect(result.factor).toBeCloseTo(1, 6);
+    expect(result.totalPercent).toBe(100);
+  });
+
+  it("reports total percent for sums outside 100", () => {
+    const low = asResult(
+      computeMixtureFactor([
+        { gasId: "silane", percent: 4.95 },
+        { gasId: "nitrogen", percent: 94.95 },
+      ]),
+    );
+    expect(low.totalPercent).toBeCloseTo(99.9, 3);
+    expect(isMixturePercentValid(low.totalPercent)).toBe(true);
+
+    const off = asResult(
+      computeMixtureFactor([
+        { gasId: "silane", percent: 10 },
+        { gasId: "nitrogen", percent: 80 },
+      ]),
+    );
+    expect(off.totalPercent).toBe(90);
+    expect(isMixturePercentValid(off.totalPercent)).toBe(false);
+  });
+});
+
+describe("formatMixtureLabel", () => {
+  it("uses each gas's typeset formula", () => {
+    expect(
+      formatMixtureLabel([
+        { gasId: "silane", percent: 5 },
+        { gasId: "nitrogen", percent: 95 },
+      ]),
+    ).toBe("5% SiH₄ + 95% N₂");
+  });
+
+  it("renders fractional percentages with one decimal", () => {
+    expect(
+      formatMixtureLabel([
+        { gasId: "silane", percent: 5.5 },
+        { gasId: "nitrogen", percent: 94.5 },
+      ]),
+    ).toBe("5.5% SiH₄ + 94.5% N₂");
+  });
+
+  it("skips blank rows", () => {
+    expect(
+      formatMixtureLabel([
+        { gasId: "silane", percent: 5 },
+        { gasId: "", percent: 0 },
+        { gasId: "nitrogen", percent: 95 },
+      ]),
+    ).toBe("5% SiH₄ + 95% N₂");
+  });
+});

--- a/src/lib/finder/mixture.test.ts
+++ b/src/lib/finder/mixture.test.ts
@@ -121,6 +121,37 @@ describe("computeMixtureFactor", () => {
     expect(off.totalPercent).toBe(90);
     expect(isMixturePercentValid(off.totalPercent)).toBe(false);
   });
+
+  it("treats NaN percent as a blank row (filtered out of the math)", () => {
+    const result = computeMixtureFactor([
+      { gasId: "silane", percent: Number.NaN },
+      { gasId: "nitrogen", percent: 95 },
+    ]);
+    const r = asResult(result);
+    // NaN row dropped; only N₂ at 95% survives. UI flags totalPercent ≠ 100.
+    expect(r.totalPercent).toBe(95);
+    expect(Number.isFinite(r.factor)).toBe(true);
+    expect(r.factor).toBeGreaterThan(0);
+  });
+
+  it("treats negative percent as a blank row", () => {
+    const result = computeMixtureFactor([
+      { gasId: "silane", percent: -5 },
+      { gasId: "nitrogen", percent: 100 },
+    ]);
+    const r = asResult(result);
+    expect(r.totalPercent).toBe(100);
+  });
+
+  it("returns null when all rows have NaN/Infinity/zero percent", () => {
+    expect(
+      computeMixtureFactor([
+        { gasId: "silane", percent: Number.NaN },
+        { gasId: "nitrogen", percent: Number.POSITIVE_INFINITY },
+        { gasId: "argon", percent: 0 },
+      ]),
+    ).toBeNull();
+  });
 });
 
 describe("formatMixtureLabel", () => {

--- a/src/lib/finder/mixture.ts
+++ b/src/lib/finder/mixture.ts
@@ -42,7 +42,7 @@ export function computeMixtureFactor(
   components: readonly GasComponent[],
 ): MixtureResult | MixtureError | null {
   const usable = components.filter(
-    (c) => c.gasId.trim() !== "" && c.percent > 0,
+    (c) => c.gasId.trim() !== "" && Number.isFinite(c.percent) && c.percent > 0,
   );
   if (usable.length === 0) return null;
 
@@ -86,7 +86,7 @@ export function formatMixtureLabel(
   components: readonly GasComponent[],
 ): string {
   const usable = components.filter(
-    (c) => c.gasId.trim() !== "" && c.percent > 0,
+    (c) => c.gasId.trim() !== "" && Number.isFinite(c.percent) && c.percent > 0,
   );
   return usable
     .map((c) => {

--- a/src/lib/finder/mixture.ts
+++ b/src/lib/finder/mixture.ts
@@ -1,0 +1,117 @@
+import {
+  type GasCategory,
+  type GasFactor,
+  type GasSealNote,
+  getGasFactor,
+} from "./gas-factors";
+
+export type GasComponent = {
+  gasId: string;
+  /** Mole/volume fraction as a percentage (0..100). */
+  percent: number;
+};
+
+export type MixtureResult = {
+  /** Effective K-factor for the blend, relative to N₂. */
+  factor: number;
+  /** "specialty" if any component is specialty. */
+  category: GasCategory;
+  /** Sum of component percentages — caller validates against 100. */
+  totalPercent: number;
+  /** Most restrictive seal recommendation across specialty components, if any. */
+  sealNote?: GasSealNote;
+};
+
+export type MixtureError = {
+  /** gasId of the first component not found in the gas table. */
+  missingGas: string;
+};
+
+const PERCENT_TOLERANCE = 0.1;
+
+/**
+ * Mixture K-factor via the FAQ-documented harmonic mean:
+ *   1/K_mix = Σ (pᵢ/100) / Kᵢ
+ *
+ * Returns null for an empty or all-blank list, an error when any component
+ * references an unknown gasId, otherwise the computed factor. Components
+ * summing outside 100 ± 0.1% still produce a factor — the caller decides
+ * whether to treat the sum as valid.
+ */
+export function computeMixtureFactor(
+  components: readonly GasComponent[],
+): MixtureResult | MixtureError | null {
+  const usable = components.filter(
+    (c) => c.gasId.trim() !== "" && c.percent > 0,
+  );
+  if (usable.length === 0) return null;
+
+  const resolved: { component: GasComponent; gas: GasFactor }[] = [];
+  for (const component of usable) {
+    const gas = getGasFactor(component.gasId);
+    if (!gas) return { missingGas: component.gasId };
+    resolved.push({ component, gas });
+  }
+
+  let denominator = 0;
+  let totalPercent = 0;
+  let category: GasCategory = "common";
+  let sealNote: GasSealNote | undefined;
+  for (const { component, gas } of resolved) {
+    const fraction = component.percent / 100;
+    denominator += fraction / gas.factor;
+    totalPercent += component.percent;
+    if (gas.category === "specialty") category = "specialty";
+    sealNote = pickWorstSeal(sealNote, gas.sealNote);
+  }
+
+  return {
+    factor: denominator > 0 ? 1 / denominator : 0,
+    category,
+    totalPercent,
+    sealNote,
+  };
+}
+
+/** Whether the totalPercent is within 0.1% of 100 — used for UI validation only. */
+export function isMixturePercentValid(totalPercent: number): boolean {
+  return Math.abs(totalPercent - 100) <= PERCENT_TOLERANCE;
+}
+
+/**
+ * "5% SiH₄ + 95% N₂" — uses each gas's typeset formula; unknown ids fall back
+ * to the raw id so the label stays informative for partial entries.
+ */
+export function formatMixtureLabel(
+  components: readonly GasComponent[],
+): string {
+  const usable = components.filter(
+    (c) => c.gasId.trim() !== "" && c.percent > 0,
+  );
+  return usable
+    .map((c) => {
+      const gas = getGasFactor(c.gasId);
+      const symbol = gas?.formula ?? c.gasId;
+      return `${formatPercent(c.percent)}% ${symbol}`;
+    })
+    .join(" + ");
+}
+
+function formatPercent(percent: number): string {
+  return Number.isInteger(percent) ? String(percent) : percent.toFixed(1);
+}
+
+const SEAL_RANK: Record<GasSealNote, number> = {
+  teflon: 1,
+  kalrez: 2,
+  metal: 3,
+};
+
+function pickWorstSeal(
+  current: GasSealNote | undefined,
+  next: GasSealNote | undefined,
+): GasSealNote | undefined {
+  if (!next) return current;
+  if (!current) return next;
+  return SEAL_RANK[next] > SEAL_RANK[current] ? next : current;
+}

--- a/src/lib/finder/parseFinderUrl.test.ts
+++ b/src/lib/finder/parseFinderUrl.test.ts
@@ -47,8 +47,12 @@ describe("parseFinderUrl", () => {
     });
   });
 
-  it("ignores unknown pressure unit", () => {
-    expect(parseFinderUrl({ p: "2", pu: "atm" })).toEqual({ pressure: 2 });
+  it("rejects pressure entirely when unit is unknown (avoids misinterpreting as bar)", () => {
+    expect(parseFinderUrl({ p: "2", pu: "atm" })).toEqual({});
+  });
+
+  it("keeps pressure when unit is omitted (UI default applies)", () => {
+    expect(parseFinderUrl({ p: "2" })).toEqual({ pressure: 2 });
   });
 
   it("parses gasMix into mixture mode + components", () => {
@@ -81,5 +85,38 @@ describe("parseFinderUrl", () => {
     expect(parseFinderUrl({ fn: ["MFC", "EPC"], flow: ["50", "100"] })).toEqual(
       { fn: "MFC", flow: 50 },
     );
+  });
+
+  it("validates `gas` against the gas table (drops unknown ids)", () => {
+    expect(parseFinderUrl({ gas: "made-up-gas" })).toEqual({});
+    expect(parseFinderUrl({ gas: "argon" })).toEqual({ gas: "argon" });
+  });
+
+  it("keeps both `gas` and `gasMix` when both are present (consumer picks)", () => {
+    // Mixture mode is the active state, but pure-gas seed is preserved so the
+    // user can toggle back without losing their last single-gas choice.
+    const result = parseFinderUrl({
+      gas: "argon",
+      gasMix: "silane:5,nitrogen:95",
+    });
+    expect(result.gasMode).toBe("mixture");
+    expect(result.gas).toBe("argon");
+    expect(result.components).toHaveLength(2);
+  });
+
+  it("accepts gasMix percentages whose sum > 100 (UI flags it; parser doesn't)", () => {
+    expect(parseFinderUrl({ gasMix: "silane:150,nitrogen:50" })).toEqual({
+      gasMode: "mixture",
+      components: [
+        { gasId: "silane", percent: 150 },
+        { gasId: "nitrogen", percent: 50 },
+      ],
+    });
+  });
+
+  it("caps gasMix component count to prevent DoS via a huge URL", () => {
+    const huge = Array.from({ length: 500 }, () => "argon:1").join(",");
+    const result = parseFinderUrl({ gasMix: huge });
+    expect(result.components?.length ?? 0).toBeLessThanOrEqual(20);
   });
 });

--- a/src/lib/finder/parseFinderUrl.test.ts
+++ b/src/lib/finder/parseFinderUrl.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { parseFinderUrl } from "./parseFinderUrl";
+
+describe("parseFinderUrl", () => {
+  it("returns an empty initial for an empty query", () => {
+    expect(parseFinderUrl({})).toEqual({});
+  });
+
+  it("parses canonical scalar params", () => {
+    expect(
+      parseFinderUrl({
+        fn: "MFC",
+        gas: "nitrogen",
+        flow: "100",
+        unit: "slpm",
+        series: "analogue",
+      }),
+    ).toEqual({
+      fn: "MFC",
+      gas: "nitrogen",
+      flow: 100,
+      unit: "slpm",
+      series: "analogue",
+    });
+  });
+
+  it("ignores unknown enum values", () => {
+    expect(
+      parseFinderUrl({ fn: "ROU", unit: "kg", series: "vintage" }),
+    ).toEqual({});
+  });
+
+  it("ignores non-positive flow", () => {
+    expect(parseFinderUrl({ flow: "0" })).toEqual({});
+    expect(parseFinderUrl({ flow: "-5" })).toEqual({});
+    expect(parseFinderUrl({ flow: "not-a-number" })).toEqual({});
+  });
+
+  it("parses pressure value + unit", () => {
+    expect(parseFinderUrl({ p: "2", pu: "bar" })).toEqual({
+      pressure: 2,
+      pressureUnit: "bar",
+    });
+    expect(parseFinderUrl({ p: "200", pu: "kPa" })).toEqual({
+      pressure: 200,
+      pressureUnit: "kPa",
+    });
+  });
+
+  it("ignores unknown pressure unit", () => {
+    expect(parseFinderUrl({ p: "2", pu: "atm" })).toEqual({ pressure: 2 });
+  });
+
+  it("parses gasMix into mixture mode + components", () => {
+    expect(parseFinderUrl({ gasMix: "silane:5,nitrogen:95" })).toEqual({
+      gasMode: "mixture",
+      components: [
+        { gasId: "silane", percent: 5 },
+        { gasId: "nitrogen", percent: 95 },
+      ],
+    });
+  });
+
+  it("drops malformed gasMix entries but keeps valid ones", () => {
+    expect(
+      parseFinderUrl({ gasMix: "silane:5,bad,nitrogen:0,argon:10" }),
+    ).toEqual({
+      gasMode: "mixture",
+      components: [
+        { gasId: "silane", percent: 5 },
+        { gasId: "argon", percent: 10 },
+      ],
+    });
+  });
+
+  it("returns no mixture when every gasMix entry is invalid", () => {
+    expect(parseFinderUrl({ gasMix: "bad,worse:nope" })).toEqual({});
+  });
+
+  it("collapses array-shaped query params to the first value", () => {
+    expect(parseFinderUrl({ fn: ["MFC", "EPC"], flow: ["50", "100"] })).toEqual(
+      { fn: "MFC", flow: 50 },
+    );
+  });
+});

--- a/src/lib/finder/parseFinderUrl.ts
+++ b/src/lib/finder/parseFinderUrl.ts
@@ -1,0 +1,78 @@
+import type { ProductFinderInitial } from "@/components/finder/ProductFinder";
+import {
+  type FinderFunction,
+  type FinderSeries,
+  type FinderUnit,
+} from "./match";
+import { PRESSURE_UNITS, type PressureUnit } from "./pressure";
+
+const FUNCTIONS: ReadonlySet<FinderFunction> = new Set([
+  "any",
+  "MFC",
+  "MFM",
+  "EPC",
+]);
+const SERIES: ReadonlySet<FinderSeries> = new Set([
+  "any",
+  "analogue",
+  "digital",
+  "specialized",
+  "lepc",
+]);
+const UNITS: ReadonlySet<FinderUnit> = new Set(["slpm", "sccm"]);
+const PRESSURE_UNIT_SET: ReadonlySet<PressureUnit> = new Set(PRESSURE_UNITS);
+
+function pickString(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+export function parseFinderUrl(
+  raw: Record<string, string | string[] | undefined>,
+): ProductFinderInitial {
+  const initial: ProductFinderInitial = {};
+  const fn = pickString(raw.fn);
+  if (fn && FUNCTIONS.has(fn as FinderFunction)) {
+    initial.fn = fn as FinderFunction;
+  }
+  const gas = pickString(raw.gas);
+  if (gas) initial.gas = gas;
+  const flow = pickString(raw.flow);
+  if (flow) {
+    const n = Number(flow);
+    if (Number.isFinite(n) && n > 0) initial.flow = n;
+  }
+  const unit = pickString(raw.unit);
+  if (unit && UNITS.has(unit as FinderUnit)) {
+    initial.unit = unit as FinderUnit;
+  }
+  const series = pickString(raw.series);
+  if (series && SERIES.has(series as FinderSeries)) {
+    initial.series = series as FinderSeries;
+  }
+  const pressure = pickString(raw.p);
+  if (pressure) {
+    const n = Number(pressure);
+    if (Number.isFinite(n) && n > 0) initial.pressure = n;
+  }
+  const pressureUnit = pickString(raw.pu);
+  if (pressureUnit && PRESSURE_UNIT_SET.has(pressureUnit as PressureUnit)) {
+    initial.pressureUnit = pressureUnit as PressureUnit;
+  }
+  // `gasMix=silane:5,nitrogen:95` — comma-separated gasId:percent pairs.
+  const gasMix = pickString(raw.gasMix);
+  if (gasMix) {
+    const components = gasMix.split(",").flatMap((entry) => {
+      const [gasId, percentRaw] = entry.split(":");
+      if (!gasId) return [];
+      const percent = Number(percentRaw);
+      if (!Number.isFinite(percent) || percent <= 0) return [];
+      return [{ gasId: gasId.trim(), percent }];
+    });
+    if (components.length > 0) {
+      initial.gasMode = "mixture";
+      initial.components = components;
+    }
+  }
+  return initial;
+}

--- a/src/lib/finder/parseFinderUrl.ts
+++ b/src/lib/finder/parseFinderUrl.ts
@@ -1,10 +1,11 @@
-import type { ProductFinderInitial } from "@/components/finder/ProductFinder";
+import { getGasFactor } from "./gas-factors";
 import {
   type FinderFunction,
   type FinderSeries,
   type FinderUnit,
 } from "./match";
 import { PRESSURE_UNITS, type PressureUnit } from "./pressure";
+import type { ProductFinderInitial } from "./types";
 
 const FUNCTIONS: ReadonlySet<FinderFunction> = new Set([
   "any",
@@ -22,6 +23,11 @@ const SERIES: ReadonlySet<FinderSeries> = new Set([
 const UNITS: ReadonlySet<FinderUnit> = new Set(["slpm", "sccm"]);
 const PRESSURE_UNIT_SET: ReadonlySet<PressureUnit> = new Set(PRESSURE_UNITS);
 
+// Caps mixture component count so a hand-crafted URL like
+// `?gasMix=a:1,a:1,…×100000` can't OOM SSR or render thousands of
+// GasSelect comboboxes. Real mixtures rarely exceed 5 components.
+const MAX_MIXTURE_COMPONENTS = 20;
+
 function pickString(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) return value[0];
   return value;
@@ -36,7 +42,7 @@ export function parseFinderUrl(
     initial.fn = fn as FinderFunction;
   }
   const gas = pickString(raw.gas);
-  if (gas) initial.gas = gas;
+  if (gas && getGasFactor(gas)) initial.gas = gas;
   const flow = pickString(raw.flow);
   if (flow) {
     const n = Number(flow);
@@ -50,25 +56,34 @@ export function parseFinderUrl(
   if (series && SERIES.has(series as FinderSeries)) {
     initial.series = series as FinderSeries;
   }
-  const pressure = pickString(raw.p);
-  if (pressure) {
-    const n = Number(pressure);
-    if (Number.isFinite(n) && n > 0) initial.pressure = n;
+  // Treat `?p=2&pu=atm` (valid value, bogus unit) as garbage rather than
+  // silently assuming bar — that'd misinterpret the user's intent.
+  const pressureUnitRaw = pickString(raw.pu);
+  const pressureUnitValid =
+    pressureUnitRaw != null &&
+    PRESSURE_UNIT_SET.has(pressureUnitRaw as PressureUnit);
+  if (pressureUnitRaw == null || pressureUnitValid) {
+    const pressure = pickString(raw.p);
+    if (pressure) {
+      const n = Number(pressure);
+      if (Number.isFinite(n) && n > 0) initial.pressure = n;
+    }
   }
-  const pressureUnit = pickString(raw.pu);
-  if (pressureUnit && PRESSURE_UNIT_SET.has(pressureUnit as PressureUnit)) {
-    initial.pressureUnit = pressureUnit as PressureUnit;
+  if (pressureUnitValid) {
+    initial.pressureUnit = pressureUnitRaw as PressureUnit;
   }
   // `gasMix=silane:5,nitrogen:95` — comma-separated gasId:percent pairs.
   const gasMix = pickString(raw.gasMix);
   if (gasMix) {
-    const components = gasMix.split(",").flatMap((entry) => {
-      const [gasId, percentRaw] = entry.split(":");
-      if (!gasId) return [];
-      const percent = Number(percentRaw);
-      if (!Number.isFinite(percent) || percent <= 0) return [];
-      return [{ gasId: gasId.trim(), percent }];
-    });
+    const components = gasMix
+      .split(",", MAX_MIXTURE_COMPONENTS)
+      .flatMap((entry) => {
+        const [gasId, percentRaw] = entry.split(":");
+        if (!gasId) return [];
+        const percent = Number(percentRaw);
+        if (!Number.isFinite(percent) || percent <= 0) return [];
+        return [{ gasId: gasId.trim(), percent }];
+      });
     if (components.length > 0) {
       initial.gasMode = "mixture";
       initial.components = components;

--- a/src/lib/finder/pressure.test.ts
+++ b/src/lib/finder/pressure.test.ts
@@ -30,4 +30,12 @@ describe("catalogValueToBar", () => {
   it("defaults to bar when unit is missing", () => {
     expect(catalogValueToBar(3, undefined)).toBe(3);
   });
+
+  it("returns null when value is NaN", () => {
+    expect(catalogValueToBar(Number.NaN, "bar")).toBeNull();
+  });
+
+  it("returns null when value is Infinity", () => {
+    expect(catalogValueToBar(Number.POSITIVE_INFINITY, "bar")).toBeNull();
+  });
 });

--- a/src/lib/finder/pressure.test.ts
+++ b/src/lib/finder/pressure.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { catalogValueToBar, toBar } from "./pressure";
+
+describe("toBar", () => {
+  it("passes bar through", () => {
+    expect(toBar(2, "bar")).toBe(2);
+  });
+  it("converts kPa to bar", () => {
+    expect(toBar(200, "kPa")).toBeCloseTo(2, 6);
+  });
+  it("converts MPa to bar", () => {
+    expect(toBar(0.5, "MPa")).toBeCloseTo(5, 6);
+  });
+  it("converts psi to bar", () => {
+    expect(toBar(14.5038, "psi")).toBeCloseTo(1, 3);
+  });
+});
+
+describe("catalogValueToBar", () => {
+  it("treats barA/barG as bar", () => {
+    expect(catalogValueToBar(2, "barA")).toBe(2);
+    expect(catalogValueToBar(2, "barG")).toBe(2);
+  });
+  it("converts MPa values from catalogue", () => {
+    expect(catalogValueToBar(0.5, "MPa")).toBeCloseTo(5, 6);
+  });
+  it("returns null on unknown unit", () => {
+    expect(catalogValueToBar(1, "atm")).toBeNull();
+  });
+  it("defaults to bar when unit is missing", () => {
+    expect(catalogValueToBar(3, undefined)).toBe(3);
+  });
+});

--- a/src/lib/finder/pressure.ts
+++ b/src/lib/finder/pressure.ts
@@ -1,0 +1,40 @@
+export type PressureUnit = "bar" | "kPa" | "psi" | "MPa";
+
+export const PRESSURE_UNITS: readonly PressureUnit[] = [
+  "bar",
+  "kPa",
+  "psi",
+  "MPa",
+] as const;
+
+const TO_BAR: Record<PressureUnit, number> = {
+  bar: 1,
+  kPa: 0.01,
+  psi: 0.0689475729,
+  MPa: 10,
+};
+
+export function toBar(value: number, unit: PressureUnit): number {
+  return value * TO_BAR[unit];
+}
+
+/**
+ * Normalize a catalogue-side pressure unit string (e.g. "bar", "barA", "barG",
+ * "kPa", "MPa", "psi") to bar. Treats absolute/gauge variants as bar — the
+ * atmospheric offset is in the noise for finder ranking.
+ */
+export function catalogValueToBar(
+  value: number,
+  unit: string | undefined,
+): number | null {
+  if (!Number.isFinite(value)) return null;
+  if (!unit) return value;
+  const normalized = unit.trim().toLowerCase();
+  if (normalized.startsWith("bar")) return value;
+  if (normalized === "kpa") return value * TO_BAR.kPa;
+  if (normalized === "mpa") return value * TO_BAR.MPa;
+  if (normalized === "psi" || normalized === "psig" || normalized === "psia") {
+    return value * TO_BAR.psi;
+  }
+  return null;
+}

--- a/src/lib/finder/types.ts
+++ b/src/lib/finder/types.ts
@@ -1,0 +1,17 @@
+import type { FinderFunction, FinderSeries, FinderUnit } from "./match";
+import type { GasComponent } from "./mixture";
+import type { PressureUnit } from "./pressure";
+
+export type GasMode = "pure" | "mixture";
+
+export type ProductFinderInitial = {
+  fn?: FinderFunction;
+  gas?: string;
+  flow?: number;
+  unit?: FinderUnit;
+  series?: FinderSeries;
+  gasMode?: GasMode;
+  components?: GasComponent[];
+  pressure?: number;
+  pressureUnit?: PressureUnit;
+};


### PR DESCRIPTION
## Summary

Closes #230.

- **Gas mixture mode** — new Pure/Mixture toggle on the Product Finder. Mixture mode resolves the effective K-factor via the FAQ harmonic-mean formula (`1/K_mix = Σ pᵢ/Kᵢ`) and feeds it through the existing N₂-equivalent matching path. Customers no longer have to pick a closest-single-gas approximation for blends like 5% SiH₄ / 95% N₂.
- **Operating pressure filter** — new optional pressure input (bar / kPa / psi / MPa). EPC products must fall inside `pressureRange`; MFC/MFM products must have `maxPressure ≥ user pressure` (with per-unit conversion). Empty input preserves current behavior.
- **URL state**: `?gasMix=silane:5,nitrogen:95` and `?p=2&pu=bar`. Legacy `?gas=&flow=&unit=` continues to work unchanged.
- **Drive-by**: PR #253 introduced an `AccessoriesSideNav.test.tsx` fixture referencing `lti-200`, but #254 renamed that accessory to `lti-2000` — `tsc --noEmit` was failing on main. Updated the fixture id.

## Test plan

- [x] vitest: 489/489 pass (added 28 new across `mixture.test.ts`, `pressure.test.ts`, `parseFinderUrl.test.ts`, `MixtureEditor.test.tsx`, plus pressure cases in `match.test.ts` and `ProductFinder.test.tsx`)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed dirs
- [x] Manual: dev server at `/en/products/finder` — toggle Pure/Mixture, enter components, see total indicator + matches; enter pressure, see filtering narrow results.
- [ ] Playwright `e2e/product-finder.spec.ts` (3 new cases for mixture + pressure) — runs in CI; local run blocked by a concurrent dev server, spec lists clean (9 tests).
- [ ] Walk the page in all three locales (ko/en/zh) to confirm i18n strings render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)