### PR TITLE
fix(contact): correct prefill copy + add editable Model field

### DIFF
--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -202,6 +202,18 @@ test.describe("Contact form", () => {
     await expect(page.locator("#ct-fitting-type")).toBeVisible();
   });
 
+  test("prefilled message in ko/zh drops directional 'below' wording", async ({
+    page,
+  }) => {
+    await page.goto("/ko/contact?product=M3030VA");
+    await expect(page.locator("#ct-message")).not.toHaveValue(/아래/);
+    await expect(page.locator("#ct-quote-model")).toHaveValue("M3030VA");
+
+    await page.goto("/zh/contact?product=M3030VA");
+    await expect(page.locator("#ct-message")).not.toHaveValue(/下方/);
+    await expect(page.locator("#ct-quote-model")).toHaveValue("M3030VA");
+  });
+
   test("Model input is always visible when Quote is selected, blank without prefill", async ({
     page,
   }) => {

--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -191,11 +191,24 @@ test.describe("Contact form", () => {
       /Quote request: M3030VA/,
     );
     await expect(page.locator("#ct-message")).toHaveValue(/M3030VA/);
+    // The prefilled message must not claim conditions are "below" — they
+    // render above the message textarea, not below.
+    await expect(page.locator("#ct-message")).not.toHaveValue(/below/i);
     // Process conditions block must be rendered as a result of the prefill.
+    await expect(page.locator("#ct-quote-model")).toHaveValue("M3030VA");
     await expect(page.locator("#ct-gas")).toBeVisible();
     await expect(page.locator("#ct-flow-value")).toBeVisible();
     await expect(page.locator("#ct-pressure-value")).toBeVisible();
     await expect(page.locator("#ct-fitting-type")).toBeVisible();
+  });
+
+  test("Model input is always visible when Quote is selected, blank without prefill", async ({
+    page,
+  }) => {
+    await page.locator("#ct-inquiry-type").selectOption("quote");
+    const model = page.locator("#ct-quote-model");
+    await expect(model).toBeVisible();
+    await expect(model).toHaveValue("");
   });
 
   test("flags missing quote fields when submitted blank", async ({ page }) => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -351,7 +351,8 @@
       "pressureValue": "Please enter a positive pressure.",
       "pressureUnit": "Please choose a pressure unit.",
       "fittingType": "Please choose a fitting type.",
-      "fittingSize": "Please enter the fitting size."
+      "fittingSize": "Please enter the fitting size.",
+      "model": "Please enter the model name."
     },
     "successTitle": "Your inquiry was sent.",
     "success": "A Line Tech representative will reply to the email address you provided.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -351,7 +351,8 @@
       "pressureValue": "압력을 0보다 큰 숫자로 입력해 주세요.",
       "pressureUnit": "압력 단위를 선택해 주세요.",
       "fittingType": "피팅 타입을 선택해 주세요.",
-      "fittingSize": "피팅 사이즈를 입력해 주세요."
+      "fittingSize": "피팅 사이즈를 입력해 주세요.",
+      "model": "모델명을 입력해 주세요."
     },
     "successTitle": "문의가 정상적으로 전송되었습니다.",
     "success": "입력하신 이메일 주소로 담당자가 회신드릴 예정입니다.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -351,7 +351,8 @@
       "pressureValue": "请输入大于零的压力数值。",
       "pressureUnit": "请选择压力单位。",
       "fittingType": "请选择接头类型。",
-      "fittingSize": "请填写接头规格。"
+      "fittingSize": "请填写接头规格。",
+      "model": "请填写型号。"
     },
     "successTitle": "您的咨询已发送。",
     "success": "Line Tech 负责人将通过您填写的邮箱回复。",

--- a/sanity/schemaTypes/contactSubmission.ts
+++ b/sanity/schemaTypes/contactSubmission.ts
@@ -22,12 +22,6 @@ export const contactSubmission = defineType({
       type: "string",
     }),
     defineField({
-      name: "model",
-      title: "Model",
-      type: "string",
-      description: "Quote requests — product model the inquiry is about.",
-    }),
-    defineField({
       name: "name",
       title: "Name",
       type: "string",
@@ -56,6 +50,12 @@ export const contactSubmission = defineType({
       name: "message",
       title: "Message",
       type: "text",
+    }),
+    defineField({
+      name: "model",
+      title: "Model",
+      type: "string",
+      description: "Quote requests only — product model the inquiry is about.",
     }),
     defineField({
       name: "gasMode",

--- a/sanity/schemaTypes/contactSubmission.ts
+++ b/sanity/schemaTypes/contactSubmission.ts
@@ -22,6 +22,12 @@ export const contactSubmission = defineType({
       type: "string",
     }),
     defineField({
+      name: "model",
+      title: "Model",
+      type: "string",
+      description: "Quote requests — product model the inquiry is about.",
+    }),
+    defineField({
       name: "name",
       title: "Name",
       type: "string",

--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -12,6 +12,7 @@ import { QuoteFields } from "./QuoteFields";
 type ContactFormDefaults = {
   inquiryType: InquiryTypeId;
   extraField?: string;
+  model?: string;
   subject: string;
   message: string;
 };
@@ -190,6 +191,7 @@ export function ContactForm({ form, defaults }: Props) {
             requiredLabel={form.required}
             invalidFields={invalidFields}
             fieldErrId={fieldErrId}
+            defaultModel={defaults?.model}
           />
         )}
 

--- a/src/app/[locale]/contact/QuoteFields.test.tsx
+++ b/src/app/[locale]/contact/QuoteFields.test.tsx
@@ -10,6 +10,10 @@ vi.mock("next-intl", () => ({
 const form: ContactFormCopy["quoteFields"] = {
   heading: "Process conditions",
   helper: "Fill in.",
+  model: {
+    label: "Model",
+    placeholder: "e.g. M3030VA",
+  },
   gas: {
     label: "Gas",
     placeholder: "e.g. N2",
@@ -50,7 +54,10 @@ const form: ContactFormCopy["quoteFields"] = {
   },
 };
 
-function renderQuote(invalid: ReadonlySet<string> = new Set()) {
+function renderQuote(
+  invalid: ReadonlySet<string> = new Set(),
+  defaultModel?: string,
+) {
   return render(
     <form>
       <QuoteFields
@@ -58,12 +65,32 @@ function renderQuote(invalid: ReadonlySet<string> = new Set()) {
         requiredLabel="Required"
         invalidFields={invalid}
         fieldErrId={(name) => `ct-${name}-err`}
+        defaultModel={defaultModel}
       />
     </form>,
   );
 }
 
 describe("QuoteFields", () => {
+  it("renders an empty Model input when no defaultModel is supplied", () => {
+    renderQuote();
+    const model = document.getElementById("ct-quote-model") as HTMLInputElement;
+    expect(model).not.toBeNull();
+    expect(model.name).toBe("model");
+    expect(model.value).toBe("");
+  });
+
+  it("prefills the Model input from defaultModel", () => {
+    renderQuote(new Set(), "M3030VA");
+    const model = document.getElementById("ct-quote-model") as HTMLInputElement;
+    expect(model.value).toBe("M3030VA");
+  });
+
+  it("surfaces the model field error when the schema rejects", () => {
+    renderQuote(new Set(["model"]));
+    expect(screen.getByRole("alert")).toHaveTextContent("fieldErrors.model");
+  });
+
   it("starts in pure mode with a single gas input", () => {
     renderQuote();
     expect(screen.getByLabelText(/Pure gas/)).toBeChecked();

--- a/src/app/[locale]/contact/QuoteFields.test.tsx
+++ b/src/app/[locale]/contact/QuoteFields.test.tsx
@@ -74,21 +74,25 @@ function renderQuote(
 describe("QuoteFields", () => {
   it("renders an empty Model input when no defaultModel is supplied", () => {
     renderQuote();
-    const model = document.getElementById("ct-quote-model") as HTMLInputElement;
-    expect(model).not.toBeNull();
+    const model = screen.getByLabelText("Model") as HTMLInputElement;
     expect(model.name).toBe("model");
     expect(model.value).toBe("");
   });
 
   it("prefills the Model input from defaultModel", () => {
     renderQuote(new Set(), "M3030VA");
-    const model = document.getElementById("ct-quote-model") as HTMLInputElement;
+    const model = screen.getByLabelText("Model") as HTMLInputElement;
     expect(model.value).toBe("M3030VA");
   });
 
   it("surfaces the model field error when the schema rejects", () => {
     renderQuote(new Set(["model"]));
-    expect(screen.getByRole("alert")).toHaveTextContent("fieldErrors.model");
+    const model = screen.getByLabelText("Model");
+    const errId = model.getAttribute("aria-describedby");
+    expect(errId).toBeTruthy();
+    expect(document.getElementById(errId!)).toHaveTextContent(
+      "fieldErrors.model",
+    );
   });
 
   it("starts in pure mode with a single gas input", () => {

--- a/src/app/[locale]/contact/QuoteFields.tsx
+++ b/src/app/[locale]/contact/QuoteFields.tsx
@@ -12,6 +12,7 @@ type Props = {
   requiredLabel: string;
   invalidFields: ReadonlySet<string>;
   fieldErrId: (name: string) => string;
+  defaultModel?: string;
 };
 
 function serializeComponents(components: GasComponentDraft[]): string {
@@ -28,6 +29,7 @@ export function QuoteFields({
   requiredLabel,
   invalidFields,
   fieldErrId,
+  defaultModel,
 }: Props) {
   const t = useTranslations("contactForm");
   // useRef counter survives mode toggles but resets per mount, so HMR can't
@@ -79,6 +81,36 @@ export function QuoteFields({
       <legend className="ct-form__quote-heading">{form.heading}</legend>
       <p className="ct-form__quote-helper">{form.helper}</p>
       <div className="ct-form__quote-grid">
+        <div className="ct-form__row ct-form__quote-row--full">
+          <label htmlFor="ct-quote-model" className="ct-form__label">
+            {form.model.label}
+          </label>
+          <input
+            id="ct-quote-model"
+            name="model"
+            type="text"
+            defaultValue={defaultModel}
+            placeholder={form.model.placeholder}
+            className={
+              invalidFields.has("model")
+                ? "ct-form__input ct-form__input--invalid"
+                : "ct-form__input"
+            }
+            aria-invalid={invalidFields.has("model") || undefined}
+            aria-describedby={
+              invalidFields.has("model") ? fieldErrId("model") : undefined
+            }
+          />
+          {invalidFields.has("model") && (
+            <p
+              id={fieldErrId("model")}
+              className="ct-form__field-error"
+              role="alert"
+            >
+              {t("fieldErrors.model")}
+            </p>
+          )}
+        </div>
         <div className="ct-form__row ct-form__quote-row--full">
           <span className="ct-form__label">
             {form.gas.label}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -58,6 +58,7 @@ export default async function ContactPage({ params, searchParams }: Props) {
   const defaults = product
     ? {
         inquiryType: "quote" as const,
+        model: product.model,
         subject: form.productInquiry.subject.replaceAll(
           "{model}",
           product.model,

--- a/src/lib/contact/email.test.ts
+++ b/src/lib/contact/email.test.ts
@@ -156,6 +156,61 @@ describe("sendContactEmail", () => {
     expect(email.to).toEqual(["valid@example.com", "another@example.com"]);
   });
 
+  it("includes the model in the quote details when supplied", async () => {
+    const quote: ContactFormPayload = {
+      inquiryType: "quote",
+      name: "Buyer",
+      email: "buyer@example.com",
+      message: "Quote please.",
+      model: "M3030VA",
+      gasMode: "pure",
+      gas: "N2",
+      flowValue: "500",
+      flowUnit: "sccm",
+      pressureValue: "2",
+      pressureUnit: "bar",
+      fittingType: "VCR",
+      fittingSize: '1/4"',
+      consent: "on",
+      website: "",
+      "cf-turnstile-response": "tok",
+    };
+
+    await sendContactEmail(quote);
+
+    const email = sendMock.mock.calls[0]![0];
+    expect(email.html).toContain("모델");
+    expect(email.html).toContain("M3030VA");
+    expect(email.text).toContain("- 모델: M3030VA");
+  });
+
+  it("omits the model row from the quote details when not supplied", async () => {
+    const quote: ContactFormPayload = {
+      inquiryType: "quote",
+      name: "Buyer",
+      email: "buyer@example.com",
+      message: "Quote please.",
+      gasMode: "pure",
+      gas: "N2",
+      flowValue: "500",
+      flowUnit: "sccm",
+      pressureValue: "2",
+      pressureUnit: "bar",
+      fittingType: "VCR",
+      fittingSize: '1/4"',
+      consent: "on",
+      website: "",
+      "cf-turnstile-response": "tok",
+    };
+
+    await sendContactEmail(quote);
+
+    const email = sendMock.mock.calls[0]![0];
+    expect(email.text).not.toContain("- 모델:");
+    // The HTML quote-details table should not include a 모델 row.
+    expect(email.html).not.toMatch(/>모델</);
+  });
+
   it("falls back to the default when all entries are malformed", async () => {
     vi.stubEnv("CONTACT_FORM_TO", "nope, also-nope");
 

--- a/src/lib/contact/email.ts
+++ b/src/lib/contact/email.ts
@@ -87,6 +87,7 @@ function buildText(data: ContactFormPayload): string {
       ? [
           "",
           "공정 조건:",
+          ...(data.model ? [`- 모델: ${data.model}`] : []),
           ...(gasSummary ? [`- 가스: ${gasSummary}`] : []),
           ...(formatFlow(data) ? [`- 유량: ${formatFlow(data)}`] : []),
           ...(formatPressure(data) ? [`- 압력: ${formatPressure(data)}`] : []),
@@ -177,6 +178,7 @@ function buildHtml(data: ContactFormPayload): string {
     row("문의 유형", escapeHtml(formatInquiryType(data))),
     ...(data.company ? [row("회사명", escapeHtml(data.company))] : []),
     ...(data.subject ? [row("제목", escapeHtml(data.subject))] : []),
+    ...(isQuote && data.model ? [row("모델", escapeHtml(data.model))] : []),
     ...(isQuote && gasText ? [row("가스", escapeHtml(gasText))] : []),
     ...(isQuote && flowText ? [row("유량", escapeHtml(flowText))] : []),
     ...(isQuote && pressureText ? [row("압력", escapeHtml(pressureText))] : []),

--- a/src/lib/contact/persist.test.ts
+++ b/src/lib/contact/persist.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import {
   contactPayloadFixture,
   makeContactPayload,
+  makeQuotePayload,
 } from "@/test/fixtures/contact";
 
 const { createClientMock, createMock } = vi.hoisted(() => ({
@@ -79,6 +80,15 @@ describe("persistContactSubmission", () => {
     expect(doc.company).toBeUndefined();
     expect(doc.phone).toBeUndefined();
     expect(doc.subject).toBeUndefined();
+    expect(doc.model).toBeUndefined();
+  });
+
+  it("persists the model on quote submissions", async () => {
+    vi.stubEnv("SANITY_WRITE_TOKEN", "write-token");
+    await persistContactSubmission(makeQuotePayload({ model: "M3030VA" }));
+
+    const doc = createMock.mock.calls[0][0];
+    expect(doc.model).toBe("M3030VA");
   });
 
   it("propagates errors from the Sanity client", async () => {

--- a/src/lib/contact/persist.ts
+++ b/src/lib/contact/persist.ts
@@ -23,6 +23,7 @@ export async function persistContactSubmission(
     submittedAt: new Date().toISOString(),
     inquiryType: data.inquiryType,
     typeDetail: data.typeDetail ?? undefined,
+    model: data.model ?? undefined,
     name: data.name,
     email: data.email,
     company: data.company ?? undefined,

--- a/src/lib/contact/schema.test.ts
+++ b/src/lib/contact/schema.test.ts
@@ -253,6 +253,9 @@ describe("contactFormSchema", () => {
         makeQuotePayload({ model: "x".repeat(121) }),
       );
       expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.model).toBeDefined();
+      }
     });
 
     it("does not require quote fields for non-quote inquiries", () => {

--- a/src/lib/contact/schema.test.ts
+++ b/src/lib/contact/schema.test.ts
@@ -240,6 +240,21 @@ describe("contactFormSchema", () => {
       expect(result.success).toBe(false);
     });
 
+    it("accepts an optional model string on a quote payload", () => {
+      const result = contactFormSchema.safeParse(
+        makeQuotePayload({ model: "M3030VA" }),
+      );
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.model).toBe("M3030VA");
+    });
+
+    it("rejects a model longer than 120 chars", () => {
+      const result = contactFormSchema.safeParse(
+        makeQuotePayload({ model: "x".repeat(121) }),
+      );
+      expect(result.success).toBe(false);
+    });
+
     it("does not require quote fields for non-quote inquiries", () => {
       const result = contactFormSchema.safeParse({
         inquiryType: "general",

--- a/src/lib/contact/schema.ts
+++ b/src/lib/contact/schema.ts
@@ -64,6 +64,7 @@ export const contactFormSchema = z
   .object({
     inquiryType: z.string().min(1).max(64),
     typeDetail: z.string().max(200).optional(),
+    model: z.string().max(120).optional(),
     name: z.string().min(1).max(120),
     email: z.string().email().max(254),
     company: z.string().max(200).optional(),

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -24,6 +24,10 @@ export type QuoteUnit<V extends string = string> = {
 export type QuoteFieldsCopy = {
   heading: string;
   helper: string;
+  model: {
+    label: string;
+    placeholder: string;
+  };
   gas: {
     label: string;
     placeholder: string;
@@ -242,7 +246,11 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       ],
       quoteFields: {
         heading: "공정 조건",
-        helper: "정확한 견적을 위해 아래 네 가지 정보를 함께 알려주세요.",
+        helper: "정확한 견적을 위해 아래 정보를 함께 알려주세요.",
+        model: {
+          label: "모델명",
+          placeholder: "예: M3030VA",
+        },
         gas: {
           label: "가스",
           placeholder: "예: N2, Ar",
@@ -316,7 +324,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       productInquiry: {
         subject: "{model} 견적 문의",
         message:
-          "{model}에 대한 견적을 요청드립니다. 아래에 공정 조건을 입력해 주세요.",
+          "{model}에 대한 견적을 요청드립니다. 공정 조건은 양식에 함께 입력했습니다.",
       },
     },
     distributors: {
@@ -439,7 +447,11 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       quoteFields: {
         heading: "Process conditions",
         helper:
-          "Share the four details below so we can price your MFC/MFM accurately.",
+          "Share the details below so we can price your MFC/MFM accurately.",
+        model: {
+          label: "Model",
+          placeholder: "e.g. M3030VA",
+        },
         gas: {
           label: "Gas",
           placeholder: "e.g. N2, Ar",
@@ -514,7 +526,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       productInquiry: {
         subject: "Quote request: {model}",
         message:
-          "I'd like to request a quote for the {model}. Process conditions are filled in below.",
+          "I'd like to request a quote for the {model}. Process conditions are included in this form.",
       },
     },
     distributors: {
@@ -640,7 +652,11 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       ],
       quoteFields: {
         heading: "工艺条件",
-        helper: "请提供以下四项信息，便于我们准确报价。",
+        helper: "请提供以下信息，便于我们准确报价。",
+        model: {
+          label: "型号",
+          placeholder: "例如：M3030VA",
+        },
         gas: {
           label: "气体",
           placeholder: "例如：N2、Ar",
@@ -713,7 +729,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       },
       productInquiry: {
         subject: "{model} 报价咨询",
-        message: "我想申请 {model} 的报价，工艺条件已在下方填写。",
+        message: "我想申请 {model} 的报价，工艺条件已在表单中填写。",
       },
     },
     distributors: {

--- a/src/lib/content/contact.ts
+++ b/src/lib/content/contact.ts
@@ -323,8 +323,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       },
       productInquiry: {
         subject: "{model} 견적 문의",
-        message:
-          "{model}에 대한 견적을 요청드립니다. 공정 조건은 양식에 함께 입력했습니다.",
+        message: "{model}에 대한 견적을 요청드립니다.",
       },
     },
     distributors: {
@@ -525,8 +524,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       },
       productInquiry: {
         subject: "Quote request: {model}",
-        message:
-          "I'd like to request a quote for the {model}. Process conditions are included in this form.",
+        message: "I'd like to request a quote for the {model}.",
       },
     },
     distributors: {
@@ -729,7 +727,7 @@ export const LT_CONTACT: Record<Locale, ContactContent> = {
       },
       productInquiry: {
         subject: "{model} 报价咨询",
-        message: "我想申请 {model} 的报价，工艺条件已在表单中填写。",
+        message: "我想申请 {model} 的报价。",
       },
     },
     distributors: {


### PR DESCRIPTION
## Summary

- Reword the product-page-prefilled message (ko / en / zh) so it no longer claims process conditions are "below" — the conditions block actually renders above the message textarea.
- Add an editable **Model** input at the top of the Quote conditions block. Always visible when Quote is selected, prefilled from `?product=<model>` when arriving from a product detail page.
- Plumb optional `model` through schema validation, Sanity persistence, and the sales notification email.

## Test plan

- [x] `pnpm test:run` — 96 contact tests pass, including 3 new model-input tests, 2 new schema model tests, 2 new email model tests
- [x] `pnpm typecheck` — clean
- [x] `pnpm i18n:check` — locale parity holds (232 keys across en/ko/zh)
- [x] Manual: `pnpm dev` + curl `/en/contact?product=M3030VA`, `/ko/contact?product=M3030VA`, `/zh/contact?product=M3030VA` — Model input renders `value="M3030VA"`, message text matches the reworded copy, DOM order is Model → Gas → Flow → Pressure → Fitting → Subject → Message
- [ ] Playwright e2e (`pnpm e2e contact-form`) — added two new assertions (no "below" in prefilled message; Model field stays empty when Quote is selected without prefill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)