### PR TITLE
fix(header): route Quote button to /contact instead of mailto

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -44,12 +44,7 @@ export function Header({ locale }: Props) {
           <SearchTriggerButton label={shell.search.openLabel} />
           <span className="pd-top__divider" aria-hidden="true" />
           <LocaleSwitcher />
-          <Button
-            variant="primary"
-            size="md"
-            href={`mailto:${shell.footer.contact.email}`}
-            plain
-          >
+          <Button variant="primary" size="md" href="/contact">
             {shell.quoteLabel}
           </Button>
           <MobileNavTrigger

--- a/src/components/layout/MobileNav/MobileNav.test.tsx
+++ b/src/components/layout/MobileNav/MobileNav.test.tsx
@@ -76,7 +76,8 @@ describe("MobileNav", () => {
       ).toBeInTheDocument();
     });
     expect(container.querySelector(".lt-locale")).toBeInTheDocument();
-    expect(within(container).getByText("Quote")).toBeInTheDocument();
+    const quote = within(container).getByText("Quote").closest("a");
+    expect(quote).toHaveAttribute("href", "/contact");
   });
 
   it("menu items render as accordion triggers, contact renders as a link", () => {

--- a/src/components/layout/MobileNav/MobileNav.test.tsx
+++ b/src/components/layout/MobileNav/MobileNav.test.tsx
@@ -76,7 +76,7 @@ describe("MobileNav", () => {
       ).toBeInTheDocument();
     });
     expect(container.querySelector(".lt-locale")).toBeInTheDocument();
-    const quote = within(container).getByText("Quote").closest("a");
+    const quote = within(container).getByRole("link", { name: "Quote" });
     expect(quote).toHaveAttribute("href", "/contact");
   });
 

--- a/src/components/layout/MobileNav/MobileNav.tsx
+++ b/src/components/layout/MobileNav/MobileNav.tsx
@@ -4,11 +4,7 @@ import { useEffect, useId, useRef, useState, type RefObject } from "react";
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
 import { Button } from "@/components/ui/Button";
-import {
-  LT_SHELL,
-  getProductsCategories,
-  type ShellNavItem,
-} from "@/lib/content/shell";
+import { getProductsCategories, type ShellNavItem } from "@/lib/content/shell";
 import type { Locale } from "@/lib/content/home";
 import { useDialogPanel } from "@/lib/hooks/useDialogPanel";
 import { LocaleSwitcher } from "../LocaleSwitcher/LocaleSwitcher";
@@ -114,12 +110,7 @@ export function MobileNav({
 
           <div className="pd-mnav__footer">
             <LocaleSwitcher />
-            <Button
-              variant="primary"
-              size="md"
-              href={`mailto:${LT_SHELL[locale].footer.contact.email}`}
-              plain
-            >
+            <Button variant="primary" size="md" href="/contact">
               {quoteLabel}
             </Button>
           </div>

--- a/src/lib/content/shell.ts
+++ b/src/lib/content/shell.ts
@@ -130,7 +130,7 @@ export type ShellMobileNav = {
 
 export type ShellContent = {
   nav: ShellNavItem[];
-  /** Top-right "Quote" button label in the header. Mailto target is shared. */
+  /** Top-right "Quote" button label in the header. Routes to /contact. */
   quoteLabel: string;
   /** Product mega-menu categories — 4 series + 1 accessories entry. */
   productsCategories: ProductsCategory[];


### PR DESCRIPTION
## Summary

- The top-right **Quote** button (both header and mobile-nav drawer) opened the user's mail client via `mailto:linetech@line-tech.co.kr` instead of routing to the structured `/contact` form — surprising, since the form already exists, supports all 3 locales, and auto-selects `inquiryType: "quote"`.
- Swap both `<Button>` callsites to a locale-aware `href="/contact"` link (drops `plain`, so routing goes through next-intl `Link`).
- Footer `mailto:` links are untouched for users who genuinely want email.

## Test plan

- [x] `pnpm test` — 524/524 passing; `MobileNav` test tightened to assert the Quote anchor's `href` is `/contact`.
- [x] `tsc --noEmit` — clean.
- [ ] Manual: load `/en`, `/ko`, `/zh`; click Quote in the top-right and from the mobile drawer; confirm both navigate to the locale-prefixed `/contact` instead of launching the mail app.
- [ ] Footer `mailto:` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)