### PR TITLE
chore(products): sort MFC/MFM lists by model number (numeric)

### DIFF
--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -80,7 +80,10 @@ export default async function CategoryPage({ params }: Props) {
   ]);
 
   const byModel = (a: { model: string }, b: { model: string }) =>
-    a.model.localeCompare(b.model, undefined, { numeric: true, sensitivity: "base" });
+    a.model.localeCompare(b.model, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
 
   const controllers = products.filter((p) => p.function === "MFC").sort(byModel);
   const meters = products.filter((p) => p.function === "MFM").sort(byModel);

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -79,10 +79,13 @@ export default async function CategoryPage({ params }: Props) {
     getTranslations("products"),
   ]);
 
-  const controllers = products.filter((p) => p.function === "MFC");
-  const meters = products.filter((p) => p.function === "MFM");
-  const instruments = products.filter((p) => p.function === "ROU");
-  const pressureControllers = products.filter((p) => p.function === "EPC");
+  const byModel = (a: { model: string }, b: { model: string }) =>
+    a.model.localeCompare(b.model, undefined, { numeric: true, sensitivity: "base" });
+
+  const controllers = products.filter((p) => p.function === "MFC").sort(byModel);
+  const meters = products.filter((p) => p.function === "MFM").sort(byModel);
+  const instruments = products.filter((p) => p.function === "ROU").sort(byModel);
+  const pressureControllers = products.filter((p) => p.function === "EPC").sort(byModel);
 
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },

--- a/src/app/[locale]/products/[category]/page.tsx
+++ b/src/app/[locale]/products/[category]/page.tsx
@@ -85,10 +85,16 @@ export default async function CategoryPage({ params }: Props) {
       sensitivity: "base",
     });
 
-  const controllers = products.filter((p) => p.function === "MFC").sort(byModel);
+  const controllers = products
+    .filter((p) => p.function === "MFC")
+    .sort(byModel);
   const meters = products.filter((p) => p.function === "MFM").sort(byModel);
-  const instruments = products.filter((p) => p.function === "ROU").sort(byModel);
-  const pressureControllers = products.filter((p) => p.function === "EPC").sort(byModel);
+  const instruments = products
+    .filter((p) => p.function === "ROU")
+    .sort(byModel);
+  const pressureControllers = products
+    .filter((p) => p.function === "EPC")
+    .sort(byModel);
 
   const breadcrumbs = [
     { label: tCommon("home"), href: "/" },


### PR DESCRIPTION
## Summary

- MFC/MFM/ROU/EPC product lists on category pages were sorted lexicographically (from GROQ `model asc`), causing wrong order for variable-length model numbers: `MD150C` before `MD30C`, `EX1000C` before `EX70C`
- Adds a `localeCompare({numeric: true})` sort after each function-group filter in the category page, so `MD30C → MD150C → MD400C` and `EX70C → EX1000C`
- Zero schema changes; one file, five lines

## Test plan

- [x] `pnpm test:run` — 532 tests pass
- [ ] Visit `/en/products/digital` — MFC list starts `MD30C, MD150C, MD400C…`
- [ ] Visit `/en/products/specialized` — explosion-proof list starts `EX70C, EX1000C`

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)