### PR TITLE
fix(products): power-supply spec range format (+15 ~ +24 Vdc) (#268)

### DIFF
--- a/scripts/parse-catalog.test.ts
+++ b/scripts/parse-catalog.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from "vitest";
-import { buildInstrumentSpecs } from "./parse-catalog";
+import { buildInstrumentSpecs, parseSupplyPower } from "./parse-catalog";
+
+describe("parseSupplyPower", () => {
+  // Every documented raw form normalises to the same "~" range display —
+  // never the word "or" (which localizeSpecValue would render as 또는/或,
+  // reading as a false either/or rather than a continuous range). See #268.
+  it.each(["+15 ~ 24", "+15 ~ +24 Vdc", "+15 or +24 Vdc, 350 mA"])(
+    "normalises %j to the +15 ~ +24 range form",
+    (raw) => {
+      const result = parseSupplyPower(raw);
+      expect(result.display).toBe("+15 ~ +24 Vdc, 350 mA");
+      expect(result.display).not.toContain(" or ");
+      expect(result.voltages).toEqual([15, 24]);
+    },
+  );
+
+  it("parses interleaved units (DO400: +15Vdc ~ +26Vdc)", () => {
+    const result = parseSupplyPower("+15Vdc ~ +26Vdc , 350㎃");
+    expect(result.display).toBe("+15 ~ +26 Vdc, 350 mA");
+    expect(result.voltages).toEqual([15, 26]);
+  });
+
+  it("throws on an unparseable supply string", () => {
+    expect(() => parseSupplyPower("n/a")).toThrow(/Cannot parse supply power/);
+  });
+});
 
 describe("buildInstrumentSpecs", () => {
   it("returns a flat row array parsed from a Spec/Value table", () => {

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -391,11 +391,11 @@ function parseIoSignal(raw: string): IoSignal {
   return { display, outputs };
 }
 
-function parseSupplyPower(raw: string): SupplyPower {
+export function parseSupplyPower(raw: string): SupplyPower {
   // examples: "+15 ~ 24", "+15 ~ +24 Vdc", "+15 or +24 Vdc, 350 mA",
   // "+15Vdc ~ +26Vdc , 350㎃" (DO400 — units interleaved between voltages)
   const voltageMatches = raw.match(
-    /[+]?(\d+)\s*(?:Vdc)?\s*[~or]+\s*[+]?(\d+)/i,
+    /[+]?(\d+)\s*(?:Vdc)?\s*(?:~|or)\s*[+]?(\d+)/i,
   );
   if (!voltageMatches) throw new Error(`Cannot parse supply power: "${raw}"`);
   const v1 = parseInt(voltageMatches[1], 10);

--- a/scripts/parse-catalog.ts
+++ b/scripts/parse-catalog.ts
@@ -402,7 +402,7 @@ function parseSupplyPower(raw: string): SupplyPower {
   const v2 = parseInt(voltageMatches[2], 10);
   const currentMA = 350; // catalog standard for all M/MS/MD/EX/LEPC/DO
   return {
-    display: `+${v1} or +${v2} Vdc, ${currentMA} mA`,
+    display: `+${v1} ~ +${v2} Vdc, ${currentMA} mA`,
     voltages: [v1, v2],
     currentMA,
   };

--- a/scripts/sync-supply-power-format.ts
+++ b/scripts/sync-supply-power-format.ts
@@ -1,0 +1,112 @@
+/**
+ * Sanity data fix for #268 — power-supply spec formatting.
+ *
+ *   pnpm tsx scripts/sync-supply-power-format.ts            # dry-run
+ *   pnpm tsx scripts/sync-supply-power-format.ts --apply    # write to Sanity
+ *
+ * The supply-power range was seeded with the English word "or"
+ * ("+15 or +24 Vdc, 350 mA"), which localizeSpecValue then rewrites to
+ * "또는" / "或" — reading as a false either/or when +15–+24 V is a continuous
+ * range. This patches every product's massFlowSpecs.supplyPower.display to the
+ * range form ("+15 ~ +24 Vdc, 350 mA"). The committed seed source
+ * (src/lib/fixtures/products.json) is fixed in the same PR; this brings the
+ * live dataset in line.
+ *
+ * Idempotent: queries only docs that still contain " or " and rewrites just
+ * that token, so a re-run is a no-op.
+ */
+import { readFileSync } from "node:fs";
+import { createClient } from "@sanity/client";
+
+function loadEnv(p: string) {
+  try {
+    for (const line of readFileSync(p, "utf-8").split("\n")) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m) process.env[m[1]] ??= m[2].trimEnd();
+    }
+  } catch {
+    // .env.local optional
+  }
+}
+loadEnv(".env.local");
+
+const isApply = process.argv.includes("--apply");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+
+if (!projectId || !dataset) {
+  console.error(
+    "Missing NEXT_PUBLIC_SANITY_PROJECT_ID / NEXT_PUBLIC_SANITY_DATASET",
+  );
+  process.exit(1);
+}
+if (isApply && !token) {
+  console.error("--apply requires SANITY_WRITE_TOKEN");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2026-01-01",
+  useCdn: false,
+});
+
+const log = (label: string, detail?: unknown) => {
+  const prefix = isApply ? "  apply  " : "  would  ";
+  if (detail !== undefined) console.log(prefix + label, detail);
+  else console.log(prefix + label);
+};
+
+// Rewrite the " or " range separator to " ~ " — leaves any other content
+// (voltages, "Vdc", current) untouched so the fix is purely the separator.
+const toRange = (display: string) => display.replace(/\s+or\s+/g, " ~ ");
+
+async function main() {
+  console.log(
+    `\nsync-supply-power-format  [${isApply ? "APPLY" : "DRY RUN"}]\n`,
+  );
+
+  const docs = await client.fetch<Array<{ _id: string; display: string }>>(
+    `*[_type == "product" && defined(massFlowSpecs.supplyPower.display) &&
+       massFlowSpecs.supplyPower.display match "* or *"]{
+       _id, "display": massFlowSpecs.supplyPower.display }`,
+  );
+
+  if (docs.length === 0) {
+    console.log(
+      '  Nothing to patch — no supplyPower.display contains " or ".\n',
+    );
+    return;
+  }
+
+  for (const { _id, display } of docs) {
+    const next = toRange(display);
+    log(
+      `patch  ${_id}.massFlowSpecs.supplyPower.display`,
+      `"${display}" → "${next}"`,
+    );
+    if (isApply) {
+      await client
+        .patch(_id)
+        .set({ "massFlowSpecs.supplyPower.display": next })
+        .commit();
+    }
+  }
+
+  console.log(
+    `\nDone. ${docs.length} product(s). ${
+      isApply
+        ? "Applied to Sanity."
+        : "Dry-run only. Re-run with --apply to write."
+    }\n`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/fixtures/products.json
+++ b/src/lib/fixtures/products.json
@@ -98,7 +98,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -232,7 +232,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -366,7 +366,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -496,7 +496,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -623,7 +623,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -746,7 +746,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -869,7 +869,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1000,7 +1000,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1128,7 +1128,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1255,7 +1255,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1379,7 +1379,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1500,7 +1500,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1617,7 +1617,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1734,7 +1734,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1858,7 +1858,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -1998,7 +1998,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2138,7 +2138,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2271,7 +2271,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2404,7 +2404,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2533,7 +2533,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2662,7 +2662,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2799,7 +2799,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -2933,7 +2933,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3067,7 +3067,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3194,7 +3194,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3321,7 +3321,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3444,7 +3444,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3567,7 +3567,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3702,7 +3702,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3840,7 +3840,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -3972,7 +3972,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -4102,7 +4102,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -4234,7 +4234,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },
@@ -4346,7 +4346,7 @@
         "outputs": ["0-5Vdc", "4-20mA"]
       },
       "supplyPower": {
-        "display": "+15 or +24 Vdc, 350 mA",
+        "display": "+15 ~ +24 Vdc, 350 mA",
         "voltages": [15, 24],
         "currentMA": 350
       },

--- a/src/lib/products/localizeSpecValue.test.ts
+++ b/src/lib/products/localizeSpecValue.test.ts
@@ -18,9 +18,6 @@ describe("localizeSpecValue", () => {
     );
     expect(localizeSpecValue("±1% of FS", "ko")).toBe("±1% F.S.");
     expect(localizeSpecValue("±1% of fs", "ko")).toBe("±1% F.S.");
-    expect(localizeSpecValue("+15 or +24 Vdc, 350 mA", "ko")).toBe(
-      "+15 또는 +24 Vdc, 350 mA",
-    );
   });
 
   it("translates English prose words to Chinese", () => {


### PR DESCRIPTION
## Summary

- The supply-power spec rendered as a false either/or — `+15 또는 +24 VDC` (KO), `+15 或 +24` (ZH) — because the catalog parser emitted the English word `or`, which `localizeSpecValue` rewrites per locale. `+15`–`+24 V` is a continuous **range**, so the data now reads `+15 ~ +24 Vdc, 350 mA`.
- Fixed at the data level (not a render hack) at all three source-of-truth points: the parser (`parse-catalog.ts` emits `~`), the committed seed (`fixtures/products.json`, 34 entries), and live Sanity (via the new `sync-supply-power-format.ts`, **already applied** to all 34 product docs).
- `localizeSpecValue` keeps its ` or ` → `또는`/`或` rule for the legitimate I/O-signal spec (`0–5 Vdc or 4–20 mA`). The two accessory `@ 500 mA` Output-Power entries are intentionally untouched (selectable output, not a range).
- Review follow-ups: `parseSupplyPower` is now exported and unit-tested (every documented raw form normalises to the `~` range, never `or`); the separator regex tightened from `[~or]+` to `(?:~|or)`.

Closes #268. (Supersedes #279, which GitHub auto-closed during a branch rename.)

## Test plan

- [x] `pnpm vitest run scripts/parse-catalog.test.ts src/lib/products/localizeSpecValue.test.ts` — 14/14 pass
- [x] `fixtures/products.json`: 0 old strings, 34 new
- [x] Sync script applied to live Sanity; dry-run re-run reports nothing to patch (idempotent)
- [x] Verified rendered output on the running app across KO/EN/ZH — Supply Power row shows `+15 ~ +24 Vdc, 350 mA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)